### PR TITLE
CI: Add Dockerfiles for dev and docs

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,41 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    python3.10 \
+    python3-pip \
+    bzip2\
+    tar \
+    clang-tidy \
+    wget \
+    curl \
+    git \
+    gcc-11 \
+    g++-11\
+    lcov\
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.5/cmake-3.22.5-linux-x86_64.sh \
+    && chmod +x cmake-3.22.5-linux-x86_64.sh \
+    && ./cmake-3.22.5-linux-x86_64.sh --skip-license --prefix=/usr/local \
+    && rm cmake-3.22.5-linux-x86_64.sh
+
+RUN wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 \
+    && tar -xjf gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 -C /usr/local \
+    && rm gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 \
+    && ln -s /usr/local/gcc-arm-none-eabi-10.3-2021.10/bin/* /usr/local/bin/ 
+
+RUN mkdir -p /root/.local/bin
+
+RUN curl -L https://github.com/numtide/treefmt/releases/download/v2.1.0/treefmt_2.1.0_linux_amd64.tar.gz -o treefmt.tar.gz \
+    && tar -xvzf treefmt.tar.gz \
+    && install -m 755 treefmt /root/.local/bin/treefmt \
+    && rm LICENSE README.md treefmt treefmt.tar.gz
+
+RUN curl -L https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-32d3ac78/clang-format-17_linux-amd64 -o /root/.local/bin/clang-format && \
+    chmod +x /root/.local/bin/clang-format
+
+ENV PATH="/root/.local/bin:$PATH"
+
+RUN pip3 install cmakelang
+
+RUN echo 'export HISTFILE=/root/.bash_history/history' >> /root/.bashrc

--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -1,0 +1,18 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y python3.10 python3-pip openjdk-11-jdk graphviz \
+    doxygen\
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY ../doc/requirements.txt .
+
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+RUN wget https://sourceforge.net/projects/plantuml/files/plantuml.jar/download -O /usr/local/bin/plantuml.jar \
+    && echo '#!/bin/sh\njava -jar /usr/local/bin/plantuml.jar "$@"' > /usr/local/bin/plantuml && \
+    chmod +x /usr/local/bin/plantuml
+
+RUN pip3 install coverxygen
+
+RUN echo 'export HISTFILE=/root/.bash_history/history' >> /root/.bashrc

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,39 @@
+# Docker Information
+
+Developer Dockerfile can be used to set up the development environment.
+It includes all the necessary tools, libraries, and dependencies required
+for development. This ensures that all developers work in a consistent
+environment, reducing the "it works on my machine" problem.
+Documentation Dockerfile is used to build project's documentation.
+
+Project uses Docker Compose to manage both the Developer Dockerfile and the
+Documentation Dockerfile. Docker Compose simplifies the process of building
+and running multiple Docker containers, ensuring that both the development
+environment and the documentation container are consistently set up and managed.
+
+## Build the docker image
+
+If you have docker compose installed, you can use this command
+
+    docker-compose -f docker/docker-compose.yaml build
+
+If you do not want to use docker compose, you can use this command instead
+
+    docker build -f docker/<dockerfile_name> -t <image_name> .
+
+This will build the image from the Dockerfile in the current directory (the `.`).
+
+## Run the docker container
+
+If you have docker compose installed, the easiest way is to call
+
+    docker compose -f docker/docker-compose.yaml run <service_name>
+
+If you do not want to use docker compose, you can use this command instead
+
+    docker run -it --rm -v $PWD:$PWD --workdir $PWD <image_name>
+
+This command creates the docker container and enters it (`-it` for interactive).
+The container will be removed when you leave it again (`--rm`).
+Your current directory is mounted into the container. This is set up as the working
+directory in the container (`-v $PWD:$PWD --workdir $PWD`).

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,25 @@
+version: '3'
+services:
+  dev:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.dev
+    working_dir:
+      /usr/src
+    volumes:
+      - ..:/usr/src
+      - ../.docker_history:/root/.bash_history
+    command: /bin/bash
+    tty: true
+
+  docs:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.docs
+    working_dir:
+      /usr/src
+    volumes:
+      - ..:/usr/src
+      - ../.docker_history:/root/.bash_history
+    command: /bin/bash
+    tty: true


### PR DESCRIPTION
Add Dockerfiles for development and documentation, Docker Compose file, and README with usage instructions

**Development Dockerfile:**

This Dockerfile is designed for development purposes and includes:

- POSIX and S32K builds
- Unit test builds
- Clang format and CMake format
- Clang tidy
- Code coverage tools

**Documentation Dockerfile:**

This Dockerfile is dedicated to documentation-related tasks and includes:

- Sphinx documentation
- Doxygen documentation
- Documentation coverage