### PR TITLE
Integrate sscache for faster unit build compilation

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,85 +1,95 @@
 name: Code Coverage 
 
-on:
-  workflow_call:
-  push:
-    branches:
-      - main
-  pull_request:
-
-env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Debug
+on: [workflow_call, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
 
+    env:
+      BUILD_TYPE: Debug
+      SCCACHE_GHA_ENABLED: "true"
+
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
 
-    - name: Pull and Run Docker with GCC 11.4.0 and LCOV
+    - name: Install GCC 11.4.0 and LCOV
       run: |
-        docker pull ubuntu:22.04
-        docker run --rm -v $(pwd):/workspace -w /workspace ubuntu:22.04 bash -c "
-          apt-get update &&
-          apt-get install -y gcc-11 g++-11 lcov wget cmake zip &&
-          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 &&
-          update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100 &&
-          update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-11 100 &&
-          gcc --version &&
-          gcov --version &&
-          lcov --version &&
+        sudo apt-get update
+        sudo apt-get install -y gcc-11 g++-11 lcov wget zip
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
+        sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-11 100
 
-          # Clean old coverage files
-          rm -rf cmake-build-unit-tests/*.gcda cmake-build-unit-tests/*.gcno &&
+    - name: Set up sccache
+      uses: mozilla-actions/sccache-action@v0.0.7
+      with:
+        version: "v0.10.0"
 
-          # Configure and build the tests
-          rm -rf cmake-build-unit-tests &&
-          cmake -B cmake-build-unit-tests -S executables/unitTest -DBUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=${BUILD_TYPE} &&
-          cmake --build cmake-build-unit-tests -j4 &&
+    - name: Set up CMake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+          cmake-version: '3.22.x'
 
-          ctest --test-dir cmake-build-unit-tests -j4 &&
+    - name: Cache CMake files
+      id: cache-build
+      uses: actions/cache@v3
+      with:
+          path: cmake-build-unit-tests
+          key: ${{ runner.os }}-cmake-build-unit-tests-${{ hashFiles('**/*.cpp', '**/*.h',  '**/*.cmake', '**/*.txt', '**/*.c', '**/*.s') }}
+          restore-keys: |
+            ${{ runner.os }}-cmake-build-unit-tests
 
-          # Capture code coverage
-          lcov --no-external --capture --directory . \
-               --output-file cmake-build-unit-tests/coverage_unfiltered.info &&
+    - name: Configure with cmake
+      if: steps.cache-build.outputs.cache-hit != 'true'
+      run: |
+        cmake -B cmake-build-unit-tests -S executables/unitTest \
+              -DBUILD_UNIT_TESTS=ON \
+              -DCMAKE_BUILD_TYPE=${{ github.event.inputs.BUILD_TYPE }}\
+              -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
-          # Filter out 3rd party and mock files
-          lcov --remove cmake-build-unit-tests/coverage_unfiltered.info \
-               '*libs/3rdparty/googletest/*' \
-               '*/mock/*' \
-               '*/gmock/*' \
-               '*/gtest/*' \
-               '*/test/*' \
-               --output-file cmake-build-unit-tests/coverage.info &&
+    - name: Build with cmake
+      if: steps.cache-build.outputs.cache-hit != 'true'
+      run: cmake --build cmake-build-unit-tests -j4
 
-          # Generate HTML coverage report
-          genhtml cmake-build-unit-tests/coverage.info \
-                  --output-directory cmake-build-unit-tests/coverage &&
+    - name: Run tests
+      if: steps.cache-build.outputs.cache-hit != 'true'
+      run: ctest --test-dir cmake-build-unit-tests -j4
 
-          mv cmake-build-unit-tests/coverage code_coverage &&
-          zip -r code_coverage.zip code_coverage &&
+    - name: Capture code coverage
+      run: lcov --no-external --capture --directory . --output-file cmake-build-unit-tests/coverage_unfiltered.info
 
-          #Badges
-          LinePercentage=\$(lcov --summary cmake-build-unit-tests/coverage.info | grep 'lines' | awk '{print \$2}') &&
-          echo \"Line Percentage: \$LinePercentage\" &&
-          wget \"https://img.shields.io/badge/coverage-\${LinePercentage}25-brightgreen.svg\" -O line_coverage_badge.svg &&
+    - name: Filter out 3rd party and mock files
+      run:  lcov --remove cmake-build-unit-tests/coverage_unfiltered.info '*libs/3rdparty/googletest/*' '*/mock/*' '*/gmock/*' '*/gtest/*' '*/test/*' --output-file cmake-build-unit-tests/coverage.info
 
-          FunctionPercentage=\$(lcov --summary cmake-build-unit-tests/coverage.info | grep 'functions' | awk '{print \$2}') &&
-          echo \"Function Percentage: \$FunctionPercentage\" &&
-          wget \"https://img.shields.io/badge/coverage-\${FunctionPercentage}25-brightgreen.svg\" -O function_coverage_badge.svg &&
+    - name: Generate HTML coverage report
+      run:  |
+          chmod 744 cmake-build-unit-tests/coverage.info
+          genhtml cmake-build-unit-tests/coverage.info --output-directory cmake-build-unit-tests/coverage
+
+    - name: Zip coverage html
+      run: |
+          mv cmake-build-unit-tests/coverage code_coverage
+          zip -r code_coverage.zip code_coverage
+
+    - name: Badges
+      run: |
+          LinePercentage=$(lcov --summary cmake-build-unit-tests/coverage.info | grep 'lines' | awk '{print $2}') &&
+          echo "Line Percentage: $LinePercentage" &&
+          wget "https://img.shields.io/badge/coverage-${LinePercentage}25-brightgreen.svg" -O line_coverage_badge.svg &&
+
+          FunctionPercentage=$(lcov --summary cmake-build-unit-tests/coverage.info | grep 'functions' | awk '{print $2}') &&
+          echo "Function Percentage: $FunctionPercentage" &&
+          wget "https://img.shields.io/badge/coverage-${FunctionPercentage}25-brightgreen.svg" -O function_coverage_badge.svg &&
 
           mkdir coverage_badges &&
-
           mv line_coverage_badge.svg coverage_badges/ &&
           mv function_coverage_badge.svg coverage_badges/ &&
-          zip -r coverage_badges.zip coverage_badges &&
-
-          chown -R 2001:2001 cmake-build-unit-tests code_coverage coverage_badges
-        "
+          zip -r coverage_badges.zip coverage_badges
 
     - name: Upload code coverage artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Utilize sscache to speed up the compilation process for unit builds.
- Eliminate the need for Docker containers in the CI workflow to simplify the setup.
- Implement actions/cache to store cmake-build-unit-tests artifacts to ensure these cached artifacts can be reused across different workflows to improve efficiency.