### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -1,7 +1,6 @@
-name: Build and Deploy Documentation
+name: Build Documentation
 
-on: [push, pull_request]
-
+on: [workflow_call, pull_request]
 
 jobs:
   build:
@@ -41,9 +40,13 @@ jobs:
     - name: Copy redirection index.html
       run: cp github_pages/redirect_index.html build/html/index.html
 
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v4
+    - name: Zip documentation
+      run: |
+        mv build/html docs
+        zip -r docs.zip docs
+
+    - name: Upload docs
+      uses: actions/upload-artifact@v4
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: doc/build/html
-        force_orphan: true
+        name: docs
+        path: ./doc/docs.zip

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -1,0 +1,27 @@
+name: Publish Documentation
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build-docs:
+    uses: ./.github/workflows/doc-build.yml
+  publis-docs:
+    runs-on: ubuntu-latest
+    needs: build-docs
+    steps:
+      - name: Download build documentation
+        uses: actions/download-artifact@v4
+        with:
+          name: docs
+
+      - name: Unzip
+        run: unzip docs.zip
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs
+          force_orphan: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - "v*.*"
+
+jobs:
+  build-docs:
+    uses: ./.github/workflows/doc-build.yml
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: build-docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download build documentation
+        uses: actions/download-artifact@v4
+        with:
+          name: docs
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: docs.zip


### PR DESCRIPTION
Adds a release workflow which is triggered every time a tag matching `v*.*` is pushed.

Documentation matching the commit is built and attached.

Release Notes are empty for now. We need to think about how we want to handle them in the future.
It is always possible to add them manually after the action ran.