### PR TITLE
Use rim status -w to print status

### DIFF
--- a/.github/workflows/rim.yml
+++ b/.github/workflows/rim.yml
@@ -15,4 +15,4 @@ jobs:
 
      - name: Run the third party libraries check via RIM inside the docker container
        run: |
-          docker run --rm -v "$PWD:/home/jenkins" -w /home/jenkins --user $(id -u):4996 dev rim status -d --verify-clean
+          docker run --rm -v "$PWD:/home/jenkins" -w /home/jenkins --user $(id -u):4996 dev rim status -w -d --verify-clean


### PR DESCRIPTION
The output of rim was not provided, even though deviations were detected by rim, e.g.: https://github.com/eclipse-openbsw/openbsw/actions/runs/19039158394/job/54371348191?pr=227

This is probably just a workaround for a bug in rim, since -w operates on the working copy instead of the git HEAD, but this fixes the issue by by printing the responsible 3rdparty location instead of nothing.

```
$ rim status -w -d --verify-clean
[DIRTY] ------- uncommitted changes
        - libs/3rdparty/etl
$
```

Further, I can reproduce the issue (i.e. with null output) locally when running `rim status -d --verify-clean` shortly after a `git push`. The issue is gone after adding further commits locally. So it seems to be dependent on some git status.