### PR TITLE
Add required permissions to all steps in doc-publish

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: write
+
 jobs:
   build-docs:
-    permissions:
-      contents: write
     uses: ./.github/workflows/doc-build.yml
 
-  publis-docs:
+  publish-docs:
     runs-on: ubuntu-latest
     needs: build-docs
     steps:


### PR DESCRIPTION
actions-gh-pages requires 'contents: write' as well
