### PR TITLE
Move DiagJobRoot reference from interface to implementation

### DIFF
--- a/libs/bsw/uds/include/uds/DiagDispatcher.h
+++ b/libs/bsw/uds/include/uds/DiagDispatcher.h
@@ -180,6 +180,7 @@ private:
     transport::TransportMessage fBusyMessage;
     uint8_t fBusyMessageBuffer[BUSY_MESSAGE_LENGTH + UdsVmsConstants::BUSY_MESSAGE_EXTRA_BYTES];
     ::async::Function fAsyncProcessQueue;
+    DiagJobRoot& fDiagJobRoot;
 };
 
 } // namespace uds

--- a/libs/bsw/uds/include/uds/IDiagDispatcher.h
+++ b/libs/bsw/uds/include/uds/IDiagDispatcher.h
@@ -27,8 +27,8 @@ public:
      * Constructor
      * \param   sessionManager  IDiagSessionManager
      */
-    explicit IDiagDispatcher(IDiagSessionManager& sessionManager, DiagJobRoot& jobRoot)
-    : fDiagJobRoot(jobRoot), fSessionManager(sessionManager), fEnabled(true)
+    explicit IDiagDispatcher(IDiagSessionManager& sessionManager)
+    : fSessionManager(sessionManager), fEnabled(true)
     {}
 
     virtual uint16_t getSourceId() const = 0;
@@ -41,9 +41,6 @@ public:
         ::transport::TransportMessage& transportMessage,
         ::transport::ITransportMessageProcessedListener* pNotificationListener)
         = 0;
-
-protected:
-    DiagJobRoot& fDiagJobRoot;
 
 public:
     IDiagSessionManager& fSessionManager;

--- a/libs/bsw/uds/mock/gmock/include/uds/resume/DiagDispatcherMock.h
+++ b/libs/bsw/uds/mock/gmock/include/uds/resume/DiagDispatcherMock.h
@@ -13,9 +13,7 @@ namespace uds
 class DiagDispatcherMock : public IDiagDispatcher
 {
 public:
-    DiagDispatcherMock(IDiagSessionManager& sessionManager, DiagJobRoot& jobRoot)
-    : IDiagDispatcher(sessionManager, jobRoot)
-    {}
+    DiagDispatcherMock(IDiagSessionManager& sessionManager) : IDiagDispatcher(sessionManager) {}
 
     MOCK_METHOD(uint16_t, getSourceId, (), (const));
 

--- a/libs/bsw/uds/src/uds/DiagDispatcher.cpp
+++ b/libs/bsw/uds/src/uds/DiagDispatcher.cpp
@@ -33,7 +33,7 @@ DiagDispatcher::DiagDispatcher(
     AbstractDiagnosisConfiguration& configuration,
     IDiagSessionManager& sessionManager,
     DiagJobRoot& jobRoot)
-: IDiagDispatcher(sessionManager, jobRoot)
+: IDiagDispatcher(sessionManager)
 , AbstractTransportLayer(configuration.DiagBusId)
 , fConfiguration(configuration)
 , fConnectionShutdownDelegate()
@@ -44,6 +44,7 @@ DiagDispatcher::DiagDispatcher(
 , fBusyMessageBuffer()
 , fAsyncProcessQueue(
       ::async::Function::CallType::create<DiagDispatcher, &DiagDispatcher::processQueue>(*this))
+, fDiagJobRoot(jobRoot)
 {
     fBusyMessage.init(
         &fBusyMessageBuffer[0], BUSY_MESSAGE_LENGTH + UdsVmsConstants::BUSY_MESSAGE_EXTRA_BYTES);

--- a/libs/bsw/uds/test/src/uds/resume/ResumableResetDriverTest.cpp
+++ b/libs/bsw/uds/test/src/uds/resume/ResumableResetDriverTest.cpp
@@ -21,7 +21,7 @@ using namespace ::testing;
 class TestDiagDispatcher : public DiagDispatcherMock
 {
 public:
-    TestDiagDispatcher() : DiagDispatcherMock(fSessionManagerMock, fJobRoot) {}
+    TestDiagDispatcher() : DiagDispatcherMock(fSessionManagerMock) {}
 
 private:
     DiagSessionManagerMock fSessionManagerMock;


### PR DESCRIPTION
This is not accessed through the base class anymore so it can be moved down.

Change-Id: Ibb9064d5dc61709e482421b595b2c2725386d097