### PR TITLE
Initialize boolean flag to send Response Pending messages in UDS.

### DIFF
--- a/libs/bsw/uds/include/uds/DiagnosisConfiguration.h
+++ b/libs/bsw/uds/include/uds/DiagnosisConfiguration.h
@@ -58,6 +58,7 @@ public:
     , BroadcastAddress(broadcastAddress)
     , MaxResponsePayloadSize(maxResponsePayloadSize)
     , DiagBusId(busId)
+    , ActivateOutgoingPending(true)
     , AcceptAllRequests(acceptAllRequests)
     , CopyFunctionalRequests(copyFunctionalRequests)
     , Context(context)


### PR DESCRIPTION
With PR #219, the flag `activateOutgoingPending` was removed from the initializer list from `class AbstractDiagnosisConfiguration`. 

We think the value still is used however and responsible for the fact that RESPONSE_PENDING messages are not being sent anymore from the UDS stack. With this fix, the value is initialized to true.

We suggest to discuss if this configuration parameter is really needed, or at least should be named differently, e.g. `pendingMessageActivated`.