### PR TITLE
Fix: Warnings in GitHub Action of format.yml

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,6 +1,6 @@
 name: Code format check
 
-on: [ merge_group, pull_request ]
+on: [ merge_group, push, pull_request ]
 
 jobs:
   treefmt:

--- a/.treefmt.toml
+++ b/.treefmt.toml
@@ -17,6 +17,7 @@ excludes = [
   "*.json",
   "*.md",
   "*.png",
+  "*.puml",
   "*.py",
   "*.rb",
   "*.rst",
@@ -29,6 +30,7 @@ excludes = [
   "*.yml",
   "LICENSE",
   "admin/cmake/CodeCoverage.cmake",
+  "docker/**", 
   "tools/clang-format-wrapper",
 ]
 


### PR DESCRIPTION
> WARN no formatter for path: docker/Dockerfile.dev
> WARN no formatter for path: docker/Dockerfile.docs
> WARN no formatter for path: libs/bsw/uds/doc/user/runtime_diag_tree.puml

- Added files with warnings to excludes list in .treefmt.toml
- Updated format.yml to trigger on push events