### PR TITLE
Fix clang asan error in AbstractCANTransceiverTest.testNotifySentListeners

### DIFF
--- a/libs/bsw/cpp2can/test/gtest/src/can/transceiver/AbstractCANTransceiverTest.cpp
+++ b/libs/bsw/cpp2can/test/gtest/src/can/transceiver/AbstractCANTransceiverTest.cpp
@@ -372,7 +372,7 @@ TEST_F(AbstractCANTransceiverTest, testNotifySentListeners)
 
     FilteredCANFrameSentListenerMock listener1;
     FilteredCANFrameSentListenerMock listener2;
-    transceiver.addCANFrameSentListener(listener1);
+
     transceiver.addCANFrameSentListener(listener1);
     transceiver.addCANFrameSentListener(listener2);
     EXPECT_CALL(listener1, canFrameSent(Ref(frame)));
@@ -382,11 +382,11 @@ TEST_F(AbstractCANTransceiverTest, testNotifySentListeners)
     EXPECT_EQ(150U, frame.timestamp());
 
     transceiver.removeCANFrameSentListener(listener1);
-    transceiver.removeCANFrameSentListener(listener1);
     EXPECT_CALL(listener2, canFrameSent(Ref(frame)));
     EXPECT_CALL(fSystemTimer, getSystemTimeUs32Bit()).WillOnce(Return(180U));
     transceiver.notifySentListeners(frame);
     EXPECT_EQ(180U, frame.timestamp());
+    transceiver.removeCANFrameSentListener(listener2);
 }
 
 TEST_F(AbstractCANTransceiverTest, testSetFrameSentListener)


### PR DESCRIPTION
build setup:

export CFLAGS=-fsanitize=address
export CXXFLAGS=-fsanitize=address
export LDFLAGS=-fsanitize=address
export CC=clang
export CXX=clang++
-DCMAKE_BUILD_TYPE=Debug
-DBUILD_TARGET_PLATFORM=POSIX
-DPLATFORM_SUPPORT_CAN=ON
-DPLATFORM_SUPPORT_IO=ON
-DPLATFORM_SUPPORT_UDS=ON

The error is reproduced on a posix build by:

export ASAN_OPTIONS=detect_leaks=0

./openbsw/libs/bsw/uds/test/gtest/udsTest --gtest_filter=UdsIntegration.positive_response

