### PR TITLE
Fix rand() with clang toolchain

### DIFF
--- a/executables/referenceApp/lwipConfiguration/CMakeLists.txt
+++ b/executables/referenceApp/lwipConfiguration/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_library(lwipConfiguration INTERFACE)
+add_library(lwipConfiguration src/rng.cpp)
 
-target_include_directories(lwipConfiguration INTERFACE include)
+target_include_directories(lwipConfiguration PUBLIC include)
 
-target_link_libraries(lwipConfiguration INTERFACE lwipSysArch platform)
+target_link_libraries(lwipConfiguration PUBLIC lwipSysArch platform etl)

--- a/executables/referenceApp/lwipConfiguration/include/lwipopts.h
+++ b/executables/referenceApp/lwipConfiguration/include/lwipopts.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "rng.h"
+
 #include <sys/errno.h>
 
 #include <stdint.h>
@@ -54,7 +56,7 @@
 #endif
 
 #ifndef LWIP_RAND
-#define LWIP_RAND() rand()
+#define LWIP_RAND() lwip_rand()
 #endif
 
 #ifndef LWIP_AUTOIP_CREATE_SEED_ADDR

--- a/executables/referenceApp/lwipConfiguration/include/rng.h
+++ b/executables/referenceApp/lwipConfiguration/include/rng.h
@@ -1,0 +1,14 @@
+// Copyright 2025 BMW AG.
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+int lwip_rand();
+
+#ifdef __cplusplus
+}
+#endif

--- a/executables/referenceApp/lwipConfiguration/src/rng.cpp
+++ b/executables/referenceApp/lwipConfiguration/src/rng.cpp
@@ -1,0 +1,25 @@
+// Copyright 2025 BMW AG.
+
+#include "rng.h"
+
+#include <etl/random.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// The implementation of rand() in the currently used clang toolchain
+// (LLVM Embedded Toolchain for ARM 19.1.1 with picolibc as provided at
+// https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/)
+// crashes on the S32K148 target. Therefore, use the ETL implementation
+// of RNG instead.
+int lwip_rand()
+{
+    static etl::random_lcg generator{1};
+    return static_cast<int>(generator());
+}
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
When building with clang, rand() crashed on calling by LWIP. Being replaced by implementation by ETL, until fixed in the toolchain / libc.