### PR TITLE
Remove red LED from PwmSupport in ReferenceApp

### DIFF
--- a/doc/learning/SysTest/HW_Testing_Guide.rst
+++ b/doc/learning/SysTest/HW_Testing_Guide.rst
@@ -196,9 +196,9 @@ ReferenceApp Test Guide
                 ok
                6937: RefApp: CONSOLE: INFO: Received console command "help"
                7036: RefApp: CONSOLE: INFO: console command Succeeded
-               pwm set 2 2000
+               pwm set 1 2000
 
-               PWM channel 2 (eval_led_green_pwm) set to 0x1388 % On
+               PWM channel 1 (eval_led_green_pwm) set to 0x7d0 % On
 
                19355: RefApp: CONSOLE: INFO: Received console command "pwm set 2 2000"
                19360: RefApp: CONSOLE: INFO: console command Succeeded
@@ -206,10 +206,10 @@ ReferenceApp Test Guide
 
 
           pwm set channel # value from 0-10000 |br|
-          pwm set 2        2000
+          pwm set 1 2000
 
    * For 50% duty cycle use command:
-     pwm set 2 5000
+     pwm set 1 5000
 
    * This command can be used to change the duty cycle for all available channels (currently - 3).
      Duty cycle can be changed from 0-100 % using values from 0 – 10000.

--- a/doc/learning/console/pwmConsole.rst
+++ b/doc/learning/console/pwmConsole.rst
@@ -15,11 +15,11 @@ Below is the example usage:
 
 .. code-block:: bash
 
-  pwm set 2 5000
+  pwm set 1 5000
 
-    PWM channel 2 (eval_led_green_pwm) set to 0x1388 % On
+    PWM channel 1 (eval_led_green_pwm) set to 0x1388 % On
   ok
-  23587: RefApp: CONSOLE: INFO: Received console command "pwm set 2 5000"
+  23587: RefApp: CONSOLE: INFO: Received console command "pwm set 1 5000"
   23593: RefApp: CONSOLE: INFO: Console command succeeded
 
 Next: :ref:`lifecycle_console`

--- a/doc/learning/hwio/index.rst
+++ b/doc/learning/hwio/index.rst
@@ -23,11 +23,10 @@ and that this enables code in ``DemoSystem::cyclic()`` to read the ADC value con
 
     (void)AnalogInputScale::get(AnalogInput::AiEVAL_POTI_ADC, value);
 
-and then set PWM values for each colour on the RGB LED based on the measured ADC value...
+and then set PWM values for RGB LEDs based on the measured ADC value...
 
 .. code-block:: cpp
 
-    OutputPwm::setDuty(OutputPwm::EVAL_LED_RED_PWM, value * 10000 / 5000);
     OutputPwm::setDuty(OutputPwm::EVAL_LED_GREEN_PWM, value * 10000 / 5000);
     OutputPwm::setDuty(OutputPwm::EVAL_LED_BLUE_PWM, value * 10000 / 5000);
 

--- a/executables/referenceApp/platforms/s32k148evb/bspConfiguration/doc/user/bspIo_outputPwm.rst
+++ b/executables/referenceApp/platforms/s32k148evb/bspConfiguration/doc/user/bspIo_outputPwm.rst
@@ -23,9 +23,9 @@ Configuration
     - `PWM Mode`, `interruptActive`, `dmaActive`, `icrst`, `IO pin Mapping`, `minimum` and
         `maximum` dutycycle.
 
-- For demo purposes `EVAL_LED_RED_PWM`, `EVAL_LED_GREEN_PWM` and `EVAL_LED_BLUE_PWM` are configured
-  as the PWM channels for controlling the brightness of red, green and blue internal LEDs available
-  in the evaluation Board.
+- For demo purposes, `EVAL_LED_GREEN_PWM` and `EVAL_LED_BLUE_PWM` are configured
+  as the PWM channels for controlling the brightness of green and blue internal LEDs available
+  on the evaluation board.
 
 PwmSupport
 ----------
@@ -60,9 +60,8 @@ Example
     void DemoSystem::cyclic()
     {
     #ifdef PLATFORM_SUPPORT_IO
-        uint32_t value = 2500;  // 2500 is the sample value for 50% dutycycle
+        uint32_t value = 2500;  // 2500 is the sample value for 50% duty cycle
 
-        OutputPwm::setDuty(OutputPwm::EVAL_LED_RED_PWM, value * 10000 / 5000);
         OutputPwm::setDuty(OutputPwm::EVAL_LED_GREEN_PWM, value * 10000 / 5000);
         OutputPwm::setDuty(OutputPwm::EVAL_LED_BLUE_PWM, value * 10000 / 5000);
 

--- a/executables/referenceApp/platforms/s32k148evb/bspConfiguration/include/bsp/io/outputPwm/PwmSupport.h
+++ b/executables/referenceApp/platforms/s32k148evb/bspConfiguration/include/bsp/io/outputPwm/PwmSupport.h
@@ -23,7 +23,6 @@ public:
 
 private:
     // < hw channel, resolution >
-    FtmEPwm<1, 100> eval_led_red_pwm;
     FtmEPwm<2, 100> eval_led_green_pwm;
     FtmEPwm<3, 100> eval_led_blue_pwm;
 };

--- a/executables/referenceApp/platforms/s32k148evb/bspConfiguration/include/bsp/io/outputPwm/PwmSupportConfiguration.hpp
+++ b/executables/referenceApp/platforms/s32k148evb/bspConfiguration/include/bsp/io/outputPwm/PwmSupportConfiguration.hpp
@@ -10,10 +10,6 @@
 namespace bios
 {
 
-// ftm4:1
-tFtmEPwmConfiguration const EVAL_LED_RED_PWM_Configuration
-    = {tFtm::PWM_EdgeAlignedetSet0, false, false, false, Io::EVAL_LED_RED, 0, 10000};
-
 // ftm4:2
 tFtmEPwmConfiguration const EVAL_LED_GREEN_PWM_Configuration
     = {tFtm::PWM_EdgeAlignedetSet0, false, false, false, Io::EVAL_LED_GREEN, 0, 10000};

--- a/executables/referenceApp/platforms/s32k148evb/bspConfiguration/include/bsp/io/outputPwm/outputPwmConfiguration.h
+++ b/executables/referenceApp/platforms/s32k148evb/bspConfiguration/include/bsp/io/outputPwm/outputPwmConfiguration.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-// All outputs OutputPwm::
 enum outputPwm
 {
     _pwmStaticStart = 0,
@@ -11,13 +10,11 @@ enum outputPwm
     _pwmDynamicStart = _pwmStaticEnd
 
     ,
-    EVAL_LED_RED_PWM = _pwmDynamicStart,
-    EVAL_LED_GREEN_PWM,
+    EVAL_LED_GREEN_PWM = _pwmDynamicStart,
     EVAL_LED_BLUE_PWM
 
     ,
     _pwmDynamicMark,
     _pwmChannelMax   = _pwmDynamicMark,
     PORT_UNAVAILABLE = _pwmChannelMax
-
-}; //*enum
+};

--- a/executables/referenceApp/platforms/s32k148evb/bspConfiguration/include/bsp/io/outputPwm/outputPwmConfigurationStrings.h
+++ b/executables/referenceApp/platforms/s32k148evb/bspConfiguration/include/bsp/io/outputPwm/outputPwmConfigurationStrings.h
@@ -3,4 +3,4 @@
 #pragma once
 
 char const* const outputPwmConfigurationStrings[]
-    = {"dummyPwm", "eval_led_red_pwm", "eval_led_green_pwm", "eval_led_blue_pwm"};
+    = {"dummyPwm", "eval_led_green_pwm", "eval_led_blue_pwm"};

--- a/executables/referenceApp/platforms/s32k148evb/bspConfiguration/src/bsp/io/outputPwm/PwmSupport.cpp
+++ b/executables/referenceApp/platforms/s32k148evb/bspConfiguration/src/bsp/io/outputPwm/PwmSupport.cpp
@@ -8,32 +8,27 @@
 namespace bios
 {
 PwmSupport::PwmSupport(tFtm& ftm4)
-: eval_led_red_pwm(ftm4, EVAL_LED_RED_PWM_Configuration)
-, eval_led_green_pwm(ftm4, EVAL_LED_GREEN_PWM_Configuration)
+: eval_led_green_pwm(ftm4, EVAL_LED_GREEN_PWM_Configuration)
 , eval_led_blue_pwm(ftm4, EVAL_LED_BLUE_PWM_Configuration)
 {}
 
 void PwmSupport::init()
 {
-    (void)eval_led_red_pwm.init();
     (void)eval_led_green_pwm.init();
     (void)eval_led_blue_pwm.init();
 
-    (void)OutputPwm::setDynamicClient(OutputPwm::EVAL_LED_RED_PWM, 0, this);
-    (void)OutputPwm::setDynamicClient(OutputPwm::EVAL_LED_GREEN_PWM, 1, this);
-    (void)OutputPwm::setDynamicClient(OutputPwm::EVAL_LED_BLUE_PWM, 2, this);
+    (void)OutputPwm::setDynamicClient(OutputPwm::EVAL_LED_GREEN_PWM, 0, this);
+    (void)OutputPwm::setDynamicClient(OutputPwm::EVAL_LED_BLUE_PWM, 1, this);
 }
 
 void PwmSupport::start()
 {
-    (void)eval_led_red_pwm.start();
     (void)eval_led_green_pwm.start();
     (void)eval_led_blue_pwm.start();
 }
 
 void PwmSupport::stop()
 {
-    (void)eval_led_red_pwm.stop();
     (void)eval_led_green_pwm.stop();
     (void)eval_led_blue_pwm.stop();
 }
@@ -42,7 +37,6 @@ void PwmSupport::shutdown()
 {
     stop();
 
-    (void)OutputPwm::clrDynamicClient(OutputPwm::EVAL_LED_RED_PWM);
     (void)OutputPwm::clrDynamicClient(OutputPwm::EVAL_LED_GREEN_PWM);
     (void)OutputPwm::clrDynamicClient(OutputPwm::EVAL_LED_BLUE_PWM);
 }
@@ -51,9 +45,8 @@ bsp::BspReturnCode PwmSupport::setDuty(uint16_t chan, uint16_t duty, bool /* imm
 {
     switch (chan)
     {
-        case 0: eval_led_red_pwm.setDuty(eval_led_red_pwm.validDuty(duty)); break;
-        case 1: eval_led_green_pwm.setDuty(eval_led_green_pwm.validDuty(duty)); break;
-        case 2: eval_led_blue_pwm.setDuty(eval_led_blue_pwm.validDuty(duty)); break;
+        case 0: eval_led_green_pwm.setDuty(eval_led_green_pwm.validDuty(duty)); break;
+        case 1: eval_led_blue_pwm.setDuty(eval_led_blue_pwm.validDuty(duty)); break;
 
         default: return bsp::BSP_NOT_SUPPORTED;
     }
@@ -69,15 +62,10 @@ bsp::BspReturnCode PwmSupport::setPeriod(uint16_t chan, uint16_t period)
     {
         case 0:
         {
-            (void)eval_led_red_pwm.setlPeriod(period);
-            break;
-        }
-        case 1:
-        {
             (void)eval_led_green_pwm.setlPeriod(period);
             break;
         }
-        case 2:
+        case 1:
         {
             (void)eval_led_blue_pwm.setlPeriod(period);
             break;

--- a/executables/unitTest/bsp/bspConfiguration/include/bsp/io/outputPwm/outputPwmConfiguration.h
+++ b/executables/unitTest/bsp/bspConfiguration/include/bsp/io/outputPwm/outputPwmConfiguration.h
@@ -11,8 +11,7 @@ enum outputPwm
     _pwmDynamicStart = _pwmStaticEnd
 
     ,
-    EVAL_LED_RED_PWM = _pwmDynamicStart,
-    EVAL_LED_GREEN_PWM,
+    EVAL_LED_GREEN_PWM = _pwmDynamicStart,
     EVAL_LED_BLUE_PWM
 
     ,

--- a/executables/unitTest/bsp/bspConfiguration/include/bsp/io/outputPwm/outputPwmConfigurationStrings.h
+++ b/executables/unitTest/bsp/bspConfiguration/include/bsp/io/outputPwm/outputPwmConfigurationStrings.h
@@ -3,4 +3,4 @@
 #pragma once
 
 char const* const outputPwmConfigurationStrings[]
-    = {"dummyPwm", "eval_led_red_pwm", "eval_led_green_pwm", "eval_led_blue_pwm"};
+    = {"dummyPwm", "eval_led_green_pwm", "eval_led_blue_pwm"};


### PR DESCRIPTION
The red LED is already controlled via GPIO in combination with button 3 on the eval board.