### PR TITLE
Fix: cache miss issue and key value error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Cache CMake files
         id: cache-cmake
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             cmake-build-posix

--- a/.github/workflows/run-pytest-on-posix.yml
+++ b/.github/workflows/run-pytest-on-posix.yml
@@ -35,12 +35,12 @@ jobs:
 
         - name: Restore cached posix build
           id: restore-cached-posix-build
-          uses: actions/cache/restore@v3
+          uses: actions/cache/restore@v4
           with:
             path: |
               cmake-build-posix
               cmake-build-s32k148
-            key: ${{ runner.os }}-cmake-posix-20-${{ hashFiles('**/*.cpp', '**/*.h',  '**/*.cmake', '**/*.txt', '**/*.c', '**/*.s', 'admin/cmake/ArmNoneEabi.cmake') }}
+            key: ${{ runner.os }}-cmake-posix-gcc-20-${{ hashFiles('**/*.cpp', '**/*.h',  '**/*.cmake', '**/*.txt', '**/*.c', '**/*.s', 'admin/cmake/ArmNoneEabi.cmake') }}
             fail-on-cache-miss: true
 
         - name: Set up python 3.10


### PR DESCRIPTION
- Updated actions/cache and actions/cache/restore to version 4 in run-pytest-on-posix.yml and build.yml which ensures that the fail-on-cache-miss: true flag works as expected.
- Updated key value for actions/cache/restore to make pytest work.