### PR TITLE
Remove dependencies on std

### DIFF
--- a/libs/bsp/bspCharInputOutput/src/charInputOutput/bspIo.cpp
+++ b/libs/bsp/bspCharInputOutput/src/charInputOutput/bspIo.cpp
@@ -7,7 +7,6 @@
 #include <printf/printf.h>
 
 #include <cstring>
-#include <limits>
 
 #ifdef __cplusplus
 extern "C"

--- a/libs/bsw/cpp2can/src/can/filter/IntervalFilter.cpp
+++ b/libs/bsw/cpp2can/src/can/filter/IntervalFilter.cpp
@@ -3,8 +3,7 @@
 #include "can/filter/IntervalFilter.h"
 
 #include <etl/algorithm.h>
-
-#include <algorithm>
+#include <etl/utility.h>
 
 namespace can
 {
@@ -31,7 +30,7 @@ void IntervalFilter::add(uint32_t from, uint32_t to)
     // assert order
     if (from > to)
     {
-        ::std::swap(from, to);
+        ::ETL_OR_STD::swap(from, to);
     }
     // adjust lower bound
     _from = ::etl::min(_from, from);

--- a/libs/bsw/transport/src/LogicalAddress.cpp
+++ b/libs/bsw/transport/src/LogicalAddress.cpp
@@ -2,7 +2,7 @@
 
 #include "transport/LogicalAddress.h"
 
-#include <algorithm>
+#include <etl/algorithm.h>
 
 namespace transport
 {
@@ -11,7 +11,7 @@ namespace addressfinder
 ::etl::optional<LogicalAddress>
 findDoipAddressInSlice(uint16_t const address, ::etl::span<LogicalAddress const> const& list)
 {
-    auto const iter = std::find_if(
+    auto const iter = etl::find_if(
         list.begin(),
         list.end(),
         [address](LogicalAddress const addr) -> bool { return addr.addressDoip == address; });
@@ -25,7 +25,7 @@ findDoipAddressInSlice(uint16_t const address, ::etl::span<LogicalAddress const>
 ::etl::optional<LogicalAddress>
 find8BitAddressInSlice(uint16_t const address, ::etl::span<LogicalAddress const> const& list)
 {
-    auto const iter = std::find_if(
+    auto const iter = etl::find_if(
         list.begin(),
         list.end(),
         [address](LogicalAddress const addr) -> bool { return addr.address8Bit == address; });

--- a/libs/bsw/uds/src/uds/services/routinecontrol/RequestRoutineResults.cpp
+++ b/libs/bsw/uds/src/uds/services/routinecontrol/RequestRoutineResults.cpp
@@ -6,13 +6,13 @@
 #include "uds/session/DiagSession.h"
 #include "uds/session/IDiagSessionManager.h"
 
-#include <type_traits>
+#include <etl/type_traits.h>
 
 namespace uds
 {
 uint8_t const RequestRoutineResults::sfImplementedRequest[2]
     = {ServiceId::ROUTINE_CONTROL,
-       static_cast<::std::underlying_type<RoutineControl::Subfunction>::type>(
+       static_cast<::etl::underlying_type<RoutineControl::Subfunction>::type>(
            RoutineControl::Subfunction::REQUEST_ROUTINE_RESULTS)};
 
 RequestRoutineResults::RequestRoutineResults()

--- a/libs/bsw/uds/src/uds/services/routinecontrol/StartRoutine.cpp
+++ b/libs/bsw/uds/src/uds/services/routinecontrol/StartRoutine.cpp
@@ -6,13 +6,13 @@
 #include "uds/session/DiagSession.h"
 #include "uds/session/IDiagSessionManager.h"
 
-#include <type_traits>
+#include <etl/type_traits.h>
 
 namespace uds
 {
 uint8_t const StartRoutine::sfImplementedRequest[2]
     = {ServiceId::ROUTINE_CONTROL,
-       static_cast<::std::underlying_type<RoutineControl::Subfunction>::type>(
+       static_cast<::etl::underlying_type<RoutineControl::Subfunction>::type>(
            RoutineControl::Subfunction::START_ROUTINE)};
 
 StartRoutine::StartRoutine() : Subfunction(&sfImplementedRequest[0], DiagSession::ALL_SESSIONS())

--- a/libs/bsw/uds/src/uds/services/routinecontrol/StopRoutine.cpp
+++ b/libs/bsw/uds/src/uds/services/routinecontrol/StopRoutine.cpp
@@ -6,13 +6,13 @@
 #include "uds/session/DiagSession.h"
 #include "uds/session/IDiagSessionManager.h"
 
-#include <type_traits>
+#include <etl/type_traits.h>
 
 namespace uds
 {
 uint8_t const StopRoutine::sfImplementedRequest[2]
     = {ServiceId::ROUTINE_CONTROL,
-       static_cast<::std::underlying_type<RoutineControl::Subfunction>::type>(
+       static_cast<::etl::underlying_type<RoutineControl::Subfunction>::type>(
            RoutineControl::Subfunction::STOP_ROUTINE)};
 
 StopRoutine::StopRoutine() : Subfunction(&sfImplementedRequest[0], DiagSession::ALL_SESSIONS())


### PR DESCRIPTION
By replacing std usage with etl counterparts, code will compile in more cases in ETL_NO_STL mode.

This is preparational work for the upcoming ETL release from which we want to include etl::closure and in turn etl::tuple. This requires decoupling etl from std if we want to keep ETL_NO_STL mode.