### PR TITLE
Fix: Add timeout to prevent pytest hanging on CAN/Ethernet tests

### DIFF
--- a/.ci/pytest.py
+++ b/.ci/pytest.py
@@ -17,8 +17,7 @@ def build_reference_app():
 
 def run_pytest():
     os.chdir("./test/pyTest")
-    subprocess.run(["pytest", "--target=posix"], check=True)
-
+    subprocess.run(['pytest', '--target=posix', '--timeout=120'], check=True)
 
 if __name__ == "__main__":
     try:

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -69,6 +69,8 @@ RUN pip3 install rich
 # Install eftools required for ROM check functionality
 RUN pip3 install pyelftools==0.32
 
+RUN pip install --quiet pytest-timeout
+
 COPY test/pyTest/requirements.txt /home/jenkins/test/pyTest/requirements.txt
 RUN pip3 install -r /home/jenkins/test/pyTest/requirements.txt
 


### PR DESCRIPTION
originates from CR #135689