### PR TITLE
Remove undefined methods

### DIFF
--- a/executables/referenceApp/platforms/s32k148evb/main/include/lifecycle/StaticBsp.h
+++ b/executables/referenceApp/platforms/s32k148evb/main/include/lifecycle/StaticBsp.h
@@ -81,7 +81,6 @@ public:
 
 private:
     void hwInit();
-    static void releasePins();
 
     class DummyEcuPowerStateController : public bios::IEcuPowerStateController
     {

--- a/executables/unitTest/bsp/bspIo/include/io/Io.h
+++ b/executables/unitTest/bsp/bspIo/include/io/Io.h
@@ -9,9 +9,9 @@ namespace bios
 {
 class Io
 {
-    Io();
-
 public:
+    Io() = delete;
+
     enum Level
     {
         LOW,

--- a/libs/bsp/bspOutputManager/include/outputManager/Output.h
+++ b/libs/bsp/bspOutputManager/include/outputManager/Output.h
@@ -29,9 +29,9 @@ public:
     // Api for all DynamicClients
     class IDynamicOutputClient
     {
-        IDynamicOutputClient& operator=(IDynamicOutputClient const&);
-
     public:
+        IDynamicOutputClient& operator=(IDynamicOutputClient const&) = delete;
+
         virtual bsp::BspReturnCode set(uint16_t chan, uint8_t vol, bool latch) = 0;
         virtual bsp::BspReturnCode get(uint16_t chan, bool& result)            = 0;
     };
@@ -41,8 +41,6 @@ public:
     void init(uint8_t hw, bool doSetup = true);
 
     void shutdown();
-
-    void cyclic(void);
 
     /**
      * Interface output

--- a/libs/bsp/bspOutputPwm/include/outputPwm/OutputPwm.h
+++ b/libs/bsp/bspOutputPwm/include/outputPwm/OutputPwm.h
@@ -37,7 +37,6 @@ public:
     static void init(uint8_t hwVariant = 0);
     static void shutdown();
 
-    static OutputPwm::tOutputPwmCfg* getConfiguration(uint8_t hwVariant);
     /**
      * */
     static bsp::BspReturnCode setDuty(uint16_t chan, uint16_t duty, bool immediateUpdate = false);

--- a/libs/bsw/bsp/include/bsp/timer/SystemTimer.h
+++ b/libs/bsw/bsp/include/bsp/timer/SystemTimer.h
@@ -78,10 +78,6 @@ uint32_t getFastTicks(void);
 uint32_t getFastTicksPerSecond();
 
 void initSystemTimer();
-/*
- * Returns project dependent TickTime
- */
-uint32_t getSystemTime32BitUserTicks(void);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/libs/bsw/cpp2can/include/can/filter/AbstractStaticBitFieldFilter.h
+++ b/libs/bsw/cpp2can/include/can/filter/AbstractStaticBitFieldFilter.h
@@ -90,13 +90,14 @@ public:
      */
     virtual uint8_t getMaskValue(uint16_t byteIndex) const = 0;
 
+    // no copies
+    AbstractStaticBitFieldFilter(AbstractStaticBitFieldFilter const&)            = delete;
+    AbstractStaticBitFieldFilter& operator=(AbstractStaticBitFieldFilter const&) = delete;
+
 private:
     // friends
     friend bool
     operator==(AbstractStaticBitFieldFilter const& x, AbstractStaticBitFieldFilter const& y);
-    // no copies
-    AbstractStaticBitFieldFilter(AbstractStaticBitFieldFilter const&);
-    AbstractStaticBitFieldFilter& operator=(AbstractStaticBitFieldFilter const&);
 };
 
 /**

--- a/libs/bsw/cpp2can/include/can/filter/BitFieldFilter.h
+++ b/libs/bsw/cpp2can/include/can/filter/BitFieldFilter.h
@@ -130,10 +130,11 @@ public:
 
     uint8_t const* getRawBitField() const { return &_mask[0]; }
 
+    BitFieldFilter(BitFieldFilter const&)            = delete;
+    BitFieldFilter& operator=(BitFieldFilter const&) = delete;
+
 private:
     friend bool operator==(BitFieldFilter const& x, BitFieldFilter const& y);
-    BitFieldFilter(BitFieldFilter const&);
-    BitFieldFilter& operator=(BitFieldFilter const&);
     uint8_t _mask[MASK_SIZE]{};
 };
 

--- a/libs/bsw/cpp2ethernet/include/tcp/util/TcpIperf2Server.h
+++ b/libs/bsw/cpp2ethernet/include/tcp/util/TcpIperf2Server.h
@@ -25,12 +25,8 @@ public:
     void connectionClosed(ErrorCode status) override;
 
 private:
-    void sendByte(uint8_t byte);
-
     bool _locked;
     AbstractSocket& _socket;
-    uint32_t _acknowledged;
-    uint32_t _counter;
 };
 
 } // namespace tcp

--- a/libs/bsw/cpp2ethernet/src/tcp/util/TcpIperf2Server.cpp
+++ b/libs/bsw/cpp2ethernet/src/tcp/util/TcpIperf2Server.cpp
@@ -10,9 +10,7 @@ namespace tcp
 using ::util::logger::Logger;
 using ::util::logger::TCP;
 
-TcpIperf2Server::TcpIperf2Server(AbstractSocket& socket)
-: _locked(false), _socket(socket), _acknowledged(0L), _counter(0L)
-{}
+TcpIperf2Server::TcpIperf2Server(AbstractSocket& socket) : _locked(false), _socket(socket) {}
 
 AbstractSocket* TcpIperf2Server::getSocket(ip::IPAddress const&, uint16_t)
 {

--- a/libs/bsw/docan/include/docan/transmitter/DoCanMessageTransmitter.h
+++ b/libs/bsw/docan/include/docan/transmitter/DoCanMessageTransmitter.h
@@ -144,11 +144,6 @@ public:
     void release();
 
     /**
-     * Send result of the transmission to the notification listener (if given).
-     */
-    void sendResult();
-
-    /**
      * Internal logic to check to see if the passed in current system microsecond value is
      * greater than the timer expiry time \param nowUs current system microsecond value \return
      * true if the current timer has expired

--- a/libs/bsw/docan/include/docan/transport/DoCanTransportLayer.h
+++ b/libs/bsw/docan/include/docan/transport/DoCanTransportLayer.h
@@ -112,8 +112,6 @@ private:
         uint8_t blockSize,
         uint8_t encodedMinSeparationTime) override;
 
-    void shutdownDone();
-
     IDoCanPhysicalTransceiver<DataLinkLayerType>& _transceiver;
     DoCanReceiver<DataLinkLayerType> _receiver;
     DoCanTransmitter<DataLinkLayerType> _transmitter;

--- a/libs/bsw/lwipSocket/include/lwipSocket/netif/LwipNetworkInterface.h
+++ b/libs/bsw/lwipSocket/include/lwipSocket/netif/LwipNetworkInterface.h
@@ -42,8 +42,6 @@ bool initNetifIp4(
     ::ip::Ip4Config const& config,
     ::ip::NetworkInterfaceConfig const& netifConfig,
     void* state);
-bool onStatusChangedIp4(
-    ::lwipnetif::State state, netif& netif, ::ip::NetworkInterfaceConfig& config);
 #endif
 
 void start(netif& ni, ::ip::Ip4Config const& config);

--- a/libs/bsw/lwipSocket/include/lwipSocket/tcp/LwipSocket.h
+++ b/libs/bsw/lwipSocket/include/lwipSocket/tcp/LwipSocket.h
@@ -102,8 +102,6 @@ private:
 
     err_t checkResult(err_t error) const;
 
-    void notifyConnectionClosed(IDataListener::ErrorCode errorCode);
-
     // TCP stack callback functions
     static err_t tcpSentListener(void* arg, tcp_pcb* pcb, uint16_t len);
     static void tcpErrorListener(void* arg, err_t result);

--- a/libs/bsw/lwipSocket/include/lwipSocket/utils/LwipHelper.h
+++ b/libs/bsw/lwipSocket/include/lwipSocket/utils/LwipHelper.h
@@ -38,8 +38,6 @@ inline ip_addr_t to_lwipIp(::ip::IPAddress const& ip)
     return lwipIp;
 }
 
-netif* filterETHFrames(pbuf* const pCompleteFrame, bool const enableVlanTagging);
-
 bool processPbufQueue(
     ::lwiputils::PbufQueue::Receiver receiver,
     ::etl::span<netif> lwnetifs,

--- a/libs/bsw/runtime/include/runtime/RuntimeMonitor.h
+++ b/libs/bsw/runtime/include/runtime/RuntimeMonitor.h
@@ -85,8 +85,6 @@ public:
         return lastRuntime;
     }
 
-    static void resetContextEntries(::etl::span<ContextEntryType> contextEntries);
-
     void enterTask(size_t const taskIdx)
     {
         ::async::LockType const lock;

--- a/libs/bsw/transport/include/transport/ITransportMessageListener.h
+++ b/libs/bsw/transport/include/transport/ITransportMessageListener.h
@@ -20,9 +20,9 @@ class ITransportMessageProcessedListener;
  */
 class ITransportMessageListener
 {
-    ITransportMessageListener& operator=(ITransportMessageListener const&);
-
 public:
+    ITransportMessageListener& operator=(ITransportMessageListener const&) = delete;
+
     /**
      * Status indicating the result of receiving a TransportMessage
      */

--- a/libs/bsw/transport/include/transport/ITransportMessageProcessedListener.h
+++ b/libs/bsw/transport/include/transport/ITransportMessageProcessedListener.h
@@ -16,9 +16,10 @@ class TransportMessage;
  */
 class ITransportMessageProcessedListener
 {
-    ITransportMessageProcessedListener& operator=(ITransportMessageProcessedListener const&);
-
 public:
+    ITransportMessageProcessedListener& operator=(ITransportMessageProcessedListener const&)
+        = delete;
+
     /**
      * Status indicating the result of processing a TransportMessage
      */

--- a/libs/bsw/transport/include/transport/ITransportMessageProvider.h
+++ b/libs/bsw/transport/include/transport/ITransportMessageProvider.h
@@ -18,9 +18,9 @@ class TransportMessage;
  */
 class ITransportMessageProvider
 {
-    ITransportMessageProvider& operator=(ITransportMessageProvider const&);
-
 public:
+    ITransportMessageProvider& operator=(ITransportMessageProvider const&) = delete;
+
     /**
      * Errorcodes used by ITransportMessageProvider
      */

--- a/libs/bsw/uds/include/uds/resume/ResumableResetDriver.h
+++ b/libs/bsw/uds/include/uds/resume/ResumableResetDriver.h
@@ -90,8 +90,6 @@ public:
 private:
     void execute() override;
 
-    void dispatchMessage();
-
     IUdsLifecycleConnector& fUdsLifecycleConnector;
     IDiagDispatcher* fDiagDispatcher;
     ::async::ContextType fContext;

--- a/libs/bsw/util/include/util/command/HelpCommand.h
+++ b/libs/bsw/util/include/util/command/HelpCommand.h
@@ -43,8 +43,6 @@ private:
 
     void help(CommandContext& context) const;
 
-    uint32_t getIdColumnWidth(ICommand const& command, int32_t depth = -1) const;
-
     ICommand& _command;
     uint32_t _idColumnWidth;
 };

--- a/libs/bsw/util/include/util/format/PrintfFormatScanner.h
+++ b/libs/bsw/util/include/util/format/PrintfFormatScanner.h
@@ -35,23 +35,11 @@ class PrintfFormatScanner
 {
 public:
     /**
-     * Default constructor.
-     */
-    PrintfFormatScanner();
-
-    /**
      * Constructor to initialize the scanner with the format string.
      *
      * \param formatString C format string to scan
      */
     explicit PrintfFormatScanner(char const* formatString);
-
-    /**
-     * (Re)initialize the scanner with a format string.
-     *
-     * \param formatString C format string to scan
-     */
-    void init(char const* formatString);
 
     /**
      * Returns whether there are still tokens or not.

--- a/platforms/s32k1xx/bsp/bspEthernet/include/ethernet/RawEthernet.h
+++ b/platforms/s32k1xx/bsp/bspEthernet/include/ethernet/RawEthernet.h
@@ -19,12 +19,4 @@ typedef ::etl::delegate<void(
 
 } // namespace ethernet
 
-extern "C"
-{
 #endif // #ifdef __cplusplus
-
-uint8_t ethernet_write(uint8_t data[], uint32_t length);
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/platforms/s32k1xx/bsp/bspIo/include/io/Io.h
+++ b/platforms/s32k1xx/bsp/bspIo/include/io/Io.h
@@ -13,7 +13,7 @@ namespace bios
 class Io
 {
 public:
-    Io();
+    Io() = delete;
 
     enum Level
     {


### PR DESCRIPTION
Note that some constructor implementations were missing on purpose due to being private anyway. Make this more explicit by marking them deleted in the public section.

Also removed two unused variables in TcpIperf2Server.h due to corresponding errors suddenly appearing in clang.