### PR TITLE
Remove return statement from void function TaggedOutputHelper::writeBytes

### DIFF
--- a/libs/bsw/util/src/util/stream/TaggedOutputHelper.cpp
+++ b/libs/bsw/util/src/util/stream/TaggedOutputHelper.cpp
@@ -42,7 +42,7 @@ void TaggedOutputHelper::writeBytes(IOutputStream& strm, ::etl::span<uint8_t con
 void TaggedOutputHelper::writeBytes(IOutputStream& strm, ::etl::string_view const& view)
 {
     ::etl::span<uint8_t const> buffer{reinterpret_cast<uint8_t const*>(view.begin()), view.size()};
-    return writeBytes(strm, buffer);
+    writeBytes(strm, buffer);
 }
 
 void TaggedOutputHelper::endLine(IOutputStream& strm)


### PR DESCRIPTION
originates from CR #134149