### PR TITLE
Rename DiagDispatcher2 to DiagDispatcher

### DIFF
--- a/executables/referenceApp/application/include/systems/UdsSystem.h
+++ b/executables/referenceApp/application/include/systems/UdsSystem.h
@@ -51,7 +51,7 @@ public:
     void run() override;
     void shutdown() override;
 
-    DiagDispatcher2& getUdsDispatcher();
+    DiagDispatcher& getUdsDispatcher();
 
     IAsyncDiagHelper& getAsyncDiagHelper();
 
@@ -82,7 +82,7 @@ private:
     DiagnosticSessionControl _diagnosticSessionControl;
     CommunicationControl _communicationControl;
     DiagnosisConfiguration<5, 16> _udsConfiguration;
-    DiagDispatcher2 _udsDispatcher;
+    DiagDispatcher _udsDispatcher;
     uds::declare::AsyncDiagHelper<5> _asyncDiagHelper;
 
     ReadDataByIdentifier _readDataByIdentifier;

--- a/executables/referenceApp/application/src/systems/UdsSystem.cpp
+++ b/executables/referenceApp/application/src/systems/UdsSystem.cpp
@@ -88,7 +88,7 @@ void UdsSystem::shutdownComplete(transport::AbstractTransportLayer&)
     transitionDone();
 }
 
-DiagDispatcher2& UdsSystem::getUdsDispatcher() { return _udsDispatcher; }
+DiagDispatcher& UdsSystem::getUdsDispatcher() { return _udsDispatcher; }
 
 IAsyncDiagHelper& UdsSystem::getAsyncDiagHelper() { return _asyncDiagHelper; }
 

--- a/libs/bsw/uds/include/uds/DiagDispatcher.h
+++ b/libs/bsw/uds/include/uds/DiagDispatcher.h
@@ -40,7 +40,7 @@ class IDiagSessionManager;
  *
  * \see     transport::AbstractTransportLayer
  */
-class DiagDispatcher2
+class DiagDispatcher
 : public IDiagDispatcher
 , public transport::AbstractTransportLayer
 , public transport::ITransportMessageProcessedListener
@@ -52,10 +52,10 @@ public:
      * \param   configuration   AbstractDiagnosisConfiguration holding
      * the configuration for this DiagDispatcher
      * \param   sessionManager  IDiagSessionManager
-     * \param   context  Context used to handle DiagDispatcher2's
+     * \param   context  Context used to handle DiagDispatcher's
      * timeouts
      */
-    DiagDispatcher2(
+    DiagDispatcher(
         AbstractDiagnosisConfiguration& configuration,
         IDiagSessionManager& sessionManager,
         DiagJobRoot& jobRoot,

--- a/libs/bsw/uds/include/uds/DiagnosisConfiguration.h
+++ b/libs/bsw/uds/include/uds/DiagnosisConfiguration.h
@@ -31,7 +31,7 @@ public:
     /**
      * Constructor
      * @param   diagAddress Diagnosis address of this configuration. Used e.g.
-     * by DiagDispatcher2 to filter incoming requests.
+     * by DiagDispatcher to filter incoming requests.
      * @param   broadcastAddress    In addition to the specific diagnosis address
      * a diagnosis layer may also receive requests that are broadcasted within
      * the system.

--- a/libs/bsw/uds/include/uds/connection/DiagConnectionManager.h
+++ b/libs/bsw/uds/include/uds/connection/DiagConnectionManager.h
@@ -19,7 +19,7 @@ class ITransportMessageProvider;
 namespace uds
 {
 class AbstractDiagnosisConfiguration;
-class DiagDispatcher2;
+class DiagDispatcher;
 
 class DiagConnectionManager : public etl::uncopyable
 {
@@ -34,7 +34,7 @@ public:
         transport::AbstractTransportLayer& outgoingSender,
         transport::ITransportMessageProvider& outgoingProvider,
         ::async::ContextType context,
-        DiagDispatcher2& diagDispatcher);
+        DiagDispatcher& diagDispatcher);
 
     IncomingDiagConnection* requestIncomingConnection(transport::TransportMessage& requestMessage);
 
@@ -53,7 +53,7 @@ public:
     void shutdown(::etl::delegate<void()> delegate);
 
 private:
-    friend class DiagDispatcher2;
+    friend class DiagDispatcher;
 
     void checkShutdownProgress();
 
@@ -62,7 +62,7 @@ private:
     transport::AbstractTransportLayer& fOutgoingTransportMessageSender;
     transport::ITransportMessageProvider& fOutgoingTransportMessageProvider;
     ::async::ContextType fContext;
-    DiagDispatcher2& fDiagDispatcher;
+    DiagDispatcher& fDiagDispatcher;
     bool fShutdownRequested;
 };
 

--- a/libs/bsw/uds/include/uds/resume/ResumableResetDriver.h
+++ b/libs/bsw/uds/include/uds/resume/ResumableResetDriver.h
@@ -12,7 +12,7 @@
 
 namespace uds
 {
-class DiagDispatcher2;
+class DiagDispatcher;
 class IResumableResetDriverPersistence;
 
 // Note: you have to call lifecycleComplete() when lifecycle enters RUN state

--- a/libs/bsw/uds/include/uds/services/ecureset/HardReset.h
+++ b/libs/bsw/uds/include/uds/services/ecureset/HardReset.h
@@ -8,12 +8,12 @@
 
 namespace uds
 {
-class DiagDispatcher2;
+class DiagDispatcher;
 
 class HardReset : public Subfunction
 {
 public:
-    HardReset(IUdsLifecycleConnector& udsLifecycleConnector, DiagDispatcher2& diagDispatcher);
+    HardReset(IUdsLifecycleConnector& udsLifecycleConnector, DiagDispatcher& diagDispatcher);
 
     void responseSent(IncomingDiagConnection& connection, ResponseSendResult result) override;
 
@@ -26,7 +26,7 @@ private:
         uint16_t requestLength) override;
 
     IUdsLifecycleConnector& fUdsLifecycleConnector;
-    DiagDispatcher2& fDiagDispatcher;
+    DiagDispatcher& fDiagDispatcher;
 
     static uint8_t const sfImplementedRequest[2];
 };

--- a/libs/bsw/uds/include/uds/services/ecureset/SoftReset.h
+++ b/libs/bsw/uds/include/uds/services/ecureset/SoftReset.h
@@ -8,12 +8,12 @@
 
 namespace uds
 {
-class DiagDispatcher2;
+class DiagDispatcher;
 
 class SoftReset : public Subfunction
 {
 public:
-    SoftReset(IUdsLifecycleConnector& udsLifecycleConnector, DiagDispatcher2& diagDispatcher);
+    SoftReset(IUdsLifecycleConnector& udsLifecycleConnector, DiagDispatcher& diagDispatcher);
 
     void responseSent(IncomingDiagConnection& connection, ResponseSendResult result) override;
 
@@ -27,7 +27,7 @@ private:
         uint16_t requestLength) override;
 
     IUdsLifecycleConnector& fUdsLifecycleConnector;
-    DiagDispatcher2& fDiagDispatcher;
+    DiagDispatcher& fDiagDispatcher;
 };
 
 } // namespace uds

--- a/libs/bsw/uds/include/uds/services/sessioncontrol/DiagnosticSessionControl.h
+++ b/libs/bsw/uds/include/uds/services/sessioncontrol/DiagnosticSessionControl.h
@@ -17,7 +17,7 @@ namespace uds
 {
 class IOperatingModeManager;
 class ISessionPersistence;
-class DiagDispatcher2;
+class DiagDispatcher;
 
 using InitCompleteCallbackType = ::etl::delegate<void()>;
 
@@ -46,11 +46,11 @@ public:
     void responseSent(IncomingDiagConnection& connection, ResponseSendResult result) override;
 
     /**
-     * If a DiagDispatcher2 is set, it will be disabled when a session change
+     * If a DiagDispatcher is set, it will be disabled when a session change
      * that requires a reset is performed.
-     * \param pDiagDispatcher   DiagDispatcher2 to disable
+     * \param pDiagDispatcher   DiagDispatcher to disable
      */
-    void setDiagDispatcher(DiagDispatcher2* const pDiagDispatcher)
+    void setDiagDispatcher(DiagDispatcher* const pDiagDispatcher)
     {
         fpDiagDispatcher = pDiagDispatcher;
     }
@@ -148,7 +148,7 @@ protected:
     ::async::ContextType fContext;
     IUdsLifecycleConnector& fUdsLifecycleConnector;
     ISessionPersistence& fPersistence;
-    DiagDispatcher2* fpDiagDispatcher;
+    DiagDispatcher* fpDiagDispatcher;
 
     DiagSession* fpCurrentSession;
     AbstractDiagJob const* fpRequestedJob;

--- a/libs/bsw/uds/src/uds/connection/DiagConnectionManager.cpp
+++ b/libs/bsw/uds/src/uds/connection/DiagConnectionManager.cpp
@@ -31,7 +31,7 @@ DiagConnectionManager::DiagConnectionManager(
     AbstractTransportLayer& outgoingSender,
     ITransportMessageProvider& outgoingProvider,
     ::async::ContextType context,
-    DiagDispatcher2& diagDispatcher)
+    DiagDispatcher& diagDispatcher)
 : fConfiguration(configuration)
 , fOutgoingTransportMessageSender(outgoingSender)
 , fOutgoingTransportMessageProvider(outgoingProvider)

--- a/libs/bsw/uds/src/uds/services/ecureset/HardReset.cpp
+++ b/libs/bsw/uds/src/uds/services/ecureset/HardReset.cpp
@@ -11,7 +11,7 @@ namespace uds
 {
 uint8_t const HardReset::sfImplementedRequest[] = {ServiceId::ECU_RESET, 0x01U};
 
-HardReset::HardReset(IUdsLifecycleConnector& udsLifecycleConnector, DiagDispatcher2& diagDispatcher)
+HardReset::HardReset(IUdsLifecycleConnector& udsLifecycleConnector, DiagDispatcher& diagDispatcher)
 : Subfunction(
     &sfImplementedRequest[0],
     AbstractDiagJob::EMPTY_REQUEST,

--- a/libs/bsw/uds/src/uds/services/ecureset/SoftReset.cpp
+++ b/libs/bsw/uds/src/uds/services/ecureset/SoftReset.cpp
@@ -14,7 +14,7 @@ namespace uds
 {
 uint8_t const SoftReset::sfImplementedRequest[2] = {ServiceId::ECU_RESET, 0x03U};
 
-SoftReset::SoftReset(IUdsLifecycleConnector& udsLifecycleConnector, DiagDispatcher2& diagDispatcher)
+SoftReset::SoftReset(IUdsLifecycleConnector& udsLifecycleConnector, DiagDispatcher& diagDispatcher)
 : Subfunction(
     &sfImplementedRequest[0],
     AbstractDiagJob::EMPTY_REQUEST,

--- a/libs/bsw/uds/test/gtest/src/uds/IntegrationTest.cpp
+++ b/libs/bsw/uds/test/gtest/src/uds/IntegrationTest.cpp
@@ -192,8 +192,8 @@ protected:
     StrictMock<transport::TransportMessageProcessedListenerMock> _messageProcessedListener;
     StrictMock<uds::IncomingDiagConnectionMock> _incomingDiagConnection;
     StrictMock<UdsLifecycleConnectorMock> _lifecycle;
-    uds::DiagDispatcher2 _udsDispatcher;
-    uds::DiagDispatcher2 _udsDispatcher2;
+    uds::DiagDispatcher _udsDispatcher;
+    uds::DiagDispatcher _udsDispatcher2;
     uds::ReadDataByIdentifier _rdbi;
     MyReadDataByIdentifier _myRdbi;
     uds::HardReset _hardReset;

--- a/libs/bsw/uds/test/gtest/src/uds/connection/ManagedIncomingDiagConnectionTest.cpp
+++ b/libs/bsw/uds/test/gtest/src/uds/connection/ManagedIncomingDiagConnectionTest.cpp
@@ -47,7 +47,7 @@ struct ManagedIncomingDiagConnectionTest : Test
     TransportMessageProvidingListenerMock* fpTpRouterMock;
     AbstractTransportLayerMock* fpTpLayerMock;
     DiagConnectionManager* fpDiagConnectionManager;
-    DiagDispatcher2* fpDiagDispatcher;
+    DiagDispatcher* fpDiagDispatcher;
     DiagSessionManagerMock* fpSessionProvider;
     DiagJobRoot* fpDiagJobRoot;
 
@@ -73,7 +73,7 @@ struct ManagedIncomingDiagConnectionTest : Test
                 true,
                 fContext);
 
-        fpDiagDispatcher = new DiagDispatcher2(
+        fpDiagDispatcher = new DiagDispatcher(
             *fpDiagnosisConfiguration, *fpSessionProvider, *fpDiagJobRoot, fContext);
 
         fpDiagConnectionManager = new DiagConnectionManager(

--- a/libs/bsw/uds/test/gtest/src/uds/services/readdata/MultipleReadDataByIdentifierTest.cpp
+++ b/libs/bsw/uds/test/gtest/src/uds/services/readdata/MultipleReadDataByIdentifierTest.cpp
@@ -181,7 +181,7 @@ protected:
     StrictMock<IncomingDiagConnectionMock> fIncomingDiagConnection;
     StrictMock<DiagSessionManagerMock> fSessionManager;
     DiagnosisConfiguration<NUM_INCOMING_CONNECTIONS, 1> fUdsConfiguration;
-    DiagDispatcher2 fUdsDispatcher;
+    DiagDispatcher fUdsDispatcher;
     DiagJobRoot fDiagJobRoot;
 
     static uint8_t const SOURCE_ID = 0xF1U;

--- a/libs/bsw/uds/test/gtest/src/uds/services/sessioncontrol/DiagnosticSessionControlTest.cpp
+++ b/libs/bsw/uds/test/gtest/src/uds/services/sessioncontrol/DiagnosticSessionControlTest.cpp
@@ -390,7 +390,7 @@ TEST_F(
         true,
         static_cast<::async::ContextType>(1U));
 
-    DiagDispatcher2 dispatcher(
+    DiagDispatcher dispatcher(
         udsConfiguration,
         static_cast<IDiagSessionManager&>(diagSessionManager),
         fDiagJobRoot,


### PR DESCRIPTION
There is only one. So no reason to have a "2" at the end.

Change-Id: I905a7e55336b9f1efceaf1e0d2a0b8290c8ca14c