### PR TITLE
Add stack usage in ArmNoneEabi.cmake for Puncover

### DIFF
--- a/.github/workflows/puncover_tool.yml
+++ b/.github/workflows/puncover_tool.yml
@@ -29,7 +29,7 @@ jobs:
         with:
             path: |
               cmake-build-s32k148
-            key: ${{ runner.os }}-cmake-s32k148-${{ hashFiles('**/*.cpp', '**/*.h', '**/*.cmake', '**/*.txt', '**/*.c', '**/*.s', 'admin/cmake/ArmNoneEabi.cmake') }}
+            key: ${{ runner.os }}-cmake-s32k148-${{ hashFiles('**/*.cpp', '**/*.h', '**/*.cmake', '**/*.txt', '**/*.c', '**/*.s') }}
 
       - name: Install Poetry
         uses: snok/install-poetry@v1.4.1

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ venv
 .envrc
 .DS_Store
 *.egg-info
+tools/puncover_tool/output/
 .docker_history/
 .sccache/
 doc/doxygenOut

--- a/.treefmt.toml
+++ b/.treefmt.toml
@@ -32,6 +32,7 @@ excludes = [
   "admin/cmake/CodeCoverage.cmake",
   "docker/**", 
   "tools/clang-format-wrapper",
+  "tools/puncover_tool/**",
 ]
 
 [formatter.cpp]

--- a/admin/cmake/ArmNoneEabi.cmake
+++ b/admin/cmake/ArmNoneEabi.cmake
@@ -21,7 +21,7 @@ set(C_COMMON_FLAGS
     "${CPU_BUILD_FLAGS} -mthumb -fshort-enums \
 -mno-unaligned-access -Wno-psabi \
 -fno-asynchronous-unwind-tables -fno-builtin -fno-common \
--ffunction-sections -fdata-sections")
+-ffunction-sections -fdata-sections -fstack-usage")
 
 set(CMAKE_ASM_FLAGS "-g -mcpu=cortex-m4")
 set(CMAKE_C_FLAGS "${C_COMMON_FLAGS} -ffreestanding")


### PR DESCRIPTION
- For viewing the Stack Usage on puncover
- .su files will be generated under cmake-build-s32k148
- View Stack Worst-Case Scenarios and Stack Usage on puncover tools/puncover_tool/output/index.html
- Add generated tools/puncover_tool/output to .gitignore