### PR TITLE
Remove AbstractDiagnosisConfiguration

### DIFF
--- a/executables/referenceApp/application/include/systems/UdsSystem.h
+++ b/executables/referenceApp/application/include/systems/UdsSystem.h
@@ -81,7 +81,9 @@ private:
     DiagJobRoot _jobRoot;
     DiagnosticSessionControl _diagnosticSessionControl;
     CommunicationControl _communicationControl;
-    DiagnosisConfiguration<5, 16> _udsConfiguration;
+    DiagnosisConfiguration _udsConfiguration;
+    ::etl::pool<IncomingDiagConnection, 5> _connectionPool;
+    ::etl::queue<transport::TransportJob, 16> _sendJobQueue;
     DiagDispatcher _udsDispatcher;
     uds::declare::AsyncDiagHelper<5> _asyncDiagHelper;
 

--- a/executables/referenceApp/application/src/systems/UdsSystem.cpp
+++ b/executables/referenceApp/application/src/systems/UdsSystem.cpp
@@ -30,15 +30,17 @@ UdsSystem::UdsSystem(
 , _jobRoot()
 , _diagnosticSessionControl(_udsLifecycleConnector, context, _dummySessionPersistence)
 , _communicationControl()
-, _udsConfiguration(
+, _udsConfiguration{
       udsAddress,
       transport::TransportConfiguration::FUNCTIONAL_ALL_ISO14229,
-      ::busid::SELFDIAG,
       transport::TransportConfiguration::DIAG_PAYLOAD_SIZE,
+      ::busid::SELFDIAG,
+      true,  /* activate outgoing pending */
       false, /* accept all requests */
       true,  /* copy functional requests */
-      context)
-, _udsDispatcher(_udsConfiguration, _diagnosticSessionControl, _jobRoot)
+      context}
+, _udsDispatcher(
+      _connectionPool, _sendJobQueue, _udsConfiguration, _diagnosticSessionControl, _jobRoot)
 , _asyncDiagHelper(context)
 , _readDataByIdentifier()
 , _writeDataByIdentifier()

--- a/libs/bsw/uds/doc/user/dispatcher.rst
+++ b/libs/bsw/uds/doc/user/dispatcher.rst
@@ -42,7 +42,7 @@ within the same branch of the hierarchy is maintained**.
     ReadIdentifierFromMemory _read22Cf01;
     ReadIdentifierFromNvStorage _read22Cf02;
 
-    void createDispatcher(AbstractDiagnosisConfiguration& configuration,
+    void createDispatcher(DiagnosisConfiguration& configuration,
         IDiagSessionManager& sessionManager,
         DiagJobRoot& jobRoot,
         ::async::ContextType context)

--- a/libs/bsw/uds/include/uds/DiagDispatcher.h
+++ b/libs/bsw/uds/include/uds/DiagDispatcher.h
@@ -13,7 +13,10 @@
 #include <transport/AbstractTransportLayer.h>
 #include <transport/ITransportMessageProcessedListener.h>
 #include <transport/ITransportMessageProvidingListener.h>
+#include <transport/TransportJob.h>
 #include <transport/TransportMessage.h>
+
+#include <etl/queue.h>
 
 #ifdef IS_VARIANT_HANDLING_NEEDED
 #include "uds/DiagnosisConfiguration.h"
@@ -51,14 +54,16 @@ class DiagDispatcher
 public:
     /**
      * Constructor
-     * \param   configuration   AbstractDiagnosisConfiguration holding
+     * \param   configuration   DiagnosisConfiguration holding
      * the configuration for this DiagDispatcher
      * \param   sessionManager  IDiagSessionManager
      * \param   context  Context used to handle DiagDispatcher's
      * timeouts
      */
     DiagDispatcher(
-        AbstractDiagnosisConfiguration& configuration,
+        ::etl::ipool& incomingDiagConnectionPool,
+        ::etl::iqueue<transport::TransportJob>& sendJobQueue,
+        DiagnosisConfiguration& configuration,
         IDiagSessionManager& sessionManager,
         DiagJobRoot& jobRoot);
 
@@ -145,7 +150,7 @@ private:
 
     static void dispatchIncomingRequest(
         transport::TransportJob& job,
-        AbstractDiagnosisConfiguration& configuration,
+        DiagnosisConfiguration& configuration,
         DiagDispatcher& dispatcher,
         DiagJobRoot& diagJobRoot,
         transport::ITransportMessageProvidingListener& providingListener,
@@ -166,7 +171,7 @@ private:
     static transport::TransportMessage* copyFunctionalRequest(
         transport::TransportMessage& request,
         transport::ITransportMessageProvidingListener& providingListener,
-        AbstractDiagnosisConfiguration& configuration);
+        DiagnosisConfiguration& configuration);
 
     IncomingDiagConnection* requestIncomingConnection(transport::TransportMessage& requestMessage);
 
@@ -174,7 +179,9 @@ private:
 
     void checkConnectionShutdownProgress();
 
-    AbstractDiagnosisConfiguration& fConfiguration;
+    ::etl::ipool& incomingDiagConnectionPool;
+    ::etl::iqueue<transport::TransportJob>& sendJobQueue;
+    DiagnosisConfiguration& fConfiguration;
     ::etl::delegate<void()> fConnectionShutdownDelegate;
     bool fConnectionShutdownRequested;
 

--- a/libs/bsw/uds/include/uds/DiagnosisConfiguration.h
+++ b/libs/bsw/uds/include/uds/DiagnosisConfiguration.h
@@ -15,63 +15,9 @@
 
 namespace uds
 {
-/**
- * Interface to the DiagnosisConfiguration used by client classes.
- *
- * This class does only use container classes that are independent of a
- * static size. So any class using this configuration should be implemented
- * that way, e.g. use size() and max_size() functions of container classes.
- */
-class AbstractDiagnosisConfiguration
+struct DiagnosisConfiguration
 {
-public:
-    /**
-     * Constructor
-     * @param   diagAddress Diagnosis address of this configuration. Used e.g.
-     * by DiagDispatcher to filter incoming requests.
-     * @param   broadcastAddress    In addition to the specific diagnosis address
-     * a diagnosis layer may also receive requests that are broadcasted within
-     * the system.
-     * @param   busId   The diagnosis layers BusId.
-     * being sent automatically by an IncomingDiagConnection.
-     * @param   copyFunctionalRequests  Copy functional requests before processing.
-     * To keep the default behaviour use 'true' here, otherwise it is up to the
-     * application to provide only maximum sized messages that may be modified to
-     * the dispatcher.
-     */
-    AbstractDiagnosisConfiguration(
-        uint16_t const diagAddress,
-        uint16_t const broadcastAddress,
-        uint8_t const busId,
-        uint16_t const maxResponsePayloadSize,
-        bool const acceptAllRequests,
-        bool const copyFunctionalRequests,
-        ::etl::ipool& incomingPool,
-        ::etl::iqueue<transport::TransportJob>& sendJobQueue,
-        ::async::ContextType const context)
-    : IncomingDiagConnectionPool(incomingPool)
-    , SendJobQueue(sendJobQueue)
-    , DiagAddress(diagAddress)
-    , BroadcastAddress(broadcastAddress)
-    , MaxResponsePayloadSize(maxResponsePayloadSize)
-    , DiagBusId(busId)
-    , ActivateOutgoingPending(true)
-    , AcceptAllRequests(acceptAllRequests)
-    , CopyFunctionalRequests(copyFunctionalRequests)
-    , Context(context)
-    {}
-
-public:
-    ::etl::ipool& IncomingDiagConnectionPool;
-
-    ::etl::iqueue<transport::TransportJob>& SendJobQueue;
-
-#ifdef IS_VARIANT_HANDLING_NEEDED
     uint16_t DiagAddress;
-#else
-    uint16_t const DiagAddress;
-#endif
-
     uint16_t const BroadcastAddress;
     uint16_t const MaxResponsePayloadSize;
     uint8_t DiagBusId;
@@ -79,11 +25,6 @@ public:
     bool AcceptAllRequests;
     bool CopyFunctionalRequests;
     ::async::ContextType Context;
-
-    /**
-     * Returns an acquired IncomingDiagConnection initialized with the appropriate async
-     * context, nullptr if no connection is available.
-     */
 };
 
 inline IncomingDiagConnection*
@@ -95,48 +36,5 @@ acquireIncomingDiagConnection(::etl::ipool& pool, ::async::ContextType context)
     }
     return pool.template create<IncomingDiagConnection>(context);
 }
-
-/**
- * Configuration for a diagnosis layer
- * @tparam  NUM_INCOMING_CONNECTIONS    number of incoming connections that are
- * handled by the layer (i.e. simultaneous requests from outside to the layer)
- * @tparam  MAX_NUM_INCOMING_MESSAGES   this parameter specifies the maximum
- * number of TransportMessages that can be queued inside the diagnosis
- * layer. For a functional request this number should equal the number of
- * TransportMessages available in the system.
- */
-template<uint8_t NUM_INCOMING_CONNECTIONS, uint8_t MAX_NUM_INCOMING_MESSAGES>
-class DiagnosisConfiguration : public AbstractDiagnosisConfiguration
-{
-public:
-    /**
-     * Constructor
-     */
-    explicit DiagnosisConfiguration(
-        uint16_t const diagAddress,
-        uint16_t const broadcastAddress,
-        uint8_t const busId,
-        uint16_t const maxResponsePayloadSize,
-        bool const acceptAllRequests,
-        bool const copyFunctionalRequests,
-        ::async::ContextType const context)
-    : AbstractDiagnosisConfiguration(
-        diagAddress,
-        broadcastAddress,
-        busId,
-        maxResponsePayloadSize,
-        acceptAllRequests,
-        copyFunctionalRequests,
-        fIncomingDiagConnectionPool,
-        fSendJobQueue,
-        context)
-    , fIncomingDiagConnectionPool()
-    , fSendJobQueue()
-    {}
-
-private:
-    ::etl::pool<IncomingDiagConnection, NUM_INCOMING_CONNECTIONS> fIncomingDiagConnectionPool;
-    ::etl::queue<transport::TransportJob, MAX_NUM_INCOMING_MESSAGES> fSendJobQueue;
-};
 
 } // namespace uds

--- a/libs/bsw/uds/test/src/uds/services/readdata/MultipleReadDataByIdentifierTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/readdata/MultipleReadDataByIdentifierTest.cpp
@@ -132,15 +132,9 @@ public:
           ,
           DiagSession::ALL_SESSIONS())
     , fIncomingDiagConnection(fContext)
-    , fUdsConfiguration(
-          0x10U,
-          0xDFU,
-          0u,
-          transport::TransportConfiguration::DIAG_PAYLOAD_SIZE,
-          false,
-          true,
-          fContext)
-    , fUdsDispatcher(fUdsConfiguration, fSessionManager, fDiagJobRoot)
+    , fUdsConfiguration{0x10U, 0xDFU, transport::TransportConfiguration::DIAG_PAYLOAD_SIZE, 0u, true, false, true, fContext}
+    , fUdsDispatcher(
+          _connectionPool, _sendJobQueue, fUdsConfiguration, fSessionManager, fDiagJobRoot)
     {}
 
     virtual void SetUp()
@@ -180,7 +174,9 @@ protected:
     StrictMock<AbstractDiagJobMock> fDiagJob2;
     StrictMock<IncomingDiagConnectionMock> fIncomingDiagConnection;
     StrictMock<DiagSessionManagerMock> fSessionManager;
-    DiagnosisConfiguration<NUM_INCOMING_CONNECTIONS, 1> fUdsConfiguration;
+    DiagnosisConfiguration fUdsConfiguration;
+    ::etl::pool<IncomingDiagConnection, NUM_INCOMING_CONNECTIONS> _connectionPool;
+    ::etl::queue<transport::TransportJob, 1> _sendJobQueue;
     DiagDispatcher fUdsDispatcher;
     DiagJobRoot fDiagJobRoot;
 

--- a/libs/bsw/uds/test/src/uds/services/sessioncontrol/DiagnosticSessionControlTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/sessioncontrol/DiagnosticSessionControlTest.cpp
@@ -381,17 +381,25 @@ TEST_F(
 
     DiagJobRoot fDiagJobRoot;
 
-    DiagnosisConfiguration<1, 10> udsConfiguration(
+    ::etl::pool<IncomingDiagConnection, 1> _connectionPool;
+    ::etl::queue<transport::TransportJob, 10> _sendJobQueue;
+
+    DiagnosisConfiguration udsConfiguration{
         0x10U,
         0xDFU,
-        0u,
         transport::TransportConfiguration::DIAG_PAYLOAD_SIZE,
+        0u,
+        true,
         false,
         true,
-        static_cast<::async::ContextType>(1U));
+        static_cast<::async::ContextType>(1U)};
 
     DiagDispatcher dispatcher(
-        udsConfiguration, static_cast<IDiagSessionManager&>(diagSessionManager), fDiagJobRoot);
+        _connectionPool,
+        _sendJobQueue,
+        udsConfiguration,
+        static_cast<IDiagSessionManager&>(diagSessionManager),
+        fDiagJobRoot);
 
     fDiagnosticSessionControl.setDiagDispatcher(&dispatcher);
 


### PR DESCRIPTION
By moving the templated container types out and using the ETL provided interface types the need for an abstract class was removed.