### PR TITLE
Fix directories permissions in code-coverage.yml

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -76,7 +76,9 @@ jobs:
 
           mv line_coverage_badge.svg coverage_badges/ &&
           mv function_coverage_badge.svg coverage_badges/ &&
-          zip -r coverage_badges.zip coverage_badges
+          zip -r coverage_badges.zip coverage_badges &&
+
+          chown -R 2001:2001 cmake-build-unit-tests code_coverage coverage_badges
         "
 
     - name: Upload code coverage artifact


### PR DESCRIPTION
The code-coverage.yml workflow creates the directories:
cmake-build-unit-tests, code_coverage, and coverage_badges with root permissions. This happens because the command for running unit tests is executed inside a Docker image in code-coverage.yml, which generates the directories with root permissions. Therefore, this PR changes the ownership of these directories and assigns them to the Jenkins user and group.

Jira : [https://esrlabs.atlassian.net/browse/BS-2744](url)