### PR TITLE
Add github action to run pytest on posix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build S32k and posix platform
 
-on: [push, pull_request]
+on: [workflow_call, push, pull_request]
 
 jobs:
   run-command:

--- a/.github/workflows/run-pytest-on-posix.yml
+++ b/.github/workflows/run-pytest-on-posix.yml
@@ -1,0 +1,56 @@
+name: Run pytest for posix platform
+
+on: [push, pull_request]
+
+jobs:
+    run-pytest-on-posix:
+      runs-on: ubuntu-latest
+
+      steps:
+
+        - name: Install missing kernel module file for vcan
+          run: sudo apt install linux-modules-extra-$(uname -r)
+
+        - name: Install can kernel modules
+          run: |
+            sudo modprobe can
+            sudo modprobe can-raw
+            sudo modprobe vcan
+
+        - name: Set up vcan0 interface
+          run: |
+            sudo ip link add dev vcan0 type vcan
+            sudo ip link set vcan0 mtu 16
+            sudo ip link set up vcan0
+
+        - name: Show all interface info, vcan0 should be set up
+          run: ip a
+
+        - name: Checkout repository
+          uses: actions/checkout@v4
+
+        - name: Set up CMake
+          uses: jwlawson/actions-setup-cmake@v2
+          with:
+            cmake-version: '3.22.x'
+
+        - name: Build posix target
+          run: |
+            cmake -B cmake-build-posix -S executables/referenceApp
+            cmake --build cmake-build-posix --target app.referenceApp -j
+
+        - name: Set up python 3.10
+          uses: actions/setup-python@v5
+          with:
+            python-version: '3.10'
+
+        - name: Install python dependencies for tests
+          run: |
+            pip install -r test/pyTest/requirements.txt
+            cd tools/UdsTool
+            pip install .
+
+        - name: Run tests
+          run: |
+            cd test/pyTest
+            pytest --target=posix

--- a/.github/workflows/run-pytest-on-posix.yml
+++ b/.github/workflows/run-pytest-on-posix.yml
@@ -3,8 +3,12 @@ name: Run pytest for posix platform
 on: [push, pull_request]
 
 jobs:
+    cmake-build:
+      uses: ./.github/workflows/build.yml
+
     run-pytest-on-posix:
       runs-on: ubuntu-latest
+      needs: cmake-build
 
       steps:
 
@@ -29,28 +33,31 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v4
 
-        - name: Set up CMake
-          uses: jwlawson/actions-setup-cmake@v2
+        - name: Restore cached posix build
+          id: restore-cached-posix-build
+          uses: actions/cache/restore@v3
           with:
-            cmake-version: '3.22.x'
-
-        - name: Build posix target
-          run: |
-            cmake -B cmake-build-posix -S executables/referenceApp
-            cmake --build cmake-build-posix --target app.referenceApp -j
+            path: |
+              cmake-build-posix
+              cmake-build-s32k148
+            key: ${{ runner.os }}-cmake-posix-20-${{ hashFiles('**/*.cpp', '**/*.h',  '**/*.cmake', '**/*.txt', '**/*.c', '**/*.s', 'admin/cmake/ArmNoneEabi.cmake') }}
+            fail-on-cache-miss: true
 
         - name: Set up python 3.10
+          if: ${{ steps.restore-cached-posix-build.outputs.cache-hit == 'true' }}
           uses: actions/setup-python@v5
           with:
             python-version: '3.10'
 
         - name: Install python dependencies for tests
+          if: ${{ steps.restore-cached-posix-build.outputs.cache-hit == 'true' }}
           run: |
             pip install -r test/pyTest/requirements.txt
             cd tools/UdsTool
             pip install .
 
         - name: Run tests
+          if: ${{ steps.restore-cached-posix-build.outputs.cache-hit == 'true' }}
           run: |
             cd test/pyTest
             pytest --target=posix


### PR DESCRIPTION
This adds a github action to run integration tests on the posix build.
The `ubuntu-latest` runner was built with SocketCAN support but is missing the kernel module file for `vcan`.
Running `sudo apt install linux-modules-extra-$(uname -r)` adds this kernel module file, then `vcan0` can be set up and the tests work.