### PR TITLE
Update docker

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,21 +1,23 @@
 FROM ubuntu:22.04
 
-RUN apt-get update && \
-    apt-get install -y --fix-missing \
-    python3.10 \
-    python3-pip \
-    bzip2 \
-    zip \
-    tar \
-    tmux \
-    clang-tidy \
-    wget \
-    curl \
-    git \
-    gcc-11 \
-    g++-11 \
-    lcov \
-    && rm -rf /var/lib/apt/lists/*
+RUN for i in 1 2 3; do \
+        apt-get update && apt-get install -y \
+            python3.10 \
+            python3-pip \
+            bzip2 \
+            zip \
+            tar \
+            tmux \
+            clang-tidy \
+            wget \
+            curl \
+            git \
+            gcc-11 \
+            g++-11 \
+            lcov \
+        && rm -rf /var/lib/apt/lists/* \
+        && break || { echo "Apt install failed, retrying ($i/3)..."; sleep 10; }; \
+    done
 
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.5/cmake-3.22.5-linux-x86_64.sh \
     && chmod +x cmake-3.22.5-linux-x86_64.sh \

--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -1,11 +1,14 @@
 FROM ubuntu:22.04
 
-RUN apt-get update && apt-get install -y python3.10 python3-pip openjdk-11-jdk graphviz \
-    doxygen\
-    zip \
-    wget \
-    bzip2 \
-    && rm -rf /var/lib/apt/lists/*
+RUN for i in 1 2 3; do \
+        apt-get update && apt-get install -y python3.10 python3-pip openjdk-11-jdk graphviz \
+            doxygen\
+            zip \
+            wget \
+            bzip2 \
+        && rm -rf /var/lib/apt/lists/* \
+        && break || { echo "Apt install failed, retrying ($i/3)..."; sleep 10; }; \
+    done
 
 COPY doc/requirements.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt


### PR DESCRIPTION
- Update dockerfile.dev, dockerfile.docs
-  This issue occurs on the GitHub job build-docker-image  while fetching packages from ubuntu repository  and it happens only on post-merge builds. As referenced on the link below
[Error on fetching apt packages](https://github.com/eclipse-openbsw/openbsw/actions/runs/16121546881/job/45488335657)

- To overcome this retry option has been added i.e to re run option of apt-update and fetching apt packages in both the dockerfiles
