### PR TITLE
Remove add/remove diag job from dispatcher

### DIFF
--- a/executables/referenceApp/application/src/systems/UdsSystem.cpp
+++ b/executables/referenceApp/application/src/systems/UdsSystem.cpp
@@ -106,45 +106,45 @@ ReadDataByIdentifier& UdsSystem::getReadDataByIdentifier() { return _readDataByI
 void UdsSystem::addDiagJobs()
 {
     // 22 - ReadDataByIdentifier
-    (void)_udsDispatcher.addAbstractDiagJob(_readDataByIdentifier);
-    (void)_udsDispatcher.addAbstractDiagJob(_read22Cf01);
-    (void)_udsDispatcher.addAbstractDiagJob(_read22Cf02);
+    (void)_jobRoot.addAbstractDiagJob(_readDataByIdentifier);
+    (void)_jobRoot.addAbstractDiagJob(_read22Cf01);
+    (void)_jobRoot.addAbstractDiagJob(_read22Cf02);
 
     // 2E - WriteDataByIdentifier
-    (void)_udsDispatcher.addAbstractDiagJob(_writeDataByIdentifier);
+    (void)_jobRoot.addAbstractDiagJob(_writeDataByIdentifier);
 
     // 31 - Routine Control
-    (void)_udsDispatcher.addAbstractDiagJob(_routineControl);
-    (void)_udsDispatcher.addAbstractDiagJob(_startRoutine);
-    (void)_udsDispatcher.addAbstractDiagJob(_stopRoutine);
-    (void)_udsDispatcher.addAbstractDiagJob(_requestRoutineResults);
+    (void)_jobRoot.addAbstractDiagJob(_routineControl);
+    (void)_jobRoot.addAbstractDiagJob(_startRoutine);
+    (void)_jobRoot.addAbstractDiagJob(_stopRoutine);
+    (void)_jobRoot.addAbstractDiagJob(_requestRoutineResults);
 
     // Services
-    (void)_udsDispatcher.addAbstractDiagJob(_testerPresent);
-    (void)_udsDispatcher.addAbstractDiagJob(_diagnosticSessionControl);
-    (void)_udsDispatcher.addAbstractDiagJob(_communicationControl);
+    (void)_jobRoot.addAbstractDiagJob(_testerPresent);
+    (void)_jobRoot.addAbstractDiagJob(_diagnosticSessionControl);
+    (void)_jobRoot.addAbstractDiagJob(_communicationControl);
 }
 
 void UdsSystem::removeDiagJobs()
 {
     // 22 - ReadDataByIdentifier
-    (void)_udsDispatcher.removeAbstractDiagJob(_readDataByIdentifier);
-    (void)_udsDispatcher.removeAbstractDiagJob(_read22Cf01);
-    (void)_udsDispatcher.removeAbstractDiagJob(_read22Cf02);
+    (void)_jobRoot.removeAbstractDiagJob(_readDataByIdentifier);
+    (void)_jobRoot.removeAbstractDiagJob(_read22Cf01);
+    (void)_jobRoot.removeAbstractDiagJob(_read22Cf02);
 
     // 2E - WriteDataByIdentifier
-    (void)_udsDispatcher.removeAbstractDiagJob(_writeDataByIdentifier);
+    (void)_jobRoot.removeAbstractDiagJob(_writeDataByIdentifier);
 
     // 31 - Routine Control
-    (void)_udsDispatcher.removeAbstractDiagJob(_routineControl);
-    (void)_udsDispatcher.removeAbstractDiagJob(_startRoutine);
-    (void)_udsDispatcher.removeAbstractDiagJob(_stopRoutine);
-    (void)_udsDispatcher.removeAbstractDiagJob(_requestRoutineResults);
+    (void)_jobRoot.removeAbstractDiagJob(_routineControl);
+    (void)_jobRoot.removeAbstractDiagJob(_startRoutine);
+    (void)_jobRoot.removeAbstractDiagJob(_stopRoutine);
+    (void)_jobRoot.removeAbstractDiagJob(_requestRoutineResults);
 
     // Services
-    (void)_udsDispatcher.removeAbstractDiagJob(_testerPresent);
-    (void)_udsDispatcher.removeAbstractDiagJob(_diagnosticSessionControl);
-    (void)_udsDispatcher.removeAbstractDiagJob(_communicationControl);
+    (void)_jobRoot.removeAbstractDiagJob(_testerPresent);
+    (void)_jobRoot.removeAbstractDiagJob(_diagnosticSessionControl);
+    (void)_jobRoot.removeAbstractDiagJob(_communicationControl);
 }
 
 void UdsSystem::execute() {}

--- a/libs/bsw/uds/include/uds/IDiagDispatcher.h
+++ b/libs/bsw/uds/include/uds/IDiagDispatcher.h
@@ -31,13 +31,6 @@ public:
     : fDiagJobRoot(jobRoot), fSessionManager(sessionManager), fEnabled(true)
     {}
 
-    AbstractDiagJob::ErrorCode addAbstractDiagJob(AbstractDiagJob& job)
-    {
-        return fDiagJobRoot.addAbstractDiagJob(job);
-    }
-
-    void removeAbstractDiagJob(AbstractDiagJob& job) { fDiagJobRoot.removeAbstractDiagJob(job); }
-
     virtual uint16_t getSourceId() const = 0;
 
 #ifdef IS_VARIANT_HANDLING_NEEDED

--- a/libs/bsw/uds/test/src/uds/IntegrationTest.cpp
+++ b/libs/bsw/uds/test/src/uds/IntegrationTest.cpp
@@ -161,22 +161,22 @@ protected:
         uds::AbstractDiagJob::setDefaultDiagSessionManager(_sessionManager);
         _udsDispatcher.fProvidingListenerHelper.fpMessageListener = &_messageListener;
         _udsDispatcher.fProvidingListenerHelper.fpMessageProvider = &_messageProvider;
-        _udsDispatcher.addAbstractDiagJob(_rdbi);
-        _udsDispatcher.addAbstractDiagJob(_myRdbi);
-        _udsDispatcher.addAbstractDiagJob(_hardReset);
-        _udsDispatcher.addAbstractDiagJob(_softReset);
-        _udsDispatcher.addAbstractDiagJob(_powerDown);
-        _udsDispatcher.addAbstractDiagJob(_enableRapidPowerShutdown);
+        _jobRoot.addAbstractDiagJob(_rdbi);
+        _jobRoot.addAbstractDiagJob(_myRdbi);
+        _jobRoot.addAbstractDiagJob(_hardReset);
+        _jobRoot.addAbstractDiagJob(_softReset);
+        _jobRoot.addAbstractDiagJob(_powerDown);
+        _jobRoot.addAbstractDiagJob(_enableRapidPowerShutdown);
     }
 
     ~UdsIntegration() override
     {
-        _udsDispatcher.removeAbstractDiagJob(_enableRapidPowerShutdown);
-        _udsDispatcher.removeAbstractDiagJob(_powerDown);
-        _udsDispatcher.removeAbstractDiagJob(_softReset);
-        _udsDispatcher.removeAbstractDiagJob(_hardReset);
-        _udsDispatcher.removeAbstractDiagJob(_myRdbi);
-        _udsDispatcher.removeAbstractDiagJob(_rdbi);
+        _jobRoot.removeAbstractDiagJob(_enableRapidPowerShutdown);
+        _jobRoot.removeAbstractDiagJob(_powerDown);
+        _jobRoot.removeAbstractDiagJob(_softReset);
+        _jobRoot.removeAbstractDiagJob(_hardReset);
+        _jobRoot.removeAbstractDiagJob(_myRdbi);
+        _jobRoot.removeAbstractDiagJob(_rdbi);
     }
 
     async::TestContext fContext;

--- a/libs/bsw/uds/test/src/uds/services/readdata/MultipleReadDataByIdentifierTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/readdata/MultipleReadDataByIdentifierTest.cpp
@@ -155,12 +155,12 @@ public:
         fIncomingDiagConnection.fServiceId = ::ServiceId::READ_DATA_BY_IDENTIFIER;
 
         fMyMultipleReadDataByIdentifier.addAbstractDiagJob(fDiagJob);
-        fUdsDispatcher.addAbstractDiagJob(fDiagJob);
+        fDiagRoot.addAbstractDiagJob(fDiagJob);
     }
 
     virtual void TearDown()
     {
-        fUdsDispatcher.removeAbstractDiagJob(fDiagJob);
+        fDiagRoot.removeAbstractDiagJob(fDiagJob);
         fMyMultipleReadDataByIdentifier.removeAbstractDiagJob(fDiagJob);
     }
 


### PR DESCRIPTION
This was just forwarding to DiagJobRoot but all paces that call it have the job root available directly.

Change-Id: I00c7df0c029260b8aa6abd0c84ed222c4d47411b