### PR TITLE
Fix failure in test_lifecycle.py on s32k148

### DIFF
--- a/test/pyTest/console/test_lifecycle.py
+++ b/test/pyTest/console/test_lifecycle.py
@@ -47,6 +47,7 @@ def test_lc_levelchange(target_session):
         (success, lines, _) = capserial.read_until(expected, timeout=2)
         assert success
     target_session.restart()
+    assert capserial.wait_for_boot_complete()
 
 
 # Test to check lifecycle reboot command


### PR DESCRIPTION
originates from CR #132267