### PR TITLE
SOP wording cleanup

### DIFF
--- a/doc/codingGuidelines/conventions/statements.rst
+++ b/doc/codingGuidelines/conventions/statements.rst
@@ -184,7 +184,7 @@ memory got corrupted (out of bounds access through operator[]). Comment the usag
 justification.
 
 It might be acceptable during development to use asserts. In this case use ``estd_expect`` instead.
-``estd_expect`` behaves the same as ``estd_assert``, but it must be replaced before SOP with
+``estd_expect`` behaves the same as ``estd_assert``, but it must be replaced before production with
 proper error handling. The usage of ``estd_expect`` is detected by our code analyzers and
 presented in the module overview from Cijack.
 

--- a/doc/learning/setup/setup_s32k148_win_nxpide.rst
+++ b/doc/learning/setup/setup_s32k148_win_nxpide.rst
@@ -22,7 +22,7 @@ To download and install this you will first need to register for a free account 
 Note that free activation codes for software you download will be sent to the email account you register with.
 Once registered, you can `download S32 Design Studio for ARM from here <https://www.nxp.com/webapp/swlicensing/sso/downloadSoftware.sp?catid=S32DS-IDE-ARM-V2-X>`_.
 
-Download and run the installer S32DS_ARM_Win32_v :prop:`tool:s32ds_arm_version` .exe (this assumes you administrator rights on your PC).
+Download and run the installer S32DS_ARM_Win32_v :prop:`tool:s32ds_arm_version` .exe (this assumes you have administrator rights on your PC).
 Enter the activation code received by email when prompted and chose **Activate Online**.
 During the installation it will also prompt you to allow drivers from **PEMicro** to be installed - accept this.
 

--- a/libs/bsw/estd/include/estd/assert.h
+++ b/libs/bsw/estd/include/estd/assert.h
@@ -59,7 +59,6 @@
 
 // estd_expect behaves the same as estd_assert, but it shall not be used in
 // production code, only for temporary asserts during development.
-// estd_export must be replaced before SOP with proper error handling.
 // The usage of estd_expect can be detected by static code analyzers.
 #if defined(ESTD_EXPECT_ERROR)
 #define estd_expect(E__) static_assert(false, "Replace estd_expect with proper error handling")


### PR DESCRIPTION
Besides typo fixes, this PR removes references to "SOP". Some legal checks on my side suggested to remove it, and as far as I understand, OpenBSW does not support the concept of "SOP".