### PR TITLE
Fix posix console missing chars, restore terminal attributes on exit

### DIFF
--- a/executables/referenceApp/platforms/posix/main/src/main.cpp
+++ b/executables/referenceApp/platforms/posix/main/src/main.cpp
@@ -5,10 +5,15 @@
 
 #include <estd/typed_mem.h>
 
+#include <signal.h>
+#include <unistd.h>
+
 #ifdef PLATFORM_SUPPORT_CAN
 #include "systems/CanSystem.h"
 #endif // PLATFORM_SUPPORT_CAN
 
+void terminal_setup(void);
+void terminal_cleanup(void);
 extern void app_main();
 
 namespace platform
@@ -37,8 +42,16 @@ namespace systems
 } // namespace systems
 #endif // PLATFORM_SUPPORT_CAN
 
+void intHandler(int sig)
+{
+    terminal_cleanup();
+    _exit(0);
+}
+
 int main()
 {
+    signal(SIGINT, intHandler);
+    terminal_setup();
     app_main(); // entry point for the generic part
     return (1); // we never reach this point
 }

--- a/platforms/posix/bsp/bspMcu/src/reset/softwareSystemReset.cpp
+++ b/platforms/posix/bsp/bspMcu/src/reset/softwareSystemReset.cpp
@@ -4,10 +4,20 @@
 
 #include <unistd.h>
 
+void terminal_cleanup(void);
+
 extern "C"
 {
-[[noreturn]] void softwareSystemReset() { _exit(0); }
+[[noreturn]] void softwareSystemReset()
+{
+    terminal_cleanup();
+    _exit(0);
+}
 
-void softwareDestructiveReset() { _exit(0); }
+void softwareDestructiveReset()
+{
+    terminal_cleanup();
+    _exit(0);
+}
 
 } // extern "C"


### PR DESCRIPTION
Fix posix console missing chars, restore terminal attributes on exit

Change-Id: Ie2a581ddadba0e76b1a9d2dc7ab4c8cd3de63785