### PR TITLE
Fix wrong byte in Flow Control Frame.

### DIFF
--- a/executables/referenceApp/application/src/systems/DoCanSystem.cpp
+++ b/executables/referenceApp/application/src/systems/DoCanSystem.cpp
@@ -20,7 +20,7 @@ uint16_t const TX_CALLBACK_TIMEOUT    = 1000U;
 uint16_t const FLOW_CONTROL_TIMEOUT   = 1000U;
 uint8_t const ALLOCATE_RETRY_COUNT    = 15U;
 uint8_t const FLOW_CONTROL_WAIT_COUNT = 15U;
-uint16_t const MIN_SEPARATION_TIME    = 2U;
+uint16_t const MIN_SEPARATION_TIME    = 200U;
 uint8_t const BLOCK_SIZE              = 15U;
 
 uint32_t systemUs() { return getSystemTimeUs32Bit(); }

--- a/libs/bsw/docan/include/docan/common/DoCanParameters.h
+++ b/libs/bsw/docan/include/docan/common/DoCanParameters.h
@@ -227,7 +227,7 @@ inline uint32_t DoCanParameters::decodeMinSeparationTime(uint8_t const encodedMi
 inline uint8_t DoCanParameters::encodeMinSeparationTime(uint32_t const minSeparationTimeUs)
 {
     // Encode 100-900us STmin values
-    if ((minSeparationTimeUs > 0) && (minSeparationTimeUs < 1000U))
+    if ((minSeparationTimeUs >= 100U) && (minSeparationTimeUs < 1000U))
     {
         return static_cast<uint8_t>(minSeparationTimeUs / 100U) + 0xF0U;
     }

--- a/libs/bsw/docan/test/gtest/src/docan/common/DoCanParametersTest.cpp
+++ b/libs/bsw/docan/test/gtest/src/docan/common/DoCanParametersTest.cpp
@@ -70,4 +70,19 @@ TEST(DoCanParameters, testEncodeMinSeparationTime)
     }
 }
 
+TEST(DoCanParameters, encodeMinSeparationTimeTestValueRange)
+{
+    // Test that the encoding of STmin byte in Flow Control Frame is in the range of allowed values
+
+    for (uint32_t t = 0; t < (0x7FU * 1000U) + 1U; t++)
+    {
+        uint8_t result;
+        result = DoCanParameters::encodeMinSeparationTime(t);
+
+        // According to ISO-TP (ISO 15765-2:2016 9.6.5.4), STmin values 0x0 - 0x7F, 0xF1 - 0xF9 are
+        // allowed
+        EXPECT_TRUE(result <= 0x7FU || (result <= 0xF9U && result >= 0xF1U));
+    }
+}
+
 } // anonymous namespace


### PR DESCRIPTION
Sending a UDS request which doesnt fit into one single CAN frame (e.g. WDBI with larger payload) the ECU responds with the FC frame

vcan0   0F0   [8]   30 0F F0 FF FF FF FF FF

to the tester. Here, the third byte representing the STmin byte (0xF0) seems to be invalid according to ISO-TP. This seems to come from a parameter used in DoCANSystem in the reference executable. To ensure the STmin byte in the FC frame is always valid according to ISO-TP, we also modify the encoding function.