### PR TITLE
Add automatic check for commit message format

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,26 @@
+{
+    "rules": {
+      "type-enum": [1, "always", [
+      "build",
+      "ci",
+      "docs",
+      "feat",
+      "fix",
+      "perf",
+      "refactor",
+      "revert",
+      "style",
+      "test"
+    ]],
+      "header-full-stop": [2, "never"],
+      "header-trim": [2, "always"],
+      "subject-empty": [1, "never"],
+      "subject-full-stop": [2, "never", "."],
+      "subject-max-length": [1, "always", 50],
+      "subject-case": [2, "always", "sentence-case"],
+      "body-leading-blank": [2, "always"],
+      "body-max-line-length": [1, "always", 72],
+      "body-case": [2, "always", "sentence-case"],
+      "signed-off-by": [1, "always", "Signed-off-by:"]
+    }
+  }

--- a/.github/workflows/commit-message-format.yml
+++ b/.github/workflows/commit-message-format.yml
@@ -1,0 +1,16 @@
+name: Check Commit Message Format
+
+on: [push, pull_request]
+
+jobs:
+  commitmessage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Commit message format
+        uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: .commitlintrc.json


### PR DESCRIPTION
- Added GitHub Actions workflow to commit messages on push and pull request events.
- Created custom configuration file (.commitlintrc.json) to enforce commit message standards.