### PR TITLE
Rename ID to Address

### DIFF
--- a/libs/bsw/docan/include/docan/receiver/DoCanReceiver.h
+++ b/libs/bsw/docan/include/docan/receiver/DoCanReceiver.h
@@ -559,7 +559,7 @@ ReceiveResult DoCanReceiver<DataLinkLayer>::allocateTransportMessage(
                 messageReceiver.getReceptionAddress(), stringBuffer);
             switch (result)
             {
-                case ::transport::ITransportMessageProvider::ErrorCode::TPMSG_INVALID_SRC_ID:
+                case ::transport::ITransportMessageProvider::ErrorCode::TPMSG_INVALID_SRC_ADDRESS:
                 {
                     ::util::logger::Logger::warn(
                         _loggerComponent,
@@ -570,7 +570,7 @@ ReceiveResult DoCanReceiver<DataLinkLayer>::allocateTransportMessage(
                         formattedAddress);
                     break;
                 }
-                case ::transport::ITransportMessageProvider::ErrorCode::TPMSG_INVALID_TGT_ID:
+                case ::transport::ITransportMessageProvider::ErrorCode::TPMSG_INVALID_TGT_ADDRESS:
                 {
                     ::util::logger::Logger::warn(
                         _loggerComponent,
@@ -599,8 +599,8 @@ ReceiveResult DoCanReceiver<DataLinkLayer>::allocateTransportMessage(
         if (message != nullptr)
         {
             message->resetValidBytes();
-            message->setSourceId(transportAddressPair.getSourceId());
-            message->setTargetId(transportAddressPair.getTargetId());
+            message->setSourceAddress(transportAddressPair.getSourceId());
+            message->setTargetAddress(transportAddressPair.getTargetId());
             message->setPayloadLength(messageReceiver.getMessageSize());
         }
         // Don't do anything in this scope if message == nullptr

--- a/libs/bsw/docan/test/benchmark/benchmark.cpp
+++ b/libs/bsw/docan/test/benchmark/benchmark.cpp
@@ -176,8 +176,8 @@ struct TransmissionBenchmark : public ::benchmark::Fixture
         {
             data[idx] = idx % 256;
         }
-        transportMessage.setSourceId(0x10U);
-        transportMessage.setTargetId(0x11U);
+        transportMessage.setSourceAddress(0x10U);
+        transportMessage.setTargetAddress(0x11U);
         transportMessage.append(data, sizeof(data));
         transportMessage.setPayloadLength(sizeof(data));
     }
@@ -408,8 +408,8 @@ void TransmissionFullSegmentedMessage(benchmark::State& state)
     {
         data[idx] = idx % 256;
     }
-    transportMessage.setSourceId(0x10U);
-    transportMessage.setTargetId(0x11U);
+    transportMessage.setSourceAddress(0x10U);
+    transportMessage.setTargetAddress(0x11U);
     transportMessage.append(data, sizeof(data));
     transportMessage.setPayloadLength(sizeof(data));
 
@@ -535,8 +535,8 @@ void TransmissionMultipleTransportLayersFullSegmentedMessages(benchmark::State& 
         {
             data[messageIndex][byteIndex] = (messageIndex + byteIndex) % 0xFF;
         }
-        transportMessage[messageIndex].setSourceId(messageIndex + 3);
-        transportMessage[messageIndex].setTargetId(messageIndex + 2);
+        transportMessage[messageIndex].setSourceAddress(messageIndex + 3);
+        transportMessage[messageIndex].setTargetAddress(messageIndex + 2);
         transportMessage[messageIndex].append(data[messageIndex], sizeof(data[messageIndex]));
         transportMessage[messageIndex].setPayloadLength(sizeof(data[messageIndex]));
 
@@ -666,8 +666,8 @@ void TransmissionMultipleFullSegmentedMessages(benchmark::State& state)
         {
             data[messageIndex][byteIndex] = (messageIndex + byteIndex) % 0xFF;
         }
-        transportMessage[messageIndex].setSourceId(messageIndex + 3);
-        transportMessage[messageIndex].setTargetId(messageIndex + 2);
+        transportMessage[messageIndex].setSourceAddress(messageIndex + 3);
+        transportMessage[messageIndex].setTargetAddress(messageIndex + 2);
         transportMessage[messageIndex].append(data[messageIndex], sizeof(data[messageIndex]));
         transportMessage[messageIndex].setPayloadLength(sizeof(data[messageIndex]));
 

--- a/libs/bsw/docan/test/src/docan/receiver/DoCanReceiverTest.cpp
+++ b/libs/bsw/docan/test/src/docan/receiver/DoCanReceiverTest.cpp
@@ -1433,7 +1433,7 @@ TEST_F(DoCanReceiverTest, testReceiveFirstFrameOfUnknownSender)
     uint8_t data[] = {0x10, 0x08, 0xab, 0xcd};
     EXPECT_CALL(
         _messageProvidingListenerMock, getTransportMessage(_busId, 0x14, 0x23, sizeof(data), _, _))
-        .WillOnce(Return(ITransportMessageProvider::ErrorCode::TPMSG_INVALID_SRC_ID));
+        .WillOnce(Return(ITransportMessageProvider::ErrorCode::TPMSG_INVALID_SRC_ADDRESS));
     // receive the first frame
     expectLog(
         LEVEL_WARN, 0x1234, "DoCanReceiver(%s)::allocateTransportMessage(%s): Illegal source id.");
@@ -1472,7 +1472,7 @@ TEST_F(DoCanReceiverTest, testReceiveFirstFrameOfUnknownReceiver)
     uint8_t data[] = {0x10, 0x08, 0xab, 0xcd};
     EXPECT_CALL(
         _messageProvidingListenerMock, getTransportMessage(_busId, 0x14, 0x23, sizeof(data), _, _))
-        .WillOnce(Return(ITransportMessageProvider::ErrorCode::TPMSG_INVALID_TGT_ID));
+        .WillOnce(Return(ITransportMessageProvider::ErrorCode::TPMSG_INVALID_TGT_ADDRESS));
     // receive the first frame
     expectLog(
         LEVEL_WARN, 0x1234, "DoCanReceiver(%s)::allocateTransportMessage(%s): Illegal target id.");

--- a/libs/bsw/docan/test/src/docan/transmitter/DoCanTransmitterTest.cpp
+++ b/libs/bsw/docan/test/src/docan/transmitter/DoCanTransmitterTest.cpp
@@ -105,8 +105,8 @@ struct DoCanTransmitterTest : ::testing::Test
         message.init(buffer, N);
         message.setPayloadLength(N);
         message.increaseValidBytes(N);
-        message.setSourceId(tPair.getSourceId());
-        message.setTargetId(tPair.getTargetId());
+        message.setSourceAddress(tPair.getSourceId());
+        message.setTargetAddress(tPair.getTargetId());
         EXPECT_CALL(_addressConverterMock, getTransmissionParameters(tPair, _))
             .WillRepeatedly(DoAll(SetArgReferee<1>(aPair), Return(&_codec)));
     }
@@ -1582,8 +1582,8 @@ TEST_F(DoCanTransmitterTest, testSendEmptyMessage)
     auto const transportPair = DoCanTransportAddressPair(0x45, 0x54);
     message.init(data, sizeof(data));
     message.setPayloadLength(sizeof(data));
-    message.setSourceId(transportPair.getSourceId());
-    message.setTargetId(transportPair.getTargetId());
+    message.setSourceAddress(transportPair.getSourceId());
+    message.setTargetAddress(transportPair.getTargetId());
 
     EXPECT_CALL(_addressConverterMock, getTransmissionParameters(transportPair, _))
         .WillRepeatedly(DoAll(SetArgReferee<1>(addrPair), Return(&_codec)));
@@ -1626,8 +1626,8 @@ TEST_F(DoCanTransmitterTest, testSendTooBigMessage)
     message.init(data, sizeof(data));
     message.setPayloadLength(sizeof(data));
     message.increaseValidBytes(sizeof(data));
-    message.setSourceId(transportPair.getSourceId());
-    message.setTargetId(transportPair.getTargetId());
+    message.setSourceAddress(transportPair.getSourceId());
+    message.setTargetAddress(transportPair.getTargetId());
     EXPECT_CALL(smallAddressConverterMock, getTransmissionParameters(transportPair, _))
         .WillRepeatedly(DoAll(SetArgReferee<1>(addrPair), Return(&smallFrameCodec)));
 
@@ -1658,8 +1658,8 @@ TEST_F(DoCanTransmitterTest, testSendIncompleteMessage)
     auto const transportPair = DoCanTransportAddressPair(0x45, 0x54);
     message.init(data, sizeof(data));
     message.setPayloadLength(sizeof(data));
-    message.setSourceId(transportPair.getSourceId());
-    message.setTargetId(transportPair.getTargetId());
+    message.setSourceAddress(transportPair.getSourceId());
+    message.setTargetAddress(transportPair.getTargetId());
     EXPECT_CALL(_addressConverterMock, getTransmissionParameters(transportPair, _))
         .WillRepeatedly(DoAll(SetArgReferee<1>(addrPair), Return(&_codec)));
 

--- a/libs/bsw/docan/test/src/docan/transport/DoCanTransportLayerContainerTest.cpp
+++ b/libs/bsw/docan/test/src/docan/transport/DoCanTransportLayerContainerTest.cpp
@@ -112,8 +112,8 @@ TEST_F(DoCanTransportLayerContainerTest, testConstructedTransportLayers)
                0x77,
                0x66};
         BufferedTransportMessage<20> transportMessage;
-        transportMessage.setSourceId(0x46U);
-        transportMessage.setTargetId(0x89U);
+        transportMessage.setSourceAddress(0x46U);
+        transportMessage.setTargetAddress(0x89U);
         transportMessage.append(data, sizeof(data));
         transportMessage.setPayloadLength(sizeof(data));
         EXPECT_CALL(

--- a/libs/bsw/docan/test/src/docan/transport/DoCanTransportLayerTest.cpp
+++ b/libs/bsw/docan/test/src/docan/transport/DoCanTransportLayerTest.cpp
@@ -316,8 +316,8 @@ TEST_F(DoCanTransportLayerTest, testTransportMessageTransmissionLifecycle)
         BufferedTransportMessage<30> transportMessage;
         uint8_t const data[]
             = {0x12, 0x34, 0x56, 0x78, 0x19, 0x38, 0x9a, 0x5f, 0x14, 0x91, 0xa3, 0x57, 0x89, 0x99};
-        transportMessage.setSourceId(0x56U);
-        transportMessage.setTargetId(0x64U);
+        transportMessage.setSourceAddress(0x56U);
+        transportMessage.setTargetAddress(0x64U);
         transportMessage.append(data, sizeof(data));
         transportMessage.setPayloadLength(sizeof(data));
         EXPECT_CALL(
@@ -391,8 +391,8 @@ TEST_F(DoCanTransportLayerTest, testTransportMessageTransmissionLifecycle)
         // send to unknown address pair
         BufferedTransportMessage<10> transportMessage;
         uint8_t const data[] = {0x12, 0x34, 0x56, 0x78, 0x19};
-        transportMessage.setSourceId(0x56U);
-        transportMessage.setTargetId(0x64U);
+        transportMessage.setSourceAddress(0x56U);
+        transportMessage.setTargetAddress(0x64U);
         transportMessage.append(data, sizeof(data));
         transportMessage.setPayloadLength(sizeof(data));
         EXPECT_CALL(

--- a/libs/bsw/transport/doc/helpers/LogicalAddress.rst
+++ b/libs/bsw/transport/doc/helpers/LogicalAddress.rst
@@ -104,7 +104,7 @@ When we receive a message in router, we can convert between wide/cropped address
     if(targetBusId == ::busid::BusId::CAN())
     {
         uint16_t croppedTargetAddress = LogicalAddressConverterGateway::convertDoipAddressTo8Bit(targetAddress);
-        pTransportMessage->setTargetId(croppedTargetAddress);
+        pTransportMessage->setTargetAddress(croppedTargetAddress);
     }
 
 If the address passed is not found in any list, the unchanged argument will be returned.

--- a/libs/bsw/transport/include/transport/AbstractTransportLayer.h
+++ b/libs/bsw/transport/include/transport/AbstractTransportLayer.h
@@ -119,8 +119,8 @@ public:
          */
         ITransportMessageProvidingListener::ErrorCode getTransportMessage(
             uint8_t srcBusId,
-            uint16_t sourceId,
-            uint16_t targetId,
+            uint16_t sourceAddress,
+            uint16_t targetAddress,
             uint16_t size,
             ::etl::span<uint8_t const> const& peek,
             TransportMessage*& pTransportMessage) override;

--- a/libs/bsw/transport/include/transport/BufferedTransportMessage.h
+++ b/libs/bsw/transport/include/transport/BufferedTransportMessage.h
@@ -19,13 +19,13 @@ public:
     BufferedTransportMessage();
 
 private:
-    uint8_t fBuffer[PAYLOAD_SIZE];
+    uint8_t _buffer[PAYLOAD_SIZE];
 };
 
 template<uint32_t PAYLOAD_SIZE>
 inline BufferedTransportMessage<PAYLOAD_SIZE>::BufferedTransportMessage() : TransportMessage()
 {
-    init(&fBuffer[0], PAYLOAD_SIZE);
+    init(&_buffer[0], PAYLOAD_SIZE);
 }
 
 } // namespace transport

--- a/libs/bsw/transport/include/transport/ITransportMessageProvider.h
+++ b/libs/bsw/transport/include/transport/ITransportMessageProvider.h
@@ -29,9 +29,9 @@ public:
         /** no error */
         TPMSG_OK,
         /** source id is invalid */
-        TPMSG_INVALID_SRC_ID,
+        TPMSG_INVALID_SRC_ADDRESS,
         /** target id is invalid */
-        TPMSG_INVALID_TGT_ID,
+        TPMSG_INVALID_TGT_ADDRESS,
         /** no TransportMessage is available */
         TPMSG_NO_MSG_AVAILABLE,
         /** requested size is too large*/
@@ -41,18 +41,18 @@ public:
     };
 
     /**
-     * returns a TransportMessage for a given sourceBusId and targetId
+     * returns a TransportMessage for a given sourceBusId and targetAddress
      * \param srcBusId          id of bus message is received from
-     * \param sourceId          id of TransportMessage's source
-     * \param targetId          id of TransportMessage's target
+     * \param sourceAddress          id of TransportMessage's source
+     * \param targetAddress          id of TransportMessage's target
      * \param size              size of the requested TransportMessage
      * \param peek              slice to the payload of the underlying data
      * buffer \param pTransportMessage a pointer to TransportMessage (0L if no
      *          message was available) is written to this pointer.
      * \return
      *          - TPMSG_OK: pTransportMessage has been set
-     *          - TPMSG_INVALID_SRC_ID: sourceId is not allowed from srcBusId
-     *          - TPMSG_INVALID_TGT_ID: requested targetId is invalid
+     *          - TPMSG_INVALID_SRC_ADDRESS: sourceAddress is not allowed from srcBusId
+     *          - TPMSG_INVALID_TGT_ADDRESS: requested targetAddress is invalid
      *          - TPMSG_NO_MSG_AVAILABLE: all params are valid but all
      *          TransportMessages are currently locked
      *          - TPMSG_NOT_RESPONSIBLE: not the correct provider for this
@@ -64,8 +64,8 @@ public:
      */
     virtual ErrorCode getTransportMessage(
         uint8_t srcBusId,
-        uint16_t sourceId,
-        uint16_t targetId,
+        uint16_t sourceAddress,
+        uint16_t targetAddress,
         uint16_t size,
         ::etl::span<uint8_t const> const& peek,
         TransportMessage*& pTransportMessage)

--- a/libs/bsw/transport/include/transport/TransportMessage.h
+++ b/libs/bsw/transport/include/transport/TransportMessage.h
@@ -111,7 +111,7 @@ public:
     /**
      * \pre   fpBuffer != NULL
      */
-    void setSourceId(uint16_t sourceId);
+    void setSourceAddress(uint16_t sourceAddress);
 
     /**
      * Returns the target id of the TransportMessage.
@@ -125,7 +125,7 @@ public:
     /**
      * \pre   fpBuffer != NULL
      */
-    void setTargetId(uint16_t targetId);
+    void setTargetAddress(uint16_t targetId);
 
     /**
      * Returns the service id of the TransportMessage.
@@ -202,9 +202,9 @@ public:
      *          - TP_MSG_OK if data was correctly appended
      *          - TP_MSG_LENGTH_EXCEEDED if data was too long
      *
-     * The TransportMessage has internal counter fValidBytes which is
+     * The TransportMessage has internal counter _validBytes which is
      * initialized with 0. Appending data will copy the data to the index
-     * fValidBytes in the payload of the TransportMessage.
+     * _validBytes in the payload of the TransportMessage.
      */
     ErrorCode append(uint8_t const data[], uint16_t length);
 
@@ -215,19 +215,19 @@ public:
      *          - TP_MSG_OK if data was correctly appended
      *          - TP_MSG_LENGTH_EXCEEDED if data was too long
      *
-     * fValidBytes will be increased by one if one more byte fits into the
+     * _validBytes will be increased by one if one more byte fits into the
      * buffer.
      */
     ErrorCode append(uint8_t data);
 
     /**
-     * Resets fValidBytes to 0.
+     * Resets _validBytes to 0.
      */
     void resetValidBytes();
 
     /**
-     * Increases fValidBytes by n.
-     * \param   n value to increase fValidBytes by
+     * Increases _validBytes by n.
+     * \param   n value to increase _validBytes by
      * \return
      *          - TP_MSG_OK if valid bytes was increased
      *          - TP_MSG_LENGTH_EXCEEDED if valid bytes would have been too
@@ -275,22 +275,22 @@ public:
 
 private:
     /** Pointer to optional IDataProgressListener */
-    IDataProgressListener* fpDataProgressListener;
+    IDataProgressListener* _dataProgressListener;
 
     /* internal buffer */
-    ::etl::span<uint8_t> fBuffer;
+    ::etl::span<uint8_t> _buffer;
 
     /** source id of TransportMessage */
-    uint16_t fSourceId;
+    uint16_t _sourceAddress;
 
     /** target id of TransportMessage */
-    uint16_t fTargetId;
+    uint16_t _targetAddress;
 
     /** total length of payload in bytes */
-    uint16_t fPayloadLength;
+    uint16_t _payloadLength;
 
     /** Current number of valid bytes in payload */
-    uint16_t fValidBytes;
+    uint16_t _validBytes;
 
 private:
     void notifyDataProgressListener(uint32_t numberOfNewValidBytes);
@@ -304,59 +304,65 @@ private:
 
 inline uint16_t TransportMessage::getSourceId() const { return sourceAddress(); }
 
-inline void TransportMessage::setSourceId(uint16_t const sourceId) { fSourceId = sourceId; }
+inline void TransportMessage::setSourceAddress(uint16_t const sourceAddress)
+{
+    _sourceAddress = sourceAddress;
+}
 
-inline uint16_t TransportMessage::sourceAddress() const { return fSourceId; }
+inline uint16_t TransportMessage::sourceAddress() const { return _sourceAddress; }
 
 inline uint16_t TransportMessage::getTargetId() const { return targetAddress(); }
 
-inline uint16_t TransportMessage::targetAddress() const { return fTargetId; }
+inline uint16_t TransportMessage::targetAddress() const { return _targetAddress; }
 
-inline void TransportMessage::setTargetId(uint16_t const targetId) { fTargetId = targetId; }
+inline void TransportMessage::setTargetAddress(uint16_t const targetId)
+{
+    _targetAddress = targetId;
+}
 
 inline uint8_t TransportMessage::getServiceId() const { return serviceId(); }
 
-inline uint8_t TransportMessage::serviceId() const { return fBuffer[SERVICE_ID_INDEX]; }
+inline uint8_t TransportMessage::serviceId() const { return _buffer[SERVICE_ID_INDEX]; }
 
-inline uint8_t* TransportMessage::getBuffer() const { return fBuffer.data(); }
+inline uint8_t* TransportMessage::getBuffer() const { return _buffer.data(); }
 
 inline uint32_t TransportMessage::getBufferLength() const
 {
-    return static_cast<uint32_t>(fBuffer.size());
+    return static_cast<uint32_t>(_buffer.size());
 }
 
-inline uint8_t* TransportMessage::getPayload() { return fBuffer.data(); }
+inline uint8_t* TransportMessage::getPayload() { return _buffer.data(); }
 
-inline uint8_t const* TransportMessage::getPayload() const { return fBuffer.data(); }
+inline uint8_t const* TransportMessage::getPayload() const { return _buffer.data(); }
 
 inline uint8_t& TransportMessage::operator[](uint16_t const pos)
 {
-    return fBuffer[static_cast<size_t>(pos)];
+    return _buffer[static_cast<size_t>(pos)];
 }
 
 inline uint8_t const& TransportMessage::operator[](uint16_t const pos) const
 {
-    return fBuffer[static_cast<size_t>(pos)];
+    return _buffer[static_cast<size_t>(pos)];
 }
 
 inline uint16_t TransportMessage::getPayloadLength() const { return payloadLength(); }
 
-inline uint16_t TransportMessage::payloadLength() const { return fPayloadLength; }
+inline uint16_t TransportMessage::payloadLength() const { return _payloadLength; }
 
 inline uint16_t TransportMessage::getMaxPayloadLength() const { return maxPayloadLength(); }
 
 inline uint16_t TransportMessage::maxPayloadLength() const
 {
-    return static_cast<uint16_t>(fBuffer.size());
+    return static_cast<uint16_t>(_buffer.size());
 }
 
-inline void TransportMessage::resetValidBytes() { fValidBytes = 0U; }
+inline void TransportMessage::resetValidBytes() { _validBytes = 0U; }
 
 inline uint16_t TransportMessage::getValidBytes() const { return validBytes(); }
 
-inline uint16_t TransportMessage::validBytes() const { return fValidBytes; }
+inline uint16_t TransportMessage::validBytes() const { return _validBytes; }
 
-inline bool TransportMessage::isComplete() const { return fValidBytes >= getPayloadLength(); }
+inline bool TransportMessage::isComplete() const { return _validBytes >= getPayloadLength(); }
 
 inline uint16_t TransportMessage::missingBytes() const
 {

--- a/libs/bsw/transport/mock/gmock/include/transport/TransportMessageProvidingListenerMock.h
+++ b/libs/bsw/transport/mock/gmock/include/transport/TransportMessageProvidingListenerMock.h
@@ -30,24 +30,24 @@ public:
         ErrorCode,
         getTransportMessage,
         (uint8_t srcBusId,
-         uint16_t sourceId,
-         uint16_t targetId,
+         uint16_t sourceAddress,
+         uint16_t targetAddress,
          uint16_t size,
          ::etl::span<uint8_t const> const& peek,
          TransportMessage*& pTransportMessage));
 
     MOCK_METHOD(void, releaseTransportMessage, (TransportMessage & transportMessage));
 
-    MOCK_METHOD(void, refuseSourceId, (uint8_t sourceId));
+    MOCK_METHOD(void, refuseSourceId, (uint8_t sourceAddress));
 
-    MOCK_METHOD(void, refuseTargetId, (uint8_t targetId));
+    MOCK_METHOD(void, refuseTargetId, (uint8_t targetAddress));
 
     MOCK_METHOD(void, dump, ());
 
     ErrorCode getTransportMessageImplementation(
         uint8_t srcBusId,
-        uint16_t sourceId,
-        uint16_t targetId,
+        uint16_t sourceAddress,
+        uint16_t targetAddress,
         uint16_t size,
         ::etl::span<uint8_t const> const& peek,
         TransportMessage*& pTransportMessage);
@@ -58,8 +58,8 @@ public:
     void releaseTransportMessageImplementation(TransportMessage& transportMessage);
 
 private:
-    void refuseSourceIdImplementation(uint8_t sourceId);
-    void refuseTargetIdImplementation(uint8_t targetId);
+    void refuseSourceAddressImplementation(uint8_t sourceAddress);
+    void refuseTargetAddressImplementation(uint8_t targetAddress);
 
     std::set<uint8_t> fRefusedSourceIds;
     std::set<uint8_t> fRefusedTargetIds;

--- a/libs/bsw/transport/mock/gmock/src/TransportMessageProvidingListenerMock.cpp
+++ b/libs/bsw/transport/mock/gmock/src/TransportMessageProvidingListenerMock.cpp
@@ -25,32 +25,32 @@ TransportMessageProvidingListenerMock::TransportMessageProvidingListenerMock(boo
                 this,
                 &TransportMessageProvidingListenerMock::releaseTransportMessageImplementation));
         ON_CALL(*this, refuseSourceId(_))
-            .WillByDefault(
-                Invoke(this, &TransportMessageProvidingListenerMock::refuseSourceIdImplementation));
+            .WillByDefault(Invoke(
+                this, &TransportMessageProvidingListenerMock::refuseSourceAddressImplementation));
         ON_CALL(*this, refuseTargetId(_))
-            .WillByDefault(
-                Invoke(this, &TransportMessageProvidingListenerMock::refuseTargetIdImplementation));
+            .WillByDefault(Invoke(
+                this, &TransportMessageProvidingListenerMock::refuseTargetAddressImplementation));
     }
 }
 
 ITransportMessageProvider::ErrorCode
 TransportMessageProvidingListenerMock::getTransportMessageImplementation(
     uint8_t /* srcBusId */,
-    uint16_t sourceId,
-    uint16_t targetId,
+    uint16_t sourceAddress,
+    uint16_t targetAddress,
     uint16_t size,
     ::etl::span<uint8_t const> const& /* peek */,
     TransportMessage*& pTransportMessage)
 {
-    if (fRefusedSourceIds.count(sourceId) > 0)
+    if (fRefusedSourceIds.count(sourceAddress) > 0)
     {
         pTransportMessage = 0L;
-        return ITransportMessageProvidingListener::ErrorCode::TPMSG_INVALID_SRC_ID;
+        return ITransportMessageProvidingListener::ErrorCode::TPMSG_INVALID_SRC_ADDRESS;
     }
-    if (fRefusedTargetIds.count(targetId) > 0)
+    if (fRefusedTargetIds.count(targetAddress) > 0)
     {
         pTransportMessage = 0L;
-        return ITransportMessageProvidingListener::ErrorCode::TPMSG_INVALID_TGT_ID;
+        return ITransportMessageProvidingListener::ErrorCode::TPMSG_INVALID_TGT_ADDRESS;
     }
     pTransportMessage = new TransportMessage();
     pTransportMessage->init(new uint8_t[size], size);
@@ -81,14 +81,14 @@ TransportMessageProvidingListenerMock::messageReceivedImplementation(
     return ITransportMessageListener::ReceiveResult::RECEIVED_NO_ERROR;
 }
 
-void TransportMessageProvidingListenerMock::refuseSourceIdImplementation(uint8_t sourceId)
+void TransportMessageProvidingListenerMock::refuseSourceAddressImplementation(uint8_t sourceAddress)
 {
-    fRefusedSourceIds.insert(sourceId);
+    fRefusedSourceIds.insert(sourceAddress);
 }
 
-void TransportMessageProvidingListenerMock::refuseTargetIdImplementation(uint8_t targetId)
+void TransportMessageProvidingListenerMock::refuseTargetAddressImplementation(uint8_t targetAddress)
 {
-    fRefusedTargetIds.insert(targetId);
+    fRefusedTargetIds.insert(targetAddress);
 }
 
 } // namespace transport

--- a/libs/bsw/transport/src/AbstractTransportLayer.cpp
+++ b/libs/bsw/transport/src/AbstractTransportLayer.cpp
@@ -36,8 +36,8 @@ AbstractTransportLayer::TransportMessageProvidingListenerHelper::
 ITransportMessageProvidingListener::ErrorCode
 AbstractTransportLayer::TransportMessageProvidingListenerHelper::getTransportMessage(
     uint8_t const srcBusId,
-    uint16_t const sourceId,
-    uint16_t const targetId,
+    uint16_t const sourceAddress,
+    uint16_t const targetAddress,
     uint16_t const size,
     ::etl::span<uint8_t const> const& peek,
     TransportMessage*& pTransportMessage)
@@ -45,7 +45,7 @@ AbstractTransportLayer::TransportMessageProvidingListenerHelper::getTransportMes
     if (fpMessageProvider != nullptr)
     {
         return fpMessageProvider->getTransportMessage(
-            srcBusId, sourceId, targetId, size, peek, pTransportMessage);
+            srcBusId, sourceAddress, targetAddress, size, peek, pTransportMessage);
     }
     Logger::warn(
         TRANSPORT,

--- a/libs/bsw/transport/test/src/TransportMessageTest.cpp
+++ b/libs/bsw/transport/test/src/TransportMessageTest.cpp
@@ -69,19 +69,19 @@ TEST_F(TransportMessageTest, Init)
 
 TEST_F(TransportMessageTest, GetSetSourceId)
 {
-    m.setSourceId(2U);
+    m.setSourceAddress(2U);
     EXPECT_EQ(2U, m.getSourceId());
 
-    m.setSourceId(0xFFFFU);
+    m.setSourceAddress(0xFFFFU);
     EXPECT_EQ(0xFFFFU, m.getSourceId());
 }
 
 TEST_F(TransportMessageTest, GetSetTargetId)
 {
-    m.setTargetId(42U);
+    m.setTargetAddress(42U);
     EXPECT_EQ(42U, m.getTargetId());
 
-    m.setTargetId(0xFFFFU);
+    m.setTargetAddress(0xFFFFU);
     EXPECT_EQ(0xFFFFU, m.getTargetId());
 }
 
@@ -181,8 +181,8 @@ TEST_F(TransportMessageTest, TransportMessageAppend)
     uint8_t buffer[16] = {0};
     TransportMessage m;
     m.init(buffer, 16);
-    m.setTargetId(0x1);
-    m.setSourceId(0x2);
+    m.setTargetAddress(0x1);
+    m.setSourceAddress(0x2);
     uint8_t const data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     EXPECT_EQ(TransportMessage::ErrorCode::TP_MSG_LENGTH_EXCEEDED, m.append(data, 17));
@@ -213,12 +213,12 @@ TEST_F(TransportMessageTest, CompareOperator)
     memset(fBuffer, 0xAB, BUFFER_LENGTH);
 
     localMessage.init(fpLocalBuffer, BUFFER_LENGTH);
-    localMessage.setSourceId(0xC0);
-    localMessage.setTargetId(0xC1);
+    localMessage.setSourceAddress(0xC0);
+    localMessage.setTargetAddress(0xC1);
     localMessage.setPayloadLength(BUFFER_LENGTH);
     m.init(fBuffer, BUFFER_LENGTH);
-    m.setSourceId(0xC0);
-    m.setTargetId(0xC1);
+    m.setSourceAddress(0xC0);
+    m.setTargetAddress(0xC1);
     m.setPayloadLength(BUFFER_LENGTH);
     EXPECT_EQ(true, m == localMessage);
 
@@ -251,21 +251,21 @@ TEST_F(TransportMessageTest, CompareOperator)
     localMessage.resetValidBytes();
     EXPECT_EQ(m, localMessage);
     EXPECT_EQ(m.getTargetId(), localMessage.getTargetId());
-    m.setTargetId(0xF1);
-    localMessage.setTargetId(0xF2);
+    m.setTargetAddress(0xF1);
+    localMessage.setTargetAddress(0xF2);
     EXPECT_FALSE(m == localMessage);
 
     // source different
-    m.setTargetId(0xF1);
-    localMessage.setTargetId(0xF1);
+    m.setTargetAddress(0xF1);
+    localMessage.setTargetAddress(0xF1);
     EXPECT_EQ(m, localMessage);
-    m.setSourceId(0xAB);
-    localMessage.setSourceId(0xCD);
+    m.setSourceAddress(0xAB);
+    localMessage.setSourceAddress(0xCD);
     EXPECT_FALSE(m == localMessage);
 
     // restore equality
-    m.setSourceId(0xAB);
-    localMessage.setSourceId(0xAB);
+    m.setSourceAddress(0xAB);
+    localMessage.setSourceAddress(0xAB);
     EXPECT_EQ(m, localMessage);
 
     // payload contents different
@@ -291,10 +291,10 @@ TEST_F(TransportMessageTest, CompareSameEverything)
     localMessage.init(fpLocalBuffer, BUFFER_LENGTH);
     m.init(fBuffer, BUFFER_LENGTH);
 
-    m.setSourceId(0xC0);
-    m.setTargetId(0xC1);
-    localMessage.setSourceId(0xC0);
-    localMessage.setTargetId(0xC1);
+    m.setSourceAddress(0xC0);
+    m.setTargetAddress(0xC1);
+    localMessage.setSourceAddress(0xC0);
+    localMessage.setTargetAddress(0xC1);
     EXPECT_EQ(m, localMessage);
 
     // payload contents different

--- a/libs/bsw/transportRouterSimple/include/transport/routing/TransportRouterSimple.h
+++ b/libs/bsw/transportRouterSimple/include/transport/routing/TransportRouterSimple.h
@@ -38,7 +38,7 @@ public:
 
     ErrorCode getTransportMessage(
         uint8_t srcBusId,
-        uint16_t sourceId,
+        uint16_t sourceAddress,
         uint16_t targetId,
         uint16_t size,
         ::etl::span<uint8_t const> const& peek,

--- a/libs/bsw/transportRouterSimple/src/transport/routing/TransportRouterSimple.cpp
+++ b/libs/bsw/transportRouterSimple/src/transport/routing/TransportRouterSimple.cpp
@@ -35,7 +35,7 @@ void TransportRouterSimple::shutdown() { _transportLayers.clear(); }
 
 ITransportMessageProvidingListener::ErrorCode TransportRouterSimple::getTransportMessage(
     uint8_t const /* srcBusId */,
-    uint16_t const sourceId,
+    uint16_t const sourceAddress,
     uint16_t const targetId,
     uint16_t const size,
     ::etl::span<uint8_t const> const& /* peek */,
@@ -43,8 +43,8 @@ ITransportMessageProvidingListener::ErrorCode TransportRouterSimple::getTranspor
 {
     Logger::debug(
         TPROUTER,
-        "TransportRouterSimple::getTransportMessage : sourceId 0x%x, targetId 0x%x",
-        sourceId,
+        "TransportRouterSimple::getTransportMessage : sourceAddress 0x%x, targetId 0x%x",
+        sourceAddress,
         targetId);
     pTransportMessage = 0L;
     ::async::LockType const lockGuard;

--- a/libs/bsw/uds/include/uds/DiagDispatcher.h
+++ b/libs/bsw/uds/include/uds/DiagDispatcher.h
@@ -94,10 +94,13 @@ public:
 
     void shutdownIncomingConnections(::etl::delegate<void()> delegate);
 
-    uint16_t getSourceId() const override { return fConfiguration.DiagAddress; }
+    uint16_t getDispatcherSourceId() const override { return fConfiguration.DiagAddress; }
 
 #ifdef IS_VARIANT_HANDLING_NEEDED
-    virtual void setSourceId(uint16_t diagAddress) { fConfiguration.DiagAddress = diagAddress; }
+    virtual void setSourceAddress(uint16_t diagAddress)
+    {
+        fConfiguration.DiagAddress = diagAddress;
+    }
 #endif
 
 private:

--- a/libs/bsw/uds/include/uds/IDiagDispatcher.h
+++ b/libs/bsw/uds/include/uds/IDiagDispatcher.h
@@ -31,10 +31,10 @@ public:
     : fSessionManager(sessionManager), fEnabled(true)
     {}
 
-    virtual uint16_t getSourceId() const = 0;
+    virtual uint16_t getDispatcherSourceId() const = 0;
 
 #ifdef IS_VARIANT_HANDLING_NEEDED
-    virtual void setSourceId(uint16_t) = 0;
+    virtual void setSourceAddress(uint16_t) = 0;
 #endif
 
     virtual ::transport::AbstractTransportLayer::ErrorCode resume(

--- a/libs/bsw/uds/include/uds/connection/NestedDiagRequest.h
+++ b/libs/bsw/uds/include/uds/connection/NestedDiagRequest.h
@@ -31,7 +31,7 @@ public:
     /**
      * Initialize a new nested request. The request is (eventually converted) and stored.
      * \param sender Reference to abstract diag job that will send the response. This sender
-     *        is stored during the nested request in fSender.
+     *        is stored during the nested request in senderJob.
      * \param messageBuffer Available buffer for both response and stored request
      * \param request Incoming request
      */
@@ -152,21 +152,21 @@ protected:
     ::etl::span<uint8_t const> consumeStoredRequest(uint16_t consumedLength);
 
 public:
-    uint16_t responseLength() const { return fResponseLength; }
+    uint16_t responseLength() const { return _responseLength; }
 
-    AbstractDiagJob* fSender;
-    AbstractDiagJob* fPendingResponseSender;
-    uint8_t const fPrefixLength;
-    bool fIsPendingSent;
-    DiagReturnCode::Type fResponseCode;
+    AbstractDiagJob* senderJob;
+    AbstractDiagJob* pendingResponseSender;
+    uint8_t const prefixLength;
+    bool isPendingSent;
+    DiagReturnCode::Type responseCode;
 
 protected:
-    uint16_t fResponseLength = 0;
-    ::etl::span<uint8_t> fMessageBuffer;
-    uint16_t fStoredRequestLength;
-    uint8_t fNumIdentifiers;
-    uint8_t fNumPrefixIdentifiers;
-    ::etl::span<uint8_t const> fNestedRequest = {};
+    uint16_t _responseLength = 0;
+    ::etl::span<uint8_t> _messageBuffer;
+    uint16_t _storedRequestLength;
+    uint8_t _numIdentifiers;
+    uint8_t _numPrefixIdentifiers;
+    ::etl::span<uint8_t const> _nestedRequest = {};
 };
 
 /**

--- a/libs/bsw/uds/include/uds/services/sessioncontrol/DiagnosticSessionControl.h
+++ b/libs/bsw/uds/include/uds/services/sessioncontrol/DiagnosticSessionControl.h
@@ -52,7 +52,7 @@ public:
      */
     void setDiagDispatcher(DiagDispatcher* const pDiagDispatcher)
     {
-        fpDiagDispatcher = pDiagDispatcher;
+        diagDispatcher = pDiagDispatcher;
     }
 
     /**
@@ -148,7 +148,7 @@ protected:
     ::async::ContextType fContext;
     IUdsLifecycleConnector& fUdsLifecycleConnector;
     ISessionPersistence& fPersistence;
-    DiagDispatcher* fpDiagDispatcher;
+    DiagDispatcher* diagDispatcher;
 
     DiagSession* fpCurrentSession;
     AbstractDiagJob const* fpRequestedJob;

--- a/libs/bsw/uds/mock/gmock/include/uds/resume/DiagDispatcherMock.h
+++ b/libs/bsw/uds/mock/gmock/include/uds/resume/DiagDispatcherMock.h
@@ -15,7 +15,7 @@ class DiagDispatcherMock : public IDiagDispatcher
 public:
     DiagDispatcherMock(IDiagSessionManager& sessionManager) : IDiagDispatcher(sessionManager) {}
 
-    MOCK_METHOD(uint16_t, getSourceId, (), (const));
+    MOCK_METHOD(uint16_t, getDispatcherSourceId, (), (const));
 
     MOCK_METHOD(
         transport::AbstractTransportLayer::ErrorCode,

--- a/libs/bsw/uds/mock/gmock/src/uds/connection/IncomingDiagConnectionMock.cpp
+++ b/libs/bsw/uds/mock/gmock/src/uds/connection/IncomingDiagConnectionMock.cpp
@@ -75,7 +75,7 @@ PositiveResponse& IncomingDiagConnection::releaseRequestGetResponse()
 {
     if (IncomingDiagConnectionMockHelper::instance().isStub())
     {
-        return fPositiveResponse;
+        return _positiveResponse;
     }
     return IncomingDiagConnectionMockHelper::instance().releaseRequestGetResponse();
 }
@@ -94,11 +94,11 @@ uint8_t IncomingDiagConnection::getIdentifier(uint16_t idx) const
 {
     if (IncomingDiagConnectionMockHelper::instance().isStub())
     {
-        if (idx >= fIdentifiers.size())
+        if (idx >= _identifiers.size())
         {
             return 0U;
         }
-        return fIdentifiers[idx];
+        return _identifiers[idx];
     }
     return IncomingDiagConnectionMockHelper::instance().getIdentifier(idx);
 }

--- a/libs/bsw/uds/mock/stub/include/UdsStub.h
+++ b/libs/bsw/uds/mock/stub/include/UdsStub.h
@@ -37,7 +37,7 @@ public:
     : IDiagDispatcher(sessionManager, fDiagJobRoot)
     {}
 
-    virtual uint16_t getSourceId() const { return 0xab; }
+    virtual uint16_t getDispatcherSourceId() const { return 0xab; }
 
     virtual transport::AbstractTransportLayer::ErrorCode
     resume(transport::TransportMessage&, transport::ITransportMessageProcessedListener*)
@@ -46,7 +46,7 @@ public:
     }
 
     virtual IOutgoingDiagConnectionProvider::ErrorCode getOutgoingDiagConnection(
-        uint16_t targetId,
+        uint16_t targetAddress,
         OutgoingDiagConnection*& pConnection,
         transport::TransportMessage* pRequestMessage)
     {

--- a/libs/bsw/uds/mock/stub/src/UdsStub.cpp
+++ b/libs/bsw/uds/mock/stub/src/UdsStub.cpp
@@ -41,7 +41,7 @@ size_t PositiveResponse::increaseDataLength(size_t length)
     return ::uds::ErrorCode::OK;
 }
 
-PositiveResponse& IncomingDiagConnection::releaseRequestGetResponse() { return fPositiveResponse; }
+PositiveResponse& IncomingDiagConnection::releaseRequestGetResponse() { return _positiveResponse; }
 
 void IncomingDiagConnection::transportMessageProcessed(
     transport::TransportMessage&, ProcessingResult status)
@@ -74,15 +74,15 @@ IncomingDiagConnection::sendPositiveResponseInternal(uint16_t const length, Abst
 
 void IncomingDiagConnection::open(bool activatePending)
 {
-    fOpen                       = true;
-    fPendingActivated           = activatePending;
-    fSuppressPositiveResponse   = false;
-    fResponsePendingSent        = false;
-    fResponsePendingIsBeingSent = false;
-    fIsResponseActive           = false;
+    open                        = true;
+    _pendingActivated           = activatePending;
+    _suppressPositiveResponse   = false;
+    _responsePendingSent        = false;
+    _responsePendingIsBeingSent = false;
+    _isResponseActive           = false;
 }
 
-void IncomingDiagConnection::terminate() { fOpen = false; }
+void IncomingDiagConnection::terminate() { open = false; }
 
 /*
  * class DiagSession

--- a/libs/bsw/uds/src/uds/base/AbstractDiagJob.cpp
+++ b/libs/bsw/uds/src/uds/base/AbstractDiagJob.cpp
@@ -50,7 +50,7 @@ DiagReturnCode::Type AbstractDiagJob::execute(
             acceptJob(connection, request, requestLength);
             return DiagReturnCode::ISO_REQUEST_OUT_OF_RANGE;
         }
-        if (!getDiagAuthenticator().isAuthenticated(connection.fSourceId))
+        if (!getDiagAuthenticator().isAuthenticated(connection.sourceAddress))
         {
             acceptJob(connection, request, requestLength);
             return getDiagAuthenticator().getNotAuthenticatedReturnCode();

--- a/libs/bsw/uds/src/uds/base/DiagJobRoot.cpp
+++ b/libs/bsw/uds/src/uds/base/DiagJobRoot.cpp
@@ -33,14 +33,14 @@ DiagReturnCode::Type DiagJobRoot::verify(uint8_t const* const request, uint16_t 
 DiagReturnCode::Type DiagJobRoot::execute(
     IncomingDiagConnection& connection, uint8_t const* const request, uint16_t const requestLength)
 {
-    if (connection.fServiceId == 0x7FU) // no response to incoming NRC
+    if (connection.serviceId == 0x7FU) // no response to incoming NRC
     {
         connection.terminate();
         return DiagReturnCode::OK;
     }
-    if (TransportConfiguration::isFunctionalAddress(connection.fTargetId))
+    if (TransportConfiguration::isFunctionalAddress(connection.targetAddress))
     {
-        if (connection.fServiceId == uds::ServiceId::TESTER_PRESENT)
+        if (connection.serviceId == uds::ServiceId::TESTER_PRESENT)
         {
             if ((!getDiagSessionManager().isSessionTimeoutActive()) && (requestLength > 1U)
                 && (((request[1] & SUPPRESS_POSITIVE_RESPONSE_MASK)) > 0U))

--- a/libs/bsw/uds/src/uds/services/readdata/MultipleReadDataByIdentifier.cpp
+++ b/libs/bsw/uds/src/uds/services/readdata/MultipleReadDataByIdentifier.cpp
@@ -93,7 +93,7 @@ DiagReturnCode::Type MultipleReadDataByIdentifier::process(
     }
     else if (fGetDidLimit.is_valid())
     {
-        uint8_t const didLimit = fGetDidLimit(*connection.fpRequestMessage);
+        uint8_t const didLimit = fGetDidLimit(*connection.requestMessage);
         if ((didLimit > 0U) && ((requestLength / 2U) > didLimit))
         {
             return DiagReturnCode::ISO_INVALID_FORMAT;
@@ -130,7 +130,7 @@ MultipleReadDataByIdentifier::prepareNestedRequest(::etl::span<uint8_t const> co
     }
     else
     {
-        fResponseCode = fCombinedResponseCode;
+        responseCode = fCombinedResponseCode;
         return {};
     }
 }
@@ -148,11 +148,12 @@ DiagReturnCode::Type MultipleReadDataByIdentifier::processNestedRequest(
     return responseCode;
 }
 
-void MultipleReadDataByIdentifier::handleNestedResponseCode(DiagReturnCode::Type const responseCode)
+void MultipleReadDataByIdentifier::handleNestedResponseCode(
+    DiagReturnCode::Type const nestedResponseCode)
 {
-    if (!fCheckResponse(responseCode, fCombinedResponseCode))
+    if (!fCheckResponse(nestedResponseCode, fCombinedResponseCode))
     {
-        fResponseCode = fCombinedResponseCode;
+        responseCode = fCombinedResponseCode;
     }
 }
 

--- a/libs/bsw/uds/src/uds/services/sessioncontrol/DiagnosticSessionControl.cpp
+++ b/libs/bsw/uds/src/uds/services/sessioncontrol/DiagnosticSessionControl.cpp
@@ -31,7 +31,7 @@ DiagnosticSessionControl::DiagnosticSessionControl(
 , fContext(context)
 , fUdsLifecycleConnector(udsLifecycleConnector)
 , fPersistence(persistence)
-, fpDiagDispatcher(nullptr)
+, diagDispatcher(nullptr)
 , fpCurrentSession(&DiagSession::APPLICATION_DEFAULT_SESSION())
 , fpRequestedJob(nullptr)
 , fpTesterPresent(nullptr)
@@ -304,9 +304,9 @@ void DiagnosticSessionControl::switchSession(DiagSession& newSession)
     }
     else if (newSession == DiagSession::PROGRAMMING_SESSION())
     {
-        if (fpDiagDispatcher != nullptr)
+        if (diagDispatcher != nullptr)
         {
-            fpDiagDispatcher->fEnabled = false;
+            diagDispatcher->fEnabled = false;
         }
         fRequestProgrammingSession = true;
     }

--- a/libs/bsw/uds/test/mock/include/transport/TransportMessageWithBuffer.h
+++ b/libs/bsw/uds/test/mock/include/transport/TransportMessageWithBuffer.h
@@ -17,7 +17,10 @@ struct TransportMessageWithBuffer
 {
     explicit TransportMessageWithBuffer(uint32_t size);
     TransportMessageWithBuffer(
-        uint8_t sourceId, uint8_t targetId, ::etl::span<uint8_t const> data, uint32_t maxSize = 0);
+        uint8_t sourceAddress,
+        uint8_t targetId,
+        ::etl::span<uint8_t const> data,
+        uint32_t maxSize = 0);
 
     TransportMessageWithBuffer(TransportMessageWithBuffer const&)            = delete;
     TransportMessageWithBuffer& operator=(TransportMessageWithBuffer const&) = delete;

--- a/libs/bsw/uds/test/mock/src/transport/TransportMessageWithBuffer.cpp
+++ b/libs/bsw/uds/test/mock/src/transport/TransportMessageWithBuffer.cpp
@@ -12,12 +12,12 @@ TransportMessageWithBuffer::TransportMessageWithBuffer(uint32_t size) : buffer(s
 }
 
 TransportMessageWithBuffer::TransportMessageWithBuffer(
-    uint8_t sourceId, uint8_t targetId, ::etl::span<uint8_t const> data, uint32_t maxSize)
+    uint8_t sourceAddress, uint8_t targetId, ::etl::span<uint8_t const> data, uint32_t maxSize)
 : TransportMessageWithBuffer((0 == maxSize) ? static_cast<uint32_t>(data.size()) : maxSize)
 {
     m.append(data.data(), static_cast<uint16_t>(data.size()));
-    m.setSourceId(sourceId);
-    m.setTargetId(targetId);
+    m.setSourceAddress(sourceAddress);
+    m.setTargetAddress(targetId);
     m.setPayloadLength(static_cast<uint16_t>(data.size()));
 }
 

--- a/libs/bsw/uds/test/src/uds/IntegrationTest.cpp
+++ b/libs/bsw/uds/test/src/uds/IntegrationTest.cpp
@@ -240,7 +240,7 @@ TEST_F(UdsIntegration, positive_response)
             SaveArg<2>(&pProcessedListener),
             Return(transport::ITransportMessageListener::ReceiveResult::RECEIVED_NO_ERROR)));
 
-    EXPECT_EQ(_udsDispatcher.getSourceId(), 0x10);
+    EXPECT_EQ(_udsDispatcher.getDispatcherSourceId(), 0x10);
 
     _udsDispatcher.processQueue();
     CONTEXT_EXECUTE;
@@ -322,8 +322,8 @@ TEST_F(UdsIntegration, no_response_for_7f)
 
     transport::TransportMessage transportMessage(buffer, sizeof(buffer));
     transportMessage.setServiceId(0x7fU);
-    transportMessage.setSourceId(0x01U);
-    transportMessage.setTargetId(0x02U);
+    transportMessage.setSourceAddress(0x01U);
+    transportMessage.setTargetAddress(0x02U);
 
     EXPECT_CALL(_messageProvider, getTransportMessage(_, _, _, _, _, _))
         .WillRepeatedly(
@@ -600,8 +600,8 @@ TEST_F(UdsIntegration, dispatchIncomingRequest_returns_earlier_if_request_comes_
     uint8_t buffer[] = {0x22U, 0x01U, 0x01U};
 
     transport::TransportMessage transportMessage(buffer, sizeof(buffer));
-    transportMessage.setSourceId(0x10U);
-    transportMessage.setTargetId(transport::TransportMessage::INVALID_ADDRESS);
+    transportMessage.setSourceAddress(0x10U);
+    transportMessage.setTargetAddress(transport::TransportMessage::INVALID_ADDRESS);
 
     transport::TransportMessage message;
     ::etl::array<uint8_t, 9> requestBuffer;
@@ -630,8 +630,8 @@ TEST_F(
     uint8_t buffer[] = {0x22U, 0x01U, 0x01U};
 
     transport::TransportMessage transportMessage(buffer, sizeof(buffer));
-    transportMessage.setSourceId(0x10U);
-    transportMessage.setTargetId(0xDFU);
+    transportMessage.setSourceAddress(0x10U);
+    transportMessage.setTargetAddress(0xDFU);
 
     EXPECT_CALL(_messageProvider, getTransportMessage(_, _, _, _, _, _))
         .WillRepeatedly(Return(transport::ITransportMessageProvider::ErrorCode::TPMSG_OK));
@@ -660,8 +660,8 @@ TEST_F(
     uint8_t buffer[] = {0x22U, 0x01U, 0x01U};
 
     transport::TransportMessage transportMessage(buffer, sizeof(buffer));
-    transportMessage.setSourceId(0x10U);
-    transportMessage.setTargetId(0xDFU);
+    transportMessage.setSourceAddress(0x10U);
+    transportMessage.setTargetAddress(0xDFU);
 
     EXPECT_CALL(_messageProvider, getTransportMessage(_, _, _, _, _, _))
         .WillRepeatedly(
@@ -688,8 +688,8 @@ TEST_F(UdsIntegration, dispatchIncomingRequest_setProcessedListener_if_no_one_wa
     uint8_t buffer[] = {0x22U, 0x01U, 0x01U};
 
     transport::TransportMessage transportMessage(buffer, sizeof(buffer));
-    transportMessage.setSourceId(0x10U);
-    transportMessage.setTargetId(0xDFU);
+    transportMessage.setSourceAddress(0x10U);
+    transportMessage.setTargetAddress(0xDFU);
 
     transport::TransportMessage message;
     ::etl::array<uint8_t, 9> requestBuffer;
@@ -725,8 +725,8 @@ TEST_F(
 
     transport::TransportMessage transportMessage(buffer, sizeof(buffer));
     transportMessage.setServiceId(0x31U);
-    transportMessage.setSourceId(0x10U);
-    transportMessage.setTargetId(0xDFU);
+    transportMessage.setSourceAddress(0x10U);
+    transportMessage.setTargetAddress(0xDFU);
 
     transport::TransportMessage message;
     ::etl::array<uint8_t, 9> requestBuffer;
@@ -763,8 +763,8 @@ TEST_F(
 
     transport::TransportMessage transportMessage(buffer, sizeof(buffer));
     transportMessage.setServiceId(0x3EU);
-    transportMessage.setSourceId(0x10U);
-    transportMessage.setTargetId(0xDFU);
+    transportMessage.setSourceAddress(0x10U);
+    transportMessage.setTargetAddress(0xDFU);
 
     EXPECT_CALL(_messageProvider, getTransportMessage(_, _, _, _, _, _))
         .WillRepeatedly(
@@ -809,7 +809,7 @@ TEST_F(
 
     TransportMessageWithBuffer pRequest(SOURCE_ID, TARGET_ID, hardResetRequest, EMPTY_RESPONSE);
 
-    _incomingDiagConnection.fpRequestMessage = pRequest.get();
+    _incomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -834,7 +834,7 @@ TEST_F(
 
     TransportMessageWithBuffer pRequest(SOURCE_ID, TARGET_ID, hardResetRequest, EMPTY_RESPONSE);
 
-    _incomingDiagConnection.fpRequestMessage = pRequest.get();
+    _incomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -887,7 +887,7 @@ TEST_F(
 
     TransportMessageWithBuffer pRequest(SOURCE_ID, TARGET_ID, softResetRequest, EMPTY_RESPONSE);
 
-    _incomingDiagConnection.fpRequestMessage = pRequest.get();
+    _incomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -913,7 +913,7 @@ TEST_F(
 
     TransportMessageWithBuffer pRequest(SOURCE_ID, TARGET_ID, softResetRequest, EMPTY_RESPONSE);
 
-    _incomingDiagConnection.fpRequestMessage = pRequest.get();
+    _incomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -968,12 +968,12 @@ TEST_F(UdsIntegration, calling_PowerDown)
     TransportMessageWithBuffer pRequest(
         SOURCE_ID, TARGET_ID, POWER_DOWN_REQUEST, sizeof(POWER_DOWN_REQUEST));
 
-    _incomingDiagConnection.fpRequestMessage     = pRequest.get();
-    _incomingDiagConnection.fpMessageSender      = &_udsDispatcher;
-    _incomingDiagConnection.fpDiagSessionManager = &_sessionManager;
-    _incomingDiagConnection.fServiceId           = ECU_RESET;
+    _incomingDiagConnection.requestMessage     = pRequest.get();
+    _incomingDiagConnection.messageSender      = &_udsDispatcher;
+    _incomingDiagConnection.diagSessionManager = &_sessionManager;
+    _incomingDiagConnection.serviceId          = ECU_RESET;
 
-    _incomingDiagConnection.fOpen = true;
+    _incomingDiagConnection.isOpen = true;
 
     EXPECT_CALL(_lifecycle, requestPowerdown(false, _)).WillOnce(Return(true));
 
@@ -1001,12 +1001,12 @@ TEST_F(UdsIntegration, calling_RapidPowerDown)
     TransportMessageWithBuffer pRequest(
         SOURCE_ID, TARGET_ID, POWER_DOWN_REQUEST, sizeof(POWER_DOWN_REQUEST));
 
-    _incomingDiagConnection.fpRequestMessage     = pRequest.get();
-    _incomingDiagConnection.fpMessageSender      = &_udsDispatcher;
-    _incomingDiagConnection.fpDiagSessionManager = &_sessionManager;
-    _incomingDiagConnection.fServiceId           = ECU_RESET;
+    _incomingDiagConnection.requestMessage     = pRequest.get();
+    _incomingDiagConnection.messageSender      = &_udsDispatcher;
+    _incomingDiagConnection.diagSessionManager = &_sessionManager;
+    _incomingDiagConnection.serviceId          = ECU_RESET;
 
-    _incomingDiagConnection.fOpen = true;
+    _incomingDiagConnection.isOpen = true;
 
     EXPECT_CALL(_lifecycle, requestPowerdown(true, _)).WillOnce(Return(true));
 

--- a/libs/bsw/uds/test/src/uds/base/AbstractDiagJobTest.cpp
+++ b/libs/bsw/uds/test/src/uds/base/AbstractDiagJobTest.cpp
@@ -83,14 +83,14 @@ struct AbstractDiagJobTest : public Test
         fResponseMessage.init(fRequestBuffer.data(), fRequestBuffer.size());
 
         fpDiagAuthenticator.reset(new DefaultDiagAuthenticator());
-        fpDiagSessionManager.reset(new DiagSessionManagerMock());
-        AbstractDiagJob::setDefaultDiagSessionManager(*fpDiagSessionManager);
+        diagSessionManager.reset(new DiagSessionManagerMock());
+        AbstractDiagJob::setDefaultDiagSessionManager(*diagSessionManager);
 
-        fIncomingConnection.fSourceId        = 0x10U;
-        fIncomingConnection.fpRequestMessage = &fResponseMessage;
+        fIncomingConnection.sourceAddress  = 0x10U;
+        fIncomingConnection.requestMessage = &fResponseMessage;
     }
 
-    std::unique_ptr<IDiagSessionManager> fpDiagSessionManager;
+    std::unique_ptr<IDiagSessionManager> diagSessionManager;
     std::unique_ptr<IDiagAuthenticator> fpDiagAuthenticator;
     DiagJobRoot fpDiagJobRoot;
     DiagJobRoot fJobRoot;
@@ -405,7 +405,7 @@ TEST_F(
         sizeof(IMPLEMENTED_REQUEST), // fRequestLength
         0U,                          // fPrefixLength
         0U,                          // fRequestPayloadLength
-        1U);                         // fResponseLength
+        1U);                         // _responseLength
 
     extendedDiagJob.setDefaultDiagSessionManager(fSessionManager);
 

--- a/libs/bsw/uds/test/src/uds/base/AbstractDiagJobWithDiagRoot.cpp
+++ b/libs/bsw/uds/test/src/uds/base/AbstractDiagJobWithDiagRoot.cpp
@@ -105,14 +105,14 @@ struct AbstractDiagJobWithSupLinkTest : public Test
         fResponseMessage.init(fRequestBuffer.data(), fRequestBuffer.size());
 
         fpDiagAuthenticator.reset(new DefaultDiagAuthenticator());
-        fpDiagSessionManager.reset(new DiagSessionManagerMock());
-        AbstractDiagJob::setDefaultDiagSessionManager(*fpDiagSessionManager);
+        diagSessionManager.reset(new DiagSessionManagerMock());
+        AbstractDiagJob::setDefaultDiagSessionManager(*diagSessionManager);
 
-        fIncomingConnection.fSourceId        = 0x10U;
-        fIncomingConnection.fpRequestMessage = &fResponseMessage;
+        fIncomingConnection.sourceAddress  = 0x10U;
+        fIncomingConnection.requestMessage = &fResponseMessage;
     }
 
-    std::unique_ptr<IDiagSessionManager> fpDiagSessionManager;
+    std::unique_ptr<IDiagSessionManager> diagSessionManager;
     std::unique_ptr<IDiagAuthenticator> fpDiagAuthenticator;
     DiagJobRootWithSupLink fJobRoot;
     TestableDiagJob fTestableDiagJob{fJobRoot};

--- a/libs/bsw/uds/test/src/uds/base/DiagJobRootTest.cpp
+++ b/libs/bsw/uds/test/src/uds/base/DiagJobRootTest.cpp
@@ -73,11 +73,11 @@ TEST_F(
     DiagJobRootTest,
     session_timeout_is_not_active_so_TesterPresent_request_should_be_ignore_and_execute_returns_OK)
 {
-    uint8_t const request[]          = {0x3E, 0x80};
-    uint16_t const serviceId         = request[0];
-    uint16_t const functionalAddress = 0xDF;
-    fIncomingConnection.fTargetId    = functionalAddress;
-    fIncomingConnection.fServiceId   = serviceId;
+    uint8_t const request[]           = {0x3E, 0x80};
+    uint16_t const serviceId          = request[0];
+    uint16_t const functionalAddress  = 0xDF;
+    fIncomingConnection.targetAddress = functionalAddress;
+    fIncomingConnection.serviceId     = serviceId;
 
     EXPECT_CALL(fSessionManager, isSessionTimeoutActive()).WillOnce(Return(false));
 
@@ -93,11 +93,11 @@ TEST_F(
 TEST_F(
     DiagJobRootTest, session_timeout_is_active_AbstractDiagJob_execute_should_be_call_immediately)
 {
-    uint8_t const request[]          = {0x3E, 0x80};
-    uint16_t const serviceId         = request[0];
-    uint16_t const functionalAddress = 0xDF;
-    fIncomingConnection.fTargetId    = functionalAddress;
-    fIncomingConnection.fServiceId   = serviceId;
+    uint8_t const request[]           = {0x3E, 0x80};
+    uint16_t const serviceId          = request[0];
+    uint16_t const functionalAddress  = 0xDF;
+    fIncomingConnection.targetAddress = functionalAddress;
+    fIncomingConnection.serviceId     = serviceId;
 
     EXPECT_CALL(fSessionManager, isSessionTimeoutActive()).WillOnce(Return(true));
 
@@ -118,11 +118,11 @@ TEST_F(
     DiagJobRootTest,
     service_id_is_not_TesterPresent_AbstractDiagJob_execute_should_be_call_immediately)
 {
-    uint8_t const request[]          = {0x21, 0x80};
-    uint16_t const serviceId         = request[0];
-    uint16_t const functionalAddress = 0xDF;
-    fIncomingConnection.fTargetId    = functionalAddress;
-    fIncomingConnection.fServiceId   = serviceId;
+    uint8_t const request[]           = {0x21, 0x80};
+    uint16_t const serviceId          = request[0];
+    uint16_t const functionalAddress  = 0xDF;
+    fIncomingConnection.targetAddress = functionalAddress;
+    fIncomingConnection.serviceId     = serviceId;
 
     EXPECT_CALL(fSessionManager, getActiveSession()).WillOnce(ReturnRef(fApplicationSession));
 
@@ -141,11 +141,11 @@ TEST_F(
     DiagJobRootTest,
     TesterPresent_request_is_too_short_AbstractDiagJob_execute_should_be_call_immediately)
 {
-    uint8_t const request[]          = {0x3E};
-    uint16_t const serviceId         = request[0];
-    uint16_t const functionalAddress = 0xDF;
-    fIncomingConnection.fTargetId    = functionalAddress;
-    fIncomingConnection.fServiceId   = serviceId;
+    uint8_t const request[]           = {0x3E};
+    uint16_t const serviceId          = request[0];
+    uint16_t const functionalAddress  = 0xDF;
+    fIncomingConnection.targetAddress = functionalAddress;
+    fIncomingConnection.serviceId     = serviceId;
 
     EXPECT_CALL(fSessionManager, isSessionTimeoutActive()).WillOnce(Return(false));
 
@@ -167,11 +167,11 @@ TEST_F(
     DiagJobRootTest,
     positive_response_is_not_suppress_AbstractDiagJob_execute_should_be_call_immediately)
 {
-    uint8_t const request[]          = {0x3E, 0x00};
-    uint16_t const serviceId         = request[0];
-    uint16_t const functionalAddress = 0xDF;
-    fIncomingConnection.fTargetId    = functionalAddress;
-    fIncomingConnection.fServiceId   = serviceId;
+    uint8_t const request[]           = {0x3E, 0x00};
+    uint16_t const serviceId          = request[0];
+    uint16_t const functionalAddress  = 0xDF;
+    fIncomingConnection.targetAddress = functionalAddress;
+    fIncomingConnection.serviceId     = serviceId;
 
     EXPECT_CALL(fSessionManager, isSessionTimeoutActive()).WillOnce(Return(false));
 

--- a/libs/bsw/uds/test/src/uds/jobs/ReadIdentifierFromMemoryJobTest.cpp
+++ b/libs/bsw/uds/test/src/uds/jobs/ReadIdentifierFromMemoryJobTest.cpp
@@ -66,8 +66,8 @@ TEST_F(ReadIdentifierFromMemoryJobTest, execute_valid_request)
 
     ::transport::TransportMessage responseMessage(_responseBuffer, sizeof(_responseBuffer));
 
-    _incomingDiagConnection.fpRequestMessage  = request.get();
-    _incomingDiagConnection.fpResponseMessage = &responseMessage;
+    _incomingDiagConnection.requestMessage  = request.get();
+    _incomingDiagConnection.responseMessage = &responseMessage;
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -98,8 +98,8 @@ TEST_F(ReadIdentifierFromMemoryJobTest, execute_valid_request_slice_constructor)
 
     ::transport::TransportMessage responseMessage(_responseBuffer, sizeof(_responseBuffer));
 
-    _incomingDiagConnection.fpRequestMessage  = request.get();
-    _incomingDiagConnection.fpResponseMessage = &responseMessage;
+    _incomingDiagConnection.requestMessage  = request.get();
+    _incomingDiagConnection.responseMessage = &responseMessage;
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));

--- a/libs/bsw/uds/test/src/uds/jobs/ReadIdentifierFromSliceRefTest.cpp
+++ b/libs/bsw/uds/test/src/uds/jobs/ReadIdentifierFromSliceRefTest.cpp
@@ -66,8 +66,8 @@ TEST_F(ReadIdentifierFromSliceRefJobTest, execute_valid_request)
 
     ::transport::TransportMessage responseMessage(_responseBuffer, sizeof(_responseBuffer));
 
-    _incomingDiagConnection.fpRequestMessage  = request.get();
-    _incomingDiagConnection.fpResponseMessage = &responseMessage;
+    _incomingDiagConnection.requestMessage  = request.get();
+    _incomingDiagConnection.responseMessage = &responseMessage;
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -99,8 +99,8 @@ TEST_F(ReadIdentifierFromSliceRefJobTest, execute_valid_request_and_change_slice
 
     ::transport::TransportMessage responseMessage(_responseBuffer, sizeof(_responseBuffer));
 
-    _incomingDiagConnection.fpRequestMessage  = request.get();
-    _incomingDiagConnection.fpResponseMessage = &responseMessage;
+    _incomingDiagConnection.requestMessage  = request.get();
+    _incomingDiagConnection.responseMessage = &responseMessage;
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));

--- a/libs/bsw/uds/test/src/uds/jobs/RoutineControlJobTest.cpp
+++ b/libs/bsw/uds/test/src/uds/jobs/RoutineControlJobTest.cpp
@@ -121,7 +121,7 @@ struct RoutineControlJobTest : ::testing::Test
         fRequestBuffer[3] = TestableRoutineControlJob::ROUTINE_IDENTIFIER[1];
 
         fRoutineControlJobExtended.setDefaultDiagSessionManager(fDiagSessionManager);
-        fIncomingDiagConnection.fpRequestMessage = &fMessage;
+        fIncomingDiagConnection.requestMessage = &fMessage;
     }
 
     transport::TransportMessage fMessage;

--- a/libs/bsw/uds/test/src/uds/jobs/WritedentifierToMemoryJobTest.cpp
+++ b/libs/bsw/uds/test/src/uds/jobs/WritedentifierToMemoryJobTest.cpp
@@ -52,7 +52,7 @@ TEST_F(WriteIdentifierToMemoryJobTest, execute_valid_request)
     TransportMessageWithBuffer request(
         SOURCE_ID, TARGET_ID, VALID_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
-    _incomingDiagConnection.fpRequestMessage = request.get();
+    _incomingDiagConnection.requestMessage = request.get();
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -79,7 +79,7 @@ TEST_F(WriteIdentifierToMemoryJobTest, execute_wrong_size_request)
     TransportMessageWithBuffer request(
         SOURCE_ID, TARGET_ID, VALID_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
-    _incomingDiagConnection.fpRequestMessage = request.get();
+    _incomingDiagConnection.requestMessage = request.get();
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));

--- a/libs/bsw/uds/test/src/uds/resume/ResumableResetDriverTest.cpp
+++ b/libs/bsw/uds/test/src/uds/resume/ResumableResetDriverTest.cpp
@@ -76,8 +76,8 @@ public:
     {
         if (fTransportMessage.getSourceId() != ::transport::TransportMessage::INVALID_ADDRESS)
         {
-            message.setSourceId(fTransportMessage.getSourceId());
-            message.setTargetId(fTransportMessage.getTargetId());
+            message.setSourceAddress(fTransportMessage.getSourceId());
+            message.setTargetAddress(fTransportMessage.getTargetId());
             message.append(fTransportMessage.getPayload(), fTransportMessage.getPayloadLength());
             message.setPayloadLength(fTransportMessage.getPayloadLength());
             return true;
@@ -90,8 +90,8 @@ public:
 
     void writeRequest(::transport::TransportMessage const& message) override
     {
-        fTransportMessage.setSourceId(message.getSourceId());
-        fTransportMessage.setTargetId(message.getTargetId());
+        fTransportMessage.setSourceAddress(message.getSourceId());
+        fTransportMessage.setTargetAddress(message.getTargetId());
         fTransportMessage.append(message.getPayload(), message.getPayloadLength());
         fTransportMessage.setPayloadLength(message.getPayloadLength());
     }
@@ -100,7 +100,7 @@ public:
     {
         fTransportMessage.init(
             fTransportMessage.getPayload(), fTransportMessage.getPayloadLength());
-        fTransportMessage.setSourceId(::transport::TransportMessage::INVALID_ADDRESS);
+        fTransportMessage.setSourceAddress(::transport::TransportMessage::INVALID_ADDRESS);
     }
 
 private:
@@ -126,8 +126,8 @@ TEST_F(ResumableResetDriverTest, driverStoresTransportMessageAndForcesShutdown)
         fLifecycleAdmin, _context, fResumableResetDriverPersistence, fTransportMessage);
     cut.resume(fDiagDispatcher);
     EXPECT_CALL(fDiagDispatcher, resume(_, _)).Times(0);
-    fTransportMessage.setSourceId(0x1234);
-    fTransportMessage.setTargetId(0x5678);
+    fTransportMessage.setSourceAddress(0x1234);
+    fTransportMessage.setTargetAddress(0x5678);
     uint8_t const payload[] = {0x22, 0x34};
     fTransportMessage.append(payload, sizeof(payload));
     fTransportMessage.setPayloadLength(sizeof(payload));
@@ -153,7 +153,7 @@ TEST_F(ResumableResetDriverTest, driverResetsStoredTransportMessageIfNoneGivenIn
         fLifecycleAdmin, _context, fResumableResetDriverPersistence, fTransportMessage);
     cut.resume(fDiagDispatcher);
     EXPECT_CALL(fDiagDispatcher, resume(_, _)).Times(0);
-    fResumableResetDriverPersistence.getTransportMessage().setSourceId(1U);
+    fResumableResetDriverPersistence.getTransportMessage().setSourceAddress(1U);
     ASSERT_TRUE(cut.prepareReset());
     EXPECT_EQ(
         uint32_t(TransportMessage::INVALID_ADDRESS),
@@ -167,8 +167,8 @@ TEST_F(ResumableResetDriverTest, driverResumesTransportMessageOnStartupIfStored)
 {
     ResumableResetDriver cut(
         fLifecycleAdmin, _context, fResumableResetDriverPersistence, fTransportMessage);
-    fResumableResetDriverPersistence.getTransportMessage().setSourceId(0x1425);
-    fResumableResetDriverPersistence.getTransportMessage().setTargetId(0x6823);
+    fResumableResetDriverPersistence.getTransportMessage().setSourceAddress(0x1425);
+    fResumableResetDriverPersistence.getTransportMessage().setTargetAddress(0x6823);
     uint8_t const payload[] = {0x34, 0x38};
     fResumableResetDriverPersistence.getTransportMessage().append(payload, sizeof(payload));
     fResumableResetDriverPersistence.getTransportMessage().setPayloadLength(sizeof(payload));
@@ -184,8 +184,8 @@ TEST_F(ResumableResetDriverTest, driverClearsPersistenceOnStartupIfEmptyMessageS
 {
     ResumableResetDriver cut(
         fLifecycleAdmin, _context, fResumableResetDriverPersistence, fTransportMessage);
-    fResumableResetDriverPersistence.getTransportMessage().setSourceId(0x1425);
-    fResumableResetDriverPersistence.getTransportMessage().setTargetId(0x6823);
+    fResumableResetDriverPersistence.getTransportMessage().setSourceAddress(0x1425);
+    fResumableResetDriverPersistence.getTransportMessage().setTargetAddress(0x6823);
     cut.resume(fDiagDispatcher);
     EXPECT_EQ(
         uint32_t(TransportMessage::INVALID_ADDRESS),
@@ -197,8 +197,8 @@ TEST_F(ResumableResetDriverTest, prepareResetFailsIfModeChangeIsNotAllowed)
     ResumableResetDriver cut(
         fLifecycleAdmin, _context, fResumableResetDriverPersistence, fTransportMessage);
     cut.resume(fDiagDispatcher);
-    fTransportMessage.setSourceId(0x1234);
-    fTransportMessage.setTargetId(0x5678);
+    fTransportMessage.setSourceAddress(0x1234);
+    fTransportMessage.setTargetAddress(0x5678);
     uint8_t const payload[] = {0x22, 0x34};
     fTransportMessage.append(payload, sizeof(payload));
     fTransportMessage.setPayloadLength(sizeof(payload));
@@ -214,8 +214,8 @@ TEST_F(ResumableResetDriverTest, driverAbortsResetIfShutdownFails)
     ResumableResetDriver cut(
         fLifecycleAdmin, _context, fResumableResetDriverPersistence, fTransportMessage);
     cut.resume(fDiagDispatcher);
-    fTransportMessage.setSourceId(0x1234);
-    fTransportMessage.setTargetId(0x5678);
+    fTransportMessage.setSourceAddress(0x1234);
+    fTransportMessage.setTargetAddress(0x5678);
     uint8_t const payload[] = {0x22, 0x34};
     fTransportMessage.append(payload, sizeof(payload));
     fTransportMessage.setPayloadLength(sizeof(payload));
@@ -249,8 +249,8 @@ TEST_F(ResumableResetDriverTest, driverListensToLifecycleEvents)
         0x6677,
         300U);
     cut.init(fDiagDispatcher);
-    fResumableResetDriverPersistence.getTransportMessage().setSourceId(0x6321);
-    fResumableResetDriverPersistence.getTransportMessage().setTargetId(0x6823);
+    fResumableResetDriverPersistence.getTransportMessage().setSourceAddress(0x6321);
+    fResumableResetDriverPersistence.getTransportMessage().setTargetAddress(0x6823);
     uint8_t const payload[] = {0x34, 0x38};
     fResumableResetDriverPersistence.getTransportMessage().append(payload, sizeof(payload));
     fResumableResetDriverPersistence.getTransportMessage().setPayloadLength(sizeof(payload));
@@ -276,8 +276,8 @@ TEST_F(
         IUdsLifecycleConnector::POWER_DOWN,
         0x6677,
         300U);
-    fResumableResetDriverPersistence.getTransportMessage().setSourceId(0x1425);
-    fResumableResetDriverPersistence.getTransportMessage().setTargetId(0x6823);
+    fResumableResetDriverPersistence.getTransportMessage().setSourceAddress(0x1425);
+    fResumableResetDriverPersistence.getTransportMessage().setTargetAddress(0x6823);
     uint8_t const payload[] = {0x34, 0x38};
     fResumableResetDriverPersistence.getTransportMessage().append(payload, sizeof(payload));
     fResumableResetDriverPersistence.getTransportMessage().setPayloadLength(sizeof(payload));
@@ -300,8 +300,8 @@ TEST_F(ResumableResetDriverTest, driverResumesTransportMessageAfterTimeoutInCase
         IUdsLifecycleConnector::POWER_DOWN,
         0x6677,
         300U);
-    fResumableResetDriverPersistence.getTransportMessage().setSourceId(0x6677);
-    fResumableResetDriverPersistence.getTransportMessage().setTargetId(0x6823);
+    fResumableResetDriverPersistence.getTransportMessage().setSourceAddress(0x6677);
+    fResumableResetDriverPersistence.getTransportMessage().setTargetAddress(0x6823);
     uint8_t const payload[] = {0x34, 0x38};
     fResumableResetDriverPersistence.getTransportMessage().append(payload, sizeof(payload));
     fResumableResetDriverPersistence.getTransportMessage().setPayloadLength(sizeof(payload));
@@ -330,8 +330,8 @@ TEST_F(
         IUdsLifecycleConnector::POWER_DOWN,
         0x6677,
         0U);
-    fResumableResetDriverPersistence.getTransportMessage().setSourceId(0x6677);
-    fResumableResetDriverPersistence.getTransportMessage().setTargetId(0x6823);
+    fResumableResetDriverPersistence.getTransportMessage().setSourceAddress(0x6677);
+    fResumableResetDriverPersistence.getTransportMessage().setTargetAddress(0x6823);
     uint8_t const payload[] = {0x34, 0x38};
     fResumableResetDriverPersistence.getTransportMessage().append(payload, sizeof(payload));
     fResumableResetDriverPersistence.getTransportMessage().setPayloadLength(sizeof(payload));

--- a/libs/bsw/uds/test/src/uds/services/CommunicationControlTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/CommunicationControlTest.cpp
@@ -96,7 +96,7 @@ CommunicationControlTest::CommunicationControlTest()
 , request(1024)
 {
     AbstractDiagJob::setDefaultDiagSessionManager(_sessionManager);
-    _conn.fpRequestMessage = request.get();
+    _conn.requestMessage = request.get();
 }
 
 TEST_F(CommunicationControlTest, VariableLengthConstructor)

--- a/libs/bsw/uds/test/src/uds/services/controldtcsetting/ControlDTCSettingTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/controldtcsetting/ControlDTCSettingTest.cpp
@@ -42,7 +42,7 @@ TEST_F(
 
     TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
 
-    fIncomingDiagConnection.fpRequestMessage = pRequest.get();
+    fIncomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_EXTENDED_SESSION()));
@@ -66,7 +66,7 @@ TEST_F(
 
     TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
 
-    fIncomingDiagConnection.fpRequestMessage = pRequest.get();
+    fIncomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_EXTENDED_SESSION()));
@@ -90,7 +90,7 @@ TEST_F(
 
     TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
 
-    fIncomingDiagConnection.fpRequestMessage = pRequest.get();
+    fIncomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_EXTENDED_SESSION()));

--- a/libs/bsw/uds/test/src/uds/services/readdata/MultipleReadDataByIdentifierTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/readdata/MultipleReadDataByIdentifierTest.cpp
@@ -151,8 +151,8 @@ public:
         fDiagRoot.addAbstractDiagJob(fDiagJob);
         fMyMultipleReadDataByIdentifier.setDefaultDiagSessionManager(fSessionManager);
         fMyMultipleReadDataByIdentifierWithFirstJob.setDefaultDiagSessionManager(fSessionManager);
-        fIncomingDiagConnection.fOpen      = true;
-        fIncomingDiagConnection.fServiceId = ::ServiceId::READ_DATA_BY_IDENTIFIER;
+        fIncomingDiagConnection.isOpen    = true;
+        fIncomingDiagConnection.serviceId = ::ServiceId::READ_DATA_BY_IDENTIFIER;
 
         fMyMultipleReadDataByIdentifier.addAbstractDiagJob(fDiagJob);
         fDiagRoot.addAbstractDiagJob(fDiagJob);
@@ -312,9 +312,9 @@ TEST_F(
     TransportMessageWithBuffer pRequest(
         SOURCE_ID, TARGET_ID, DATA_IDENTIFIERS_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
-    fIncomingDiagConnection.fpRequestMessage     = pRequest.get();
-    fIncomingDiagConnection.fpMessageSender      = &fUdsDispatcher;
-    fIncomingDiagConnection.fpDiagSessionManager = &fSessionManager;
+    fIncomingDiagConnection.requestMessage     = pRequest.get();
+    fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
+    fIncomingDiagConnection.diagSessionManager = &fSessionManager;
 
     EXPECT_CALL(fDiagJob, verify(_, _)).WillOnce(Return(DiagReturnCode::OK));
 
@@ -350,8 +350,8 @@ TEST_F(
     CONTEXT_EXECUTE;
 
     auto buffer = ::etl::span<uint8_t const>(
-        fIncomingDiagConnection.fpResponseMessage->getPayload(),
-        fIncomingDiagConnection.fpResponseMessage->getPayloadLength());
+        fIncomingDiagConnection.responseMessage->getPayload(),
+        fIncomingDiagConnection.responseMessage->getPayloadLength());
 
     EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
 }
@@ -381,9 +381,9 @@ TEST_F(
     TransportMessageWithBuffer pRequest(
         SOURCE_ID, TARGET_ID, DATA_IDENTIFIERS_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
-    fIncomingDiagConnection.fpRequestMessage     = pRequest.get();
-    fIncomingDiagConnection.fpMessageSender      = &fUdsDispatcher;
-    fIncomingDiagConnection.fpDiagSessionManager = &fSessionManager;
+    fIncomingDiagConnection.requestMessage     = pRequest.get();
+    fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
+    fIncomingDiagConnection.diagSessionManager = &fSessionManager;
 
     Sequence seq;
 
@@ -432,8 +432,8 @@ TEST_F(
     CONTEXT_EXECUTE;
 
     auto buffer = ::etl::span<uint8_t const>(
-        fIncomingDiagConnection.fpResponseMessage->getPayload(),
-        fIncomingDiagConnection.fpResponseMessage->getPayloadLength());
+        fIncomingDiagConnection.responseMessage->getPayload(),
+        fIncomingDiagConnection.responseMessage->getPayloadLength());
 
     EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
 }
@@ -466,9 +466,9 @@ TEST_F(
             MultipleReadDataByIdentifierTest,
             &MultipleReadDataByIdentifierTest::checkResponse>(*this));
 
-    fIncomingDiagConnection.fpRequestMessage     = pRequest.get();
-    fIncomingDiagConnection.fpMessageSender      = &fUdsDispatcher;
-    fIncomingDiagConnection.fpDiagSessionManager = &fSessionManager;
+    fIncomingDiagConnection.requestMessage     = pRequest.get();
+    fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
+    fIncomingDiagConnection.diagSessionManager = &fSessionManager;
 
     Sequence seq;
 
@@ -511,8 +511,8 @@ TEST_F(
     CONTEXT_EXECUTE;
 
     auto buffer = ::etl::span<uint8_t const>(
-        fIncomingDiagConnection.fpResponseMessage->getPayload(),
-        fIncomingDiagConnection.fpResponseMessage->getPayloadLength());
+        fIncomingDiagConnection.responseMessage->getPayload(),
+        fIncomingDiagConnection.responseMessage->getPayloadLength());
 
     EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
 }
@@ -545,9 +545,9 @@ TEST_F(
     TransportMessageWithBuffer pRequest(
         SOURCE_ID, TARGET_ID, DATA_IDENTIFIERS_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
-    fIncomingDiagConnection.fpRequestMessage     = pRequest.get();
-    fIncomingDiagConnection.fpMessageSender      = &fUdsDispatcher;
-    fIncomingDiagConnection.fpDiagSessionManager = &fSessionManager;
+    fIncomingDiagConnection.requestMessage     = pRequest.get();
+    fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
+    fIncomingDiagConnection.diagSessionManager = &fSessionManager;
 
     EXPECT_CALL(fDiagJob, verify(_, _)).WillOnce(Return(DiagReturnCode::OK));
 
@@ -598,8 +598,8 @@ TEST_F(
     Mock::VerifyAndClearExpectations(&fSessionManager);
 
     auto buffer = ::etl::span<uint8_t const>(
-        fIncomingDiagConnection.fpResponseMessage->getPayload(),
-        fIncomingDiagConnection.fpResponseMessage->getPayloadLength());
+        fIncomingDiagConnection.responseMessage->getPayload(),
+        fIncomingDiagConnection.responseMessage->getPayloadLength());
 
     EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
 }
@@ -627,9 +627,9 @@ TEST_F(
         INVALID_DATA_IDENTIFIERS_REQUEST,
         AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
-    fIncomingDiagConnection.fpRequestMessage     = pRequest.get();
-    fIncomingDiagConnection.fpMessageSender      = &fUdsDispatcher;
-    fIncomingDiagConnection.fpDiagSessionManager = &fSessionManager;
+    fIncomingDiagConnection.requestMessage     = pRequest.get();
+    fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
+    fIncomingDiagConnection.diagSessionManager = &fSessionManager;
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -664,8 +664,8 @@ TEST_F(
     CONTEXT_EXECUTE;
 
     auto buffer = ::etl::span<uint8_t const>(
-        fIncomingDiagConnection.fpResponseMessage->getPayload(),
-        fIncomingDiagConnection.fpResponseMessage->getPayloadLength());
+        fIncomingDiagConnection.responseMessage->getPayload(),
+        fIncomingDiagConnection.responseMessage->getPayloadLength());
 
     EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
 }
@@ -693,9 +693,9 @@ TEST_F(
         INVALID_DATA_IDENTIFIERS_REQUEST,
         AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
-    fIncomingDiagConnection.fpRequestMessage     = pRequest.get();
-    fIncomingDiagConnection.fpMessageSender      = &fUdsDispatcher;
-    fIncomingDiagConnection.fpDiagSessionManager = &fSessionManager;
+    fIncomingDiagConnection.requestMessage     = pRequest.get();
+    fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
+    fIncomingDiagConnection.diagSessionManager = &fSessionManager;
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -728,8 +728,8 @@ TEST_F(
     CONTEXT_EXECUTE;
 
     auto buffer = ::etl::span<uint8_t const>(
-        fIncomingDiagConnection.fpResponseMessage->getPayload(),
-        fIncomingDiagConnection.fpResponseMessage->getPayloadLength());
+        fIncomingDiagConnection.responseMessage->getPayload(),
+        fIncomingDiagConnection.responseMessage->getPayloadLength());
 
     EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
 }
@@ -765,9 +765,9 @@ TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_checked_if_
     TransportMessageWithBuffer pRequest(
         SOURCE_ID, TARGET_ID, DATA_IDENTIFIERS_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
-    fIncomingDiagConnection.fpRequestMessage     = pRequest.get();
-    fIncomingDiagConnection.fpMessageSender      = &fUdsDispatcher;
-    fIncomingDiagConnection.fpDiagSessionManager = &fSessionManager;
+    fIncomingDiagConnection.requestMessage     = pRequest.get();
+    fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
+    fIncomingDiagConnection.diagSessionManager = &fSessionManager;
 
     EXPECT_CALL(fDiagJob, verify(_, _)).WillOnce(Return(DiagReturnCode::OK));
 
@@ -820,8 +820,8 @@ TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_checked_if_
     Mock::VerifyAndClearExpectations(&fSessionManager);
 
     auto buffer = ::etl::span<uint8_t const>(
-        fIncomingDiagConnection.fpResponseMessage->getPayload(),
-        fIncomingDiagConnection.fpResponseMessage->getPayloadLength());
+        fIncomingDiagConnection.responseMessage->getPayload(),
+        fIncomingDiagConnection.responseMessage->getPayloadLength());
 
     EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
 }
@@ -857,9 +857,9 @@ TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_not_checked
     TransportMessageWithBuffer pRequest(
         SOURCE_ID, TARGET_ID, DATA_IDENTIFIERS_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
-    fIncomingDiagConnection.fpRequestMessage     = pRequest.get();
-    fIncomingDiagConnection.fpMessageSender      = &fUdsDispatcher;
-    fIncomingDiagConnection.fpDiagSessionManager = &fSessionManager;
+    fIncomingDiagConnection.requestMessage     = pRequest.get();
+    fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
+    fIncomingDiagConnection.diagSessionManager = &fSessionManager;
 
     EXPECT_CALL(fDiagJob, verify(_, _)).WillOnce(Return(DiagReturnCode::OK));
 
@@ -912,8 +912,8 @@ TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_not_checked
     Mock::VerifyAndClearExpectations(&fSessionManager);
 
     auto buffer = ::etl::span<uint8_t const>(
-        fIncomingDiagConnection.fpResponseMessage->getPayload(),
-        fIncomingDiagConnection.fpResponseMessage->getPayloadLength());
+        fIncomingDiagConnection.responseMessage->getPayload(),
+        fIncomingDiagConnection.responseMessage->getPayloadLength());
 
     EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
 }
@@ -935,9 +935,9 @@ TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_returns_ISO
     TransportMessageWithBuffer pRequest(
         SOURCE_ID, TARGET_ID, DATA_IDENTIFIERS_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
-    fIncomingDiagConnection.fpRequestMessage     = pRequest.get();
-    fIncomingDiagConnection.fpMessageSender      = &fUdsDispatcher;
-    fIncomingDiagConnection.fpDiagSessionManager = &fSessionManager;
+    fIncomingDiagConnection.requestMessage     = pRequest.get();
+    fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
+    fIncomingDiagConnection.diagSessionManager = &fSessionManager;
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));

--- a/libs/bsw/uds/test/src/uds/services/readdata/ReadDataByIdentifierTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/readdata/ReadDataByIdentifierTest.cpp
@@ -81,7 +81,7 @@ TEST_F(
     TransportMessageWithBuffer pRequest(
         SOURCE_ID, TARGET_ID, VALID_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
-    fIncomingDiagConnection.fpRequestMessage = pRequest.get();
+    fIncomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -107,7 +107,7 @@ TEST_F(
     TransportMessageWithBuffer pRequest(
         SOURCE_ID, TARGET_ID, INVALID_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
-    fIncomingDiagConnection.fpRequestMessage = pRequest.get();
+    fIncomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -130,7 +130,7 @@ TEST_F(
     TransportMessageWithBuffer pRequest(
         SOURCE_ID, TARGET_ID, INVALID_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
-    fIncomingDiagConnection.fpRequestMessage = pRequest.get();
+    fIncomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));

--- a/libs/bsw/uds/test/src/uds/services/routinecontrol/RoutineControlTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/routinecontrol/RoutineControlTest.cpp
@@ -80,7 +80,7 @@ TEST_F(
 
     TransportMessageWithBuffer pRequest(SOURCE_ID, TARGET_ID, VALID_REQUEST, RESPONSE_LENGTH);
 
-    fIncomingDiagConnection.fpRequestMessage = pRequest.get();
+    fIncomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -104,7 +104,7 @@ TEST_F(
 
     TransportMessageWithBuffer pRequest(SOURCE_ID, TARGET_ID, INVALID_REQUEST, RESPONSE_LENGTH);
 
-    fIncomingDiagConnection.fpRequestMessage = pRequest.get();
+    fIncomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -127,7 +127,7 @@ TEST_F(
 
     TransportMessageWithBuffer pRequest(SOURCE_ID, TARGET_ID, INVALID_REQUEST, RESPONSE_LENGTH);
 
-    fIncomingDiagConnection.fpRequestMessage = pRequest.get();
+    fIncomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));

--- a/libs/bsw/uds/test/src/uds/services/sessioncontrol/DiagnosticSessionControlTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/sessioncontrol/DiagnosticSessionControlTest.cpp
@@ -87,8 +87,8 @@ struct DiagnosticSessionControlTest : ::testing::Test
     {
         fResponseMessage.init(fRequestBuffer.data(), fRequestBuffer.size());
 
-        fIncomingDiagConnection.fpRequestMessage = &fResponseMessage;
-        fIncomingDiagConnection.fSourceId        = 0x10U;
+        fIncomingDiagConnection.requestMessage = &fResponseMessage;
+        fIncomingDiagConnection.sourceAddress  = 0x10U;
 
         fDiagnosticSessionControl.addDiagSessionListener(fDiagSessionChangedListener);
     }
@@ -415,7 +415,7 @@ TEST_F(
     transport::TransportMessage responseMessage;
     ::etl::array<uint8_t, 4> requestBuffer{};
     responseMessage.init(requestBuffer.data(), requestBuffer.size());
-    fIncomingDiagConnection.fpRequestMessage = &responseMessage;
+    fIncomingDiagConnection.requestMessage = &responseMessage;
 
     EXPECT_EQ(
         DiagReturnCode::ISO_RESPONSE_TOO_LONG,

--- a/libs/bsw/uds/test/src/uds/services/testerpresent/TesterPresentTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/testerpresent/TesterPresentTest.cpp
@@ -39,7 +39,7 @@ TEST_F(TesterPresentTest, process_which_is_called_by_execute_should_return_DiagR
 
     TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
 
-    fIncomingDiagConnection.fpRequestMessage = pRequest.get();
+    fIncomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -62,7 +62,7 @@ TEST_F(
 
     TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
 
-    fIncomingDiagConnection.fpRequestMessage = pRequest.get();
+    fIncomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));

--- a/libs/bsw/uds/test/src/uds/services/writedata/WriteDataByIdentifierTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/writedata/WriteDataByIdentifierTest.cpp
@@ -74,7 +74,7 @@ TEST_F(
 
     TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
 
-    fIncomingDiagConnection.fpRequestMessage = pRequest.get();
+    fIncomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -95,7 +95,7 @@ TEST_F(
 
     TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
 
-    fIncomingDiagConnection.fpRequestMessage = pRequest.get();
+    fIncomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
@@ -116,7 +116,7 @@ TEST_F(
 
     TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
 
-    fIncomingDiagConnection.fpRequestMessage = pRequest.get();
+    fIncomingDiagConnection.requestMessage = pRequest.get();
 
     EXPECT_CALL(fSessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));


### PR DESCRIPTION
The use of the term source/target "ID" is replaced with source/target "Address" since that reflects the terminology used in the UDS specification

This also updates various names to a uniform naming convention, where private members are prefixed with an undercore and public ones have no prefix.

Note that this is not complete: I had to stop at some point to not have the scope escalate, but more similar
renames will follow to get everything consistent eventually.