### PR TITLE
Fix: cache storage legacy service is shutting down error

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -25,7 +25,7 @@ jobs:
         sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-11 100
 
     - name: Set up sccache
-      uses: mozilla-actions/sccache-action@v0.0.7
+      uses: mozilla-actions/sccache-action@v0.0.8
       with:
         version: "v0.10.0"
 


### PR DESCRIPTION
Updated the sccache action to the latest version (v0.0.8). This change addresses the cache storage error caused by the decommissioning of the legacy cache service.