### PR TITLE
Fix error when built for directory with whitespaces

### DIFF
--- a/platforms/posix/bsp/socketCanTransceiver/test/gtest/CMakeLists.txt
+++ b/platforms/posix/bsp/socketCanTransceiver/test/gtest/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(
 
 target_link_libraries(
     socketCanTransceiverTest
-    PRIVATE "-Wl,--whole-archive $<TARGET_FILE:bspMock> -Wl,--no-whole-archive"
+    PRIVATE "-Wl,--whole-archive \"$<TARGET_FILE:bspMock>\" -Wl,--no-whole-archive"
             socketCanTransceiver bspMock gtest_main)
 
 gtest_discover_tests(socketCanTransceiverTest


### PR DESCRIPTION
Fix build error, when build directory has whitespaces in it.
Fixes #140 