### PR TITLE
Fix Watchdog constructor

### DIFF
--- a/platforms/s32k1xx/bsp/bspMcuWatchdog/include/watchdog/Watchdog.h
+++ b/platforms/s32k1xx/bsp/bspMcuWatchdog/include/watchdog/Watchdog.h
@@ -21,7 +21,7 @@ public:
      */
     explicit Watchdog(uint32_t const timeout, uint32_t const clockSpeed = DEFAULT_CLOCK_SPEED)
     {
-        enableWatchdog(timeout, clockSpeed);
+        enableWatchdog(timeout, false, clockSpeed);
     }
 
     /**


### PR DESCRIPTION
The actual enableWatchdog call in the ctor is wrongly using the clockSpeed as the interruptActive argument.

Instead, we need to add the interruptActive flag in the middle. Using the default (false) as in the enableWatchdog default value. Risk is low, since the Watchdog class is currently not instantiated.

This way, the intention of the ctor and enableWatchdog() is synchronized regarding the default values.