### PR TITLE
Show build status of Posix, S32k148

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,7 @@
 
 ## Build Status 🚀
 
-| Platform       | Status                                                                 |
-|----------------|------------------------------------------------------------------------|
-| POSIX Build | ![POSIX](https://github.com/eclipse-openbsw/openbsw/actions/workflows/build.yml/badge.svg?branch=main&event=push&matrix.platform=posix) |
-| S32K148     | ![S32K](https://github.com/eclipse-openbsw/openbsw/actions/workflows/build.yml/badge.svg?branch=main&event=push&matrix.platform=s32k148) |
+[![Build S32k and posix platform](https://github.com/eclipse-openbsw/openbsw/actions/workflows/build.yml/badge.svg?branch=main&event=push)](https://github.com/eclipse-openbsw/openbsw/actions/workflows/build.yml)
 
 ## Code Coverage 
 


### PR DESCRIPTION
-  This badge displays the build status of the latest push event on the main branch, including merges from pull requests.

![image](https://github.com/user-attachments/assets/bf901357-90bd-4956-87ed-4ec4a2263ada)

Clicking on the badge redirects to the corresponding GitHub Actions workflow run:
![image](https://github.com/user-attachments/assets/00d9d77c-6f79-4523-8842-b47d4c9e236c)

Output can be viewed from here: [link](https://github.com/esrlabs/openbsw/tree/StatusBadge?tab=readme-ov-file#build-status-)
