### PR TITLE
Fix build failures for target estdExamples

### DIFF
--- a/libs/bsw/estd/examples/deque.cpp
+++ b/libs/bsw/estd/examples/deque.cpp
@@ -8,7 +8,9 @@
 #include <gtest/gtest.h>
 
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#ifdef __clang__
 #pragma clang diagnostic ignored "-Wunused-private-field"
+#endif
 
 namespace
 {

--- a/libs/bsw/estd/examples/deque.cpp
+++ b/libs/bsw/estd/examples/deque.cpp
@@ -7,7 +7,6 @@
 
 #include <gtest/gtest.h>
 
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wunused-private-field"
 #endif

--- a/libs/bsw/estd/examples/uncopyable.cpp
+++ b/libs/bsw/estd/examples/uncopyable.cpp
@@ -5,7 +5,9 @@
 #include <gtest/gtest.h>
 
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#ifdef __clang__
 #pragma clang diagnostic ignored "-Wunused-private-field"
+#endif
 
 /*Below code shows how to make a class uncopyable that cannot inherit
   from the uncopyable base class.

--- a/libs/bsw/estd/examples/uncopyable.cpp
+++ b/libs/bsw/estd/examples/uncopyable.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wunused-private-field"
 #endif


### PR DESCRIPTION
Fix build failures for target estdExamples due to '#pragma clang' with gcc compiler
Only seen when building executables/unitTest