### PR TITLE
Add code coverage github action

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,43 @@
+name: Code Coverage Report
+
+on: [push, pull_request]
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    #Code coverage 
+    - name: Install lcov
+      run: sudo apt install lcov
+    
+    - name: Capture code coverage
+      run: |
+        echo "Capturing code coverage..."
+        lcov --capture --directory . \
+             --output-file cmake-build-unit-tests/coverage_unfiltered.info
+
+    - name: Filter out 3rd party and mock files
+      run: |
+        echo "Filtering out 3rd party and mock files from coverage data..."
+        lcov --remove cmake-build-unit-tests/coverage_unfiltered.info \
+             '*libs/3rdparty/googletest/*' \
+             '*/mock/*' \
+             '*/gmock/*' \
+             --output-file cmake-build-unit-tests/coverage.info
+
+    - name: Generate HTML coverage report
+      run: |
+        echo "Generating HTML coverage report..."
+        genhtml cmake-build-unit-tests/coverage.info \
+                 --output-directory cmake-build-unit-tests/coverage
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: cmake-build-unit-tests/coverage
+        force_orphan: true


### PR DESCRIPTION
This GitHub Action automates the generation and publishing of code coverage reports for the modules. It captures code coverage data using lcov, filters out third-party and mock files, and generates an HTML report that is deployed to GitHub Pages.