### PR TITLE
Mark documentation as official when built on gh

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
         sudo apt-get install -y plantuml
 
     - name: Build Sphinx documentation
-      run: make html
+      run: make html OFFICIAL_BUILD=1
 
     - name: Copy redirection index.html
       run: cp github_pages/redirect_index.html build/html/index.html


### PR DESCRIPTION
Without this each doc page is marked as UNOFFICIAL BUILD in the footer.

Signed-off-by: Thomas Frank <thomas@franks-im-web.de>
