### PR TITLE
Make sure to destroy the constructed pool objects

### DIFF
--- a/libs/bsw/docan/include/docan/receiver/DoCanReceiver.h
+++ b/libs/bsw/docan/include/docan/receiver/DoCanReceiver.h
@@ -783,7 +783,7 @@ void DoCanReceiver<DataLinkLayer>::releaseRemoveLock()
             {
                 MessageReceiverType& messageReceiver = *it;
                 it                                   = _messageReceivers.erase(it);
-                _messageReceiverPool.release(reinterpret_cast<void const*>(&messageReceiver));
+                _messageReceiverPool.destroy(&messageReceiver);
                 --_releasedReceiverCount;
             }
             else

--- a/libs/bsw/docan/include/docan/transmitter/DoCanTransmitter.h
+++ b/libs/bsw/docan/include/docan/transmitter/DoCanTransmitter.h
@@ -783,7 +783,7 @@ void DoCanTransmitter<DataLinkLayer>::releaseRemoveLock(bool const remove)
                 messageTransmitter.getMessage(), processingResult);
         }
         ::interrupts::SuspendResumeAllInterruptsScopedLock const lock;
-        _messageTransmitterPool.release(reinterpret_cast<void const*>(&messageTransmitter));
+        _messageTransmitterPool.destroy(&messageTransmitter);
     }
     if (switchContext)
     {

--- a/libs/bsw/uds/include/uds/DiagnosisConfiguration.h
+++ b/libs/bsw/uds/include/uds/DiagnosisConfiguration.h
@@ -113,7 +113,7 @@ public:
      */
     void releaseIncomingDiagConnection(IncomingDiagConnection const& connection)
     {
-        IncomingDiagConnectionPool.release(&connection);
+        IncomingDiagConnectionPool.destroy(&connection);
     }
 
     template<class Pred>
@@ -136,7 +136,14 @@ public:
      * effects because some user code might still hold a reference to an elements which
      * gets destroyed when this function is called.
      */
-    void clearIncomingDiagConnections() { IncomingDiagConnectionPool.release_all(); }
+    void clearIncomingDiagConnections()
+    {
+        while (!IncomingDiagConnectionPool.empty())
+        {
+            IncomingDiagConnectionPool.destroy(
+                static_cast<IncomingDiagConnection*>(*IncomingDiagConnectionPool.begin()));
+        }
+    }
 };
 
 /**

--- a/libs/bsw/uds/src/uds/DiagDispatcher.cpp
+++ b/libs/bsw/uds/src/uds/DiagDispatcher.cpp
@@ -393,7 +393,7 @@ void DiagDispatcher::checkConnectionShutdownProgress()
 
     ::etl::ipool const& incomingDiagConnections = fConfiguration.incomingDiagConnectionPool();
 
-    if (!incomingDiagConnections.full())
+    if (!incomingDiagConnections.empty())
     {
         Logger::error(
             UDS,

--- a/libs/bsw/uds/src/uds/async/AsyncDiagHelper.cpp
+++ b/libs/bsw/uds/src/uds/async/AsyncDiagHelper.cpp
@@ -44,7 +44,7 @@ void AsyncDiagHelper::processAndReleaseRequest(AbstractDiagJob& job, StoredReque
     IncomingDiagConnection& connection = request.getConnection();
     DiagReturnCode::Type const responseCode
         = job.process(connection, request.getRequest(), request.getRequestLength());
-    fStoredRequestPool.release(&request);
+    fStoredRequestPool.destroy(&request);
     if (responseCode != DiagReturnCode::OK)
     {
         (void)connection.sendNegativeResponse(static_cast<uint8_t>(responseCode), *this);


### PR DESCRIPTION
The corresponding classes don't provide destructors so it doesn't make a real difference if the destructors are called or not, but it might make a difference in the future.

Also fix an emptiness check in DiagDispatcher that became wrong after switching to ETL.