### PR TITLE
Deactivate publishing of code coverage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,17 +52,17 @@ jobs:
           unzip doxygen_docs.zip
           rm doxygen_docs.zip
 
-      - name: Download Code coverage report
-        uses: actions/download-artifact@v4
-        with:
-            name: code_coverage
-            path: ./doc/github_pages
-  
-      - name: Unzip Code coverage report
-        working-directory: ./doc/github_pages
-        run: |
-            unzip code_coverage.zip
-            rm code_coverage.zip
+#      - name: Download Code coverage report
+#        uses: actions/download-artifact@v4
+#        with:
+#            name: code_coverage
+#            path: ./doc/github_pages
+#
+#      - name: Unzip Code coverage report
+#        working-directory: ./doc/github_pages
+#        run: |
+#            unzip code_coverage.zip
+#            rm code_coverage.zip
       
       - name: Download Coverage badge  artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Needs to be refactored, the complete folder
is too big for gh-pages.