### PR TITLE
Fix linkerscript errors

### DIFF
--- a/executables/referenceApp/platforms/s32k148evb/main/linkerscript/application.dld
+++ b/executables/referenceApp/platforms/s32k148evb/main/linkerscript/application.dld
@@ -21,7 +21,7 @@ MEMORY
   Isr (RX) : ORIGIN = FLASH_START, LENGTH = 0x00000400
   FlashConfigField (RX) : ORIGIN = FLASH_START + 0x00000400, LENGTH = 0x00000010
   ApplicationStartUpCode (RX) : ORIGIN = FLASH_START + 0x410, LENGTH = 0x20
-  Application (RX) : ORIGIN = FLASH_START + 0x430, LENGTH = FLASH_END + 1 - FLASH_START - 0x430
+  Application (RX) : ORIGIN = FLASH_START + 0x430, LENGTH = FLASH_END + 1 - FLASH_START - 0x430 - 64
   CrcMeta (RX) : ORIGIN = FLASH_END + 1 - 64,  LENGTH = 64
   /* SRAM_L */
   Data (RW) : ORIGIN = SRAM_L_START, LENGTH = SRAM_L_END + 1 - SRAM_L_START
@@ -218,16 +218,11 @@ SECTIONS
   } > Data
 
   __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
-   ___data_size = _edata - _sdata;
-  .data_rom : AT(__DATA_ROM)
-  {
-    __DATA_ROM_START = .;
-    . += ___data_size;
-    . = ALIGN(4);
-    __DATA_ROM_END = .;
-    __USED_FLASH_END = .;
-  }
-  > Application = 0xffffffff
+  ___data_size = _edata - _sdata;
+
+  __DATA_ROM_START = __DATA_ROM;
+  __DATA_ROM_END = __DATA_ROM + ___data_size;
+  __USED_FLASH_END = __DATA_ROM_END;
 
   /* Uninitialized data */
 
@@ -242,18 +237,6 @@ SECTIONS
     . = ALIGN(4);
     __bss_end__ = .;
     __END_BSS = .;
-  } > Data
-
-  _romp_at = __DATA_ROM + SIZEOF(.data);
-  .romp : AT(_romp_at)
-  {
-    __S_romp = _romp_at;
-    LONG(__DATA_ROM);
-    LONG(_sdata);
-    LONG(___data_size);
-    LONG(0);
-    LONG(0);
-    LONG(0);
   } > Data
 
   __CRC_IVT_START   = ADDR(.interrupts);

--- a/executables/referenceApp/platforms/s32k148evb/main/src/systems/S32K148EvbEthernetSystem.cpp
+++ b/executables/referenceApp/platforms/s32k148evb/main/src/systems/S32K148EvbEthernetSystem.cpp
@@ -22,11 +22,9 @@ constexpr size_t NUM_RX_BUFFER_DESCRIPTORS = 16;
 constexpr size_t PBUF_RX_BUFSIZE           = 256;
 
 // align to 512-bit boundary
-__attribute__((aligned(64))) ENET_ETXD __attribute__((section(".ethernetDescriptorsTx")))
-fTxDescriptor[NUM_TX_BUFFER_DESCRIPTORS];
+__attribute__((aligned(64))) ENET_ETXD fTxDescriptor[NUM_TX_BUFFER_DESCRIPTORS];
 
-__attribute__((aligned(64))) ENET_ERXD __attribute__((section(".ethernetDescriptorsRx")))
-fRxDescriptor[NUM_RX_BUFFER_DESCRIPTORS];
+__attribute__((aligned(64))) ENET_ERXD fRxDescriptor[NUM_RX_BUFFER_DESCRIPTORS];
 
 __attribute__((aligned(64))) uint8_t fRxBuffers[(NUM_RX_BUFFER_DESCRIPTORS * PBUF_RX_BUFSIZE)];
 


### PR DESCRIPTION
EthernetDescriptors were not mapped, it could happen, that romp and data sections overlap, which leads to linker errors.

The CRC section at the end of the flash also overlapped with data_rom section, but this problem would only occur if flash is almost full.

Additionally, unused sections were removed to cleanup the linker script a bit.

Thanks to Martin Mössmer and Roland Reichwein for support.