### PR TITLE
Fix build with s32k148-clang

### DIFF
--- a/cmake/toolchains/ArmNoneEabi-clang.cmake
+++ b/cmake/toolchains/ArmNoneEabi-clang.cmake
@@ -34,7 +34,6 @@ set(CMAKE_SYSROOT
 
 set(_EXE_LINKER_FLAGS
     "-Wl,--start-group \
-        -lc \
         -ldummyhost \
         -lclang_rt.builtins \
     -Wl,--end-group")

--- a/platforms/s32k1xx/bsp/bspAdc/include/adc/Adc.h
+++ b/platforms/s32k1xx/bsp/bspAdc/include/adc/Adc.h
@@ -181,7 +181,7 @@ bsp::BspReturnCode Adc<AdcResolution, AdcConfiguration, maxChannels>::startInjec
 
 template<typename AdcResolution, typename AdcConfiguration, uint8_t maxChannels>
 bsp::BspReturnCode
-Adc<AdcResolution, AdcConfiguration, maxChannels>::InjectionsReady(uint32_t timeout)
+Adc<AdcResolution, AdcConfiguration, maxChannels>::InjectionsReady(uint32_t /*timeout*/)
 {
     bool mask0Ready = false;
     bool mask1Ready = false;


### PR DESCRIPTION
-lc causes newlib to be linked and causing duplicate symbols, since we also define snprintf().

Fixing an unused argument also.