### PR TITLE
Add workflow badges to README.md

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -60,9 +60,23 @@ jobs:
           genhtml cmake-build-unit-tests/coverage.info \
                   --output-directory cmake-build-unit-tests/coverage &&
 
-          # Zip the coverage report
           mv cmake-build-unit-tests/coverage code_coverage &&
-          zip -r code_coverage.zip code_coverage
+          zip -r code_coverage.zip code_coverage &&
+
+          #Badges
+          LinePercentage=\$(lcov --summary cmake-build-unit-tests/coverage.info | grep 'lines' | awk '{print \$2}') &&
+          echo \"Line Percentage: \$LinePercentage\"  # Debug print &&
+          wget \"https://img.shields.io/badge/coverage-\${LinePercentage}25-brightgreen.svg\" -O line_coverage_badge.svg &&
+
+          FunctionPercentage=\$(lcov --summary cmake-build-unit-tests/coverage.info | grep 'functions' | awk '{print \$2}') &&
+          echo \"Function Percentage: \$FunctionPercentage\"  # Debug print &&
+          wget \"https://img.shields.io/badge/coverage-\${FunctionPercentage}25-brightgreen.svg\" -O function_coverage_badge.svg &&
+
+          mkdir coverage_badges &&
+
+          mv line_coverage_badge.svg coverage_badges/ &&
+          mv function_coverage_badge.svg coverage_badges/ &&
+          zip -r coverage_badges.zip coverage_badges
         "
 
     - name: Upload code coverage artifact
@@ -70,3 +84,9 @@ jobs:
       with:
         name: code_coverage
         path: code_coverage.zip
+
+    - name: Upload Coverage Badge
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage_badges
+        path: coverage_badges.zip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,18 @@ jobs:
         run: |
             unzip code_coverage.zip
             rm code_coverage.zip
+      
+      - name: Download Coverage badge  artifact
+        uses: actions/download-artifact@v4
+        with:
+            name: coverage_badges
+            path: ./doc/github_pages
+      
+      - name: Unzip Coverage badge artifact
+        working-directory: ./doc/github_pages
+        run: |
+            unzip coverage_badges.zip 
+            rm coverage_badges.zip
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # Eclipse OpenBSW
 
+
+## Build Status 🚀
+
+| Platform       | Status                                                                 |
+|----------------|------------------------------------------------------------------------|
+| POSIX Build | ![POSIX](https://github.com/eclipse-openbsw/openbsw/actions/workflows/build.yml/badge.svg?branch=main&event=push&matrix.platform=posix) |
+| S32K148     | ![S32K](https://github.com/eclipse-openbsw/openbsw/actions/workflows/build.yml/badge.svg?branch=main&event=push&matrix.platform=s32k148) |
+
+## Code Coverage 
+
+| Code Coverage            | Status                                                                 |
+|--------------------------|------------------------------------------------------------------------|
+| Line Coverage            | ![Line Coverage](https://raw.githubusercontent.com/esrlabs/openbsw/gh-pages/coverage_badges/line_coverage_badge.svg) |
+| Function Coverage        | ![Function Coverage](https://raw.githubusercontent.com/esrlabs/openbsw/gh-pages/coverage_badges/function_coverage_badge.svg) |
+
+
+
 ## Overview
 
 Eclipse OpenBSW is an open source SDK to build professional, high quality embedded software products. 


### PR DESCRIPTION
- Removed coverage.js that was previously written for converting` coverage.info` to `Json` 
- Updated README.md with links to workflow badges

Output of badges for reference:
![image](https://github.com/user-attachments/assets/4a38b1b7-3151-4027-a569-ec6704e301a8)

