### PR TITLE
Use ETL_OR_STD for swap()

### DIFF
--- a/platforms/s32k1xx/bsp/bspEthernet/src/ethernet/RxBuffers.cpp
+++ b/platforms/s32k1xx/bsp/bspEthernet/src/ethernet/RxBuffers.cpp
@@ -21,8 +21,8 @@ uint8_t freeRxDescriptorIndex(
     auto const pbuf1 = reinterpret_cast<::lwiputils::RxCustomPbuf*>(pbufAtIndex[nextBusy]);
     auto const pbuf2 = reinterpret_cast<::lwiputils::RxCustomPbuf*>(pbufAtIndex[descriptorIndex]);
 
-    ::etl::swap(pbufAtIndex[nextBusy], pbufAtIndex[descriptorIndex]);
-    ::etl::swap(pbuf1->slot, pbuf2->slot);
+    ::ETL_OR_STD::swap(pbufAtIndex[nextBusy], pbufAtIndex[descriptorIndex]);
+    ::ETL_OR_STD::swap(pbuf1->slot, pbuf2->slot);
 
     return (nextBusy + 1) % pbufAtIndex.size();
 }


### PR DESCRIPTION
As documented at https://www.etlcpp.com/no_stl.html, the intended pattern for some ETL interfaces is to use ETL_OR_STD instead of plain etl namespace because some interfaces can't be implemented in namespace etl due to conflicts with std when in ETL_USING_STL mode (e.g. due to ADL).

This change enables OpenBSW to be compiled both with and without ETL_NO_STL in etl_profile.h