### PR TITLE
Make ILifecycleComponent's dtr protected non-virtual

### DIFF
--- a/libs/bsw/lifecycle/include/lifecycle/AsyncLifecycleComponent.h
+++ b/libs/bsw/lifecycle/include/lifecycle/AsyncLifecycleComponent.h
@@ -29,9 +29,9 @@ public:
 
     ::async::ContextType getTransitionContext(Transition::Type transition) override;
 
-    ~AsyncLifecycleComponent() override = default;
-
 protected:
+    ~AsyncLifecycleComponent() = default;
+
     /// Set the async `context` for all transitions to be run in.
     void setTransitionContext(::async::ContextType context);
     /// Set the async `context` for a single transitions of a single type to be run in.

--- a/libs/bsw/lifecycle/include/lifecycle/ILifecycleComponent.h
+++ b/libs/bsw/lifecycle/include/lifecycle/ILifecycleComponent.h
@@ -9,6 +9,7 @@
 #include <async/Async.h>
 
 #include <cstddef>
+#include <cstdint>
 
 namespace lifecycle
 {
@@ -29,6 +30,8 @@ public:
         static size_t const COUNT = 3U;
     };
 
+    ILifecycleComponent& operator=(ILifecycleComponent const&) = delete;
+
     /// Register the callback on which to call `transitionDone()`.
     ///
     /// When adding this component to a LifecycleManager, it uses this method to set itself as the
@@ -42,10 +45,8 @@ public:
     /// called on the callback
     virtual void startTransition(Transition::Type transition)                      = 0;
 
-    virtual ~ILifecycleComponent() = default;
-
-private:
-    ILifecycleComponent& operator=(ILifecycleComponent const&) = delete;
+protected:
+    ~ILifecycleComponent() = default;
 };
 
 } // namespace lifecycle

--- a/libs/bsw/lifecycle/include/lifecycle/LifecycleComponent.h
+++ b/libs/bsw/lifecycle/include/lifecycle/LifecycleComponent.h
@@ -31,9 +31,9 @@ public:
     /// See ILifecycleComponentCallback::startTransition()
     void startTransition(Transition::Type transition) override;
 
-    ~LifecycleComponent() override = default;
-
 protected:
+    ~LifecycleComponent() = default;
+
     void transitionDone();
 
     virtual void init()     = 0;

--- a/libs/bsw/lifecycle/include/lifecycle/SimpleLifecycleComponent.h
+++ b/libs/bsw/lifecycle/include/lifecycle/SimpleLifecycleComponent.h
@@ -20,15 +20,16 @@ namespace lifecycle
 class SimpleLifecycleComponent : public LifecycleComponent
 {
 public:
+    SimpleLifecycleComponent& operator=(SimpleLifecycleComponent const&) = delete;
+
     /// The transition context of this SimpleLifecycleComponent.
     ///
     /// Returns CONTEXT_INVALID, which means that the LifecycleManager will run all transitions in
     /// its own context.
     ::async::ContextType getTransitionContext(Transition::Type transition) override;
-    ~SimpleLifecycleComponent() override = default;
 
-private:
-    SimpleLifecycleComponent& operator=(SimpleLifecycleComponent const&) = delete;
+protected:
+    ~SimpleLifecycleComponent() = default;
 };
 
 } // namespace lifecycle

--- a/libs/bsw/lifecycle/include/lifecycle/SingleContextLifecycleComponent.h
+++ b/libs/bsw/lifecycle/include/lifecycle/SingleContextLifecycleComponent.h
@@ -25,7 +25,8 @@ public:
 
     ::async::ContextType getTransitionContext(Transition::Type transition) override;
 
-    ~SingleContextLifecycleComponent() override = default;
+protected:
+    ~SingleContextLifecycleComponent() = default;
 
 private:
     ::async::ContextType const _context;


### PR DESCRIPTION
This should allow compiler to ommit the generation of dtr for lifecycle components wrapped in typed_mem.