### PR TITLE
Simplify response source address logic

### DIFF
--- a/libs/bsw/uds/include/uds/DiagDispatcher.h
+++ b/libs/bsw/uds/include/uds/DiagDispatcher.h
@@ -95,8 +95,6 @@ public:
 
     void shutdownIncomingConnections(::etl::delegate<void()> delegate);
 
-    uint16_t getDispatcherSourceId() const override { return fConfiguration.DiagAddress; }
-
 private:
     using SendBusyResponseCallback
         = ::etl::delegate<void(transport::TransportMessage const* const)>;

--- a/libs/bsw/uds/include/uds/IDiagDispatcher.h
+++ b/libs/bsw/uds/include/uds/IDiagDispatcher.h
@@ -31,8 +31,6 @@ public:
     : fSessionManager(sessionManager), fEnabled(true)
     {}
 
-    virtual uint16_t getDispatcherSourceId() const = 0;
-
     virtual ::transport::AbstractTransportLayer::ErrorCode resume(
         ::transport::TransportMessage& transportMessage,
         ::transport::ITransportMessageProcessedListener* pNotificationListener)

--- a/libs/bsw/uds/include/uds/connection/IncomingDiagConnection.h
+++ b/libs/bsw/uds/include/uds/connection/IncomingDiagConnection.h
@@ -193,9 +193,11 @@ public:
         uint8_t const request[],
         uint16_t requestLength);
 
-    uint16_t sourceAddress = static_cast<uint16_t>(0xFFU);
-    uint16_t targetAddress = static_cast<uint16_t>(0XFFU);
-    uint8_t serviceId      = 0xFFU;
+    uint16_t sourceAddress         = static_cast<uint16_t>(0xFFU);
+    uint16_t targetAddress         = static_cast<uint16_t>(0xFFU);
+    uint16_t responseSourceAddress = static_cast<uint16_t>(0xFFU);
+
+    uint8_t serviceId = 0xFFU;
 
     /** Time in ms after which the first pending will be sent */
     static uint32_t const INITIAL_PENDING_TIMEOUT_MS = 40U;
@@ -236,14 +238,6 @@ public:
     void restartPendingTimeout();
 
     void sendResponsePending();
-
-    /**
-     * Sets the source id of a given TransportMessage, based on the target id
-     * of the incoming request. If the request was a functional one, the source
-     * id will be set to source id of the DiagDispatcher, otherwise
-     * it'll be set to the target id of this IncomingDiagConnection.
-     */
-    uint16_t sourceAddressForResponse() const;
 
     void asyncTransportMessageProcessed(
         transport::TransportMessage* pTransportMessage, ProcessingResult status);

--- a/libs/bsw/uds/mock/gmock/include/uds/resume/DiagDispatcherMock.h
+++ b/libs/bsw/uds/mock/gmock/include/uds/resume/DiagDispatcherMock.h
@@ -15,8 +15,6 @@ class DiagDispatcherMock : public IDiagDispatcher
 public:
     DiagDispatcherMock(IDiagSessionManager& sessionManager) : IDiagDispatcher(sessionManager) {}
 
-    MOCK_METHOD(uint16_t, getDispatcherSourceId, (), (const));
-
     MOCK_METHOD(
         transport::AbstractTransportLayer::ErrorCode,
         resume,

--- a/libs/bsw/uds/mock/stub/include/UdsStub.h
+++ b/libs/bsw/uds/mock/stub/include/UdsStub.h
@@ -37,8 +37,6 @@ public:
     : IDiagDispatcher(sessionManager, fDiagJobRoot)
     {}
 
-    virtual uint16_t getDispatcherSourceId() const { return 0xab; }
-
     virtual transport::AbstractTransportLayer::ErrorCode
     resume(transport::TransportMessage&, transport::ITransportMessageProcessedListener*)
     {

--- a/libs/bsw/uds/src/uds/DiagDispatcher.cpp
+++ b/libs/bsw/uds/src/uds/DiagDispatcher.cpp
@@ -332,12 +332,18 @@ IncomingDiagConnection* DiagDispatcher::requestIncomingConnection(TransportMessa
     }
     if (pConnection != nullptr)
     {
+        auto const targetAddress = requestMessage.getTargetId();
+
         pConnection->diagDispatcher     = this;
         pConnection->messageSender      = this;
         pConnection->diagSessionManager = &fSessionManager;
         pConnection->sourceAddress      = requestMessage.getSourceId();
-        pConnection->targetAddress      = requestMessage.getTargetId();
-        pConnection->serviceId          = requestMessage.getServiceId();
+        pConnection->targetAddress      = targetAddress;
+        pConnection->responseSourceAddress
+            = (TransportConfiguration::isFunctionalAddress(targetAddress))
+                  ? fConfiguration.DiagAddress
+                  : targetAddress;
+        pConnection->serviceId = requestMessage.getServiceId();
         pConnection->open(fConfiguration.ActivateOutgoingPending);
         pConnection->requestMessage  = &requestMessage;
         pConnection->responseMessage = nullptr;

--- a/libs/bsw/uds/test/src/uds/IntegrationTest.cpp
+++ b/libs/bsw/uds/test/src/uds/IntegrationTest.cpp
@@ -228,8 +228,6 @@ TEST_F(UdsIntegration, positive_response)
             SaveArg<2>(&pProcessedListener),
             Return(transport::ITransportMessageListener::ReceiveResult::RECEIVED_NO_ERROR)));
 
-    EXPECT_EQ(_udsDispatcher.getDispatcherSourceId(), 0x10);
-
     _udsDispatcher.processQueue();
     CONTEXT_EXECUTE;
 

--- a/libs/bsw/uds/test/src/uds/connection/ManagedIncomingDiagConnectionTest.cpp
+++ b/libs/bsw/uds/test/src/uds/connection/ManagedIncomingDiagConnectionTest.cpp
@@ -195,10 +195,11 @@ TEST_F(ManagedIncomingDiagConnectionTest, sendPositiveResponse)
     pExpectedResponse->setPayloadLength(4); // +1 because of 1 identifier (service id)
 
     TransportMessageWithBuffer pRequest(MAX_PAYLOAD_LENGTH);
-    fpIncomingDiagConnection->sourceAddress  = TESTER_ID;
-    fpIncomingDiagConnection->targetAddress  = DIAGNOSIS_ID;
-    fpIncomingDiagConnection->serviceId      = SERVICE_ID;
-    fpIncomingDiagConnection->requestMessage = pRequest.get();
+    fpIncomingDiagConnection->sourceAddress         = TESTER_ID;
+    fpIncomingDiagConnection->targetAddress         = DIAGNOSIS_ID;
+    fpIncomingDiagConnection->responseSourceAddress = DIAGNOSIS_ID;
+    fpIncomingDiagConnection->serviceId             = SERVICE_ID;
+    fpIncomingDiagConnection->requestMessage        = pRequest.get();
     fpIncomingDiagConnection->open(false);
     // save service id
     fpIncomingDiagConnection->addIdentifier();


### PR DESCRIPTION
This puts the logic in the place where all data is already available instead of passing it though multiple classes.