### PR TITLE
Move DefaultTransportMessageProcessedListener

### DIFF
--- a/libs/bsw/transport/include/transport/ITransportMessageProcessedListener.h
+++ b/libs/bsw/transport/include/transport/ITransportMessageProcessedListener.h
@@ -49,4 +49,16 @@ public:
         = 0;
 };
 
+class DefaultTransportMessageProcessedListener
+: public transport::ITransportMessageProcessedListener
+{
+public:
+    DefaultTransportMessageProcessedListener() {}
+
+    void transportMessageProcessed(
+        transport::TransportMessage& /* transportMessage */,
+        ProcessingResult const /* result */) override
+    {}
+};
+
 } // namespace transport

--- a/libs/bsw/uds/include/uds/DiagDispatcher.h
+++ b/libs/bsw/uds/include/uds/DiagDispatcher.h
@@ -104,23 +104,6 @@ private:
     friend class ::http::html::UdsController;
     friend class IncomingDiagConnection;
 
-    class DefaultTransportMessageProcessedListener
-    : public transport::ITransportMessageProcessedListener
-    , public ::etl::uncopyable
-    {
-    public:
-        DefaultTransportMessageProcessedListener() {}
-
-        /**
-         * \see transport::ITransportMessageProcessedListener::transportMessageProcessed()
-         */
-
-        void transportMessageProcessed(
-            transport::TransportMessage& /* transportMessage */,
-            ProcessingResult const /* result */) override
-        {}
-    };
-
     void connectionManagerShutdownComplete();
 
     static void dispatchIncomingRequest(
@@ -161,7 +144,7 @@ private:
     bool fConnectionShutdownRequested;
 
     ShutdownDelegate fShutdownDelegate;
-    DefaultTransportMessageProcessedListener fDefaultTransportMessageProcessedListener;
+    ::transport::DefaultTransportMessageProcessedListener fDefaultTransportMessageProcessedListener;
     transport::TransportMessage fBusyMessage;
     uint8_t fBusyMessageBuffer[BUSY_MESSAGE_LENGTH + UdsVmsConstants::BUSY_MESSAGE_EXTRA_BYTES];
     ::async::Function fAsyncProcessQueue;


### PR DESCRIPTION
This does not really have much to do with the DiagDispatcher. Putting it next to the interface seems like a natural spot.