### PR TITLE
Make sure to initialize the socketCanTransceiver frame buffer

### DIFF
--- a/platforms/posix/bsp/socketCanTransceiver/src/can/SocketCanTransceiver.cpp
+++ b/platforms/posix/bsp/socketCanTransceiver/src/can/SocketCanTransceiver.cpp
@@ -248,6 +248,7 @@ void SocketCanTransceiver::guardedRun(int maxSentPerRun, int maxReceivedPerRun)
         ::std::memcpy(static_cast<void*>(&slot), canFrameSlice.data(), sizeof(slot));
         CANFrame& canFrame = slot.frame;
         can_frame socketCanFrame;
+        ::std::memset(&socketCanFrame, 0, sizeof(socketCanFrame));
         socketCanFrame.can_id  = canFrame.getId();
         int length             = canFrame.getPayloadLength();
         socketCanFrame.can_dlc = length;


### PR DESCRIPTION
Fixes the uninitialized errors reported by valgrind, caused by some of the fields not being set.