### PR TITLE
Reduce the amount of CI checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         preset: [ "tests-debug", "tests-release", "posix", "posix-with-tracing", "s32k148-gcc" ]
         platform: [ "arm", "linux" ]
-        config: [ "", "Debug", "Release", "RelWithDebInfo" ]
+        config: [ "Debug", "Release", "RelWithDebInfo" ]
         cxxid: ["gcc", "clang"]
-        cxxstd: [ 14, 17, 20, 23 ]
+        cxxstd: [ 14, 20 ]
         exclude:
           - preset: "tests-debug"
             platform: "arm"


### PR DESCRIPTION
Reduce the amount of checks by deleting checks for C++17 and C++23 compilation. Also remove check for compilation with unspecified config.