### PR TITLE
Make enqueueMessage a non member function

### DIFF
--- a/libs/bsw/uds/include/uds/DiagDispatcher.h
+++ b/libs/bsw/uds/include/uds/DiagDispatcher.h
@@ -129,12 +129,6 @@ private:
 
     void connectionManagerShutdownComplete();
 
-    transport::AbstractTransportLayer::ErrorCode enqueueMessage(
-        transport::TransportMessage& transportMessage,
-        transport::ITransportMessageProcessedListener* pNotificationListener);
-
-    void trigger();
-
     static void dispatchIncomingRequest(
         transport::TransportJob& job,
         DiagnosisConfiguration& configuration,


### PR DESCRIPTION
The function needs only a very limited set of the DiagDispatcher members, so moving it out reduces coupling and makes it clear what the actual dependencies are.