### PR TITLE
Remove empty PACK_STRUCT_STRUCT definition

### DIFF
--- a/platforms/posix/lwipSysArch/include/arch/cc.h
+++ b/platforms/posix/lwipSysArch/include/arch/cc.h
@@ -14,8 +14,6 @@ typedef unsigned char bool_t;
 
 #define LWIP_CHKSUM_ALGORITHM 3
 
-#define PACK_STRUCT_STRUCT
-
 #define LWIP_PLATFORM_DIAG(x) // printf x;
 
 #define LWIP_PLATFORM_ASSERT(x) assert(x)

--- a/platforms/s32k1xx/lwipSysArch/include/arch/cc.h
+++ b/platforms/s32k1xx/lwipSysArch/include/arch/cc.h
@@ -25,8 +25,6 @@ typedef unsigned char bool_t;
 
 #define MEM_ALIGNMENT 16
 
-#define PACK_STRUCT_STRUCT
-
 /* Mapped LWIP_PLATFORM_DIAG to Logger in openBSW */
 #define LWIP_PLATFORM_DIAG(x) log_lwipInfo x
 


### PR DESCRIPTION
Empty definition was overriding LWIP's automatic compiler detection, causing struct packing issues and crashes.