### PR TITLE
GitHub action for code coverage 

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,67 @@
+name: Code Coverage Report
+
+on: [workflow_call, push, pull_request]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Debug
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.22.x'
+  
+    - name: Test
+      # Execute tests defined by the CMake configuration.
+      run: |
+          cmake -B cmake-build-unit-tests -S executables/unitTest -DBUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          cmake --build cmake-build-unit-tests -j4
+          ctest --test-dir cmake-build-unit-tests -j4
+    
+    - name: Install lcov
+      run: sudo apt install lcov
+    
+    # no-external command excludes the system libraries in the root directory 
+    - name: Capture code coverage
+      run: |
+        echo "Capturing code coverage..."
+        lcov --no-external --capture --directory . \
+             --output-file cmake-build-unit-tests/coverage_unfiltered.info
+
+    - name: Filter out 3rd party and mock files
+      run: |
+        echo "Filtering out 3rd party and mock files from coverage data..."
+        lcov --remove cmake-build-unit-tests/coverage_unfiltered.info \
+             '*libs/3rdparty/googletest/*' \
+             '*/mock/*' \
+             '*/gmock/*' \
+             '*/gtest/*' \
+             '*/test/*' \
+             --output-file cmake-build-unit-tests/coverage.info
+
+    - name: Generate HTML coverage report
+      run: |
+        echo "Generating HTML coverage report..."
+        genhtml cmake-build-unit-tests/coverage.info \
+                 --output-directory cmake-build-unit-tests/coverage
+    
+    
+    - name: Zip the coverage report
+      run: |
+        mv  cmake-build-unit-tests/coverage code_coverage
+        zip -r code_coverage.zip code_coverage
+
+    - name: Upload code coverage artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: code_coverage
+        path: code_coverage.zip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,12 @@ jobs:
   build-doxygen-docs:
     uses: ./.github/workflows/doxygen-build.yml
 
+  build-code-coverage:
+    uses: ./.github/workflows/code-coverage.yml
+
   publish-docs:
     runs-on: ubuntu-latest
-    needs: [build-sphinx-docs, build-doxygen-docs]
+    needs: [build-sphinx-docs, build-doxygen-docs, build-code-coverage]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -45,6 +48,18 @@ jobs:
         run: |
           unzip doxygen_docs.zip
           rm doxygen_docs.zip
+
+      - name: Download Code coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: code_coverage
+          path: ./doc/github_pages
+
+      - name: Unzip Code coverage report
+        working-directory: ./doc/github_pages
+        run: |
+          unzip code_coverage.zip
+          rm code_coverage.zip
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,14 +52,14 @@ jobs:
       - name: Download Code coverage report
         uses: actions/download-artifact@v4
         with:
-          name: code_coverage
-          path: ./doc/github_pages
-
+            name: code_coverage
+            path: ./doc/github_pages
+  
       - name: Unzip Code coverage report
         working-directory: ./doc/github_pages
         run: |
-          unzip code_coverage.zip
-          rm code_coverage.zip
+            unzip code_coverage.zip
+            rm code_coverage.zip
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/doc/github_pages/index.html
+++ b/doc/github_pages/index.html
@@ -10,7 +10,7 @@
     <h3><a href="doxygen_docs/index.html">Doxygen-generated API docs</a></h3>
     <h3>Coverage reports</h3>
     <ul>
-        <li><a href="code_coverage_url">Code coverage report</a></li>
+        <li><a href="code_coverage/index.html">Code coverage report</a></li>
     </ul>
 
     <h1>Other Publications</h1>


### PR DESCRIPTION
This GitHub Action automates the generation and publishing of code coverage reports of the modules. It captures code coverage data using lcov, filters out third-party, mock files, gtest folders and system libraries.
Then it generates an HTML report that is deployed to GitHub Pages. 

Changes made:
Added code-coverage.yml
Added CodeCoverage.cmake
Made changes in CMakeLists.txt

