### PR TITLE
Remove ld option --noinhibit-exec to expose linker errors

### DIFF
--- a/Filelists.cmake
+++ b/Filelists.cmake
@@ -50,8 +50,6 @@ add_compile_options(
 add_compile_options(
     "$<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-O2;-g3;-Werror;-Wall;-Wextra>")
 
-add_link_options(-Wl,--noinhibit-exec)
-
 if (BUILD_UNIT_TESTS)
     add_compile_definitions(UNIT_TEST=1)
     include(GoogleTest)


### PR DESCRIPTION
With --noinhibit-exec, linker errors like missing symbols can go unnoticed.