### PR TITLE
Call doc build with the required permissions

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -6,7 +6,10 @@ on:
       - main
 jobs:
   build-docs:
+    permissions:
+      contents: write
     uses: ./.github/workflows/doc-build.yml
+
   publis-docs:
     runs-on: ubuntu-latest
     needs: build-docs


### PR DESCRIPTION
Here it says the permissions can't be upgraded in a called workflow:
https://docs.github.com/en/actions/sharing-automations/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow
