### PR TITLE
Require CC to be provided for cross-compiling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
         run: >-
           DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) DOCKER_HISTORY=/dev/null docker compose run --rm development
           bash -c "
-          cmake --preset ${{ matrix.preset }} -DCMAKE_CXX_FLAGS="-gdwarf-4" -DCMAKE_C_FLAGS="-gdwarf-4" -B elf-analyzer-artifacts/${{ matrix.preset }} &&
+          CC=/opt/arm-gnu-toolchain/bin/arm-none-eabi-gcc cmake --preset ${{ matrix.preset }} -DCMAKE_CXX_FLAGS="-gdwarf-4" -DCMAKE_C_FLAGS="-gdwarf-4" -B elf-analyzer-artifacts/${{ matrix.preset }} &&
           cmake --build elf-analyzer-artifacts/${{ matrix.preset }} -t app.referenceApp --config ${{ matrix.config }}
           "
 

--- a/cmake/toolchains/ArmNoneEabi-clang.cmake
+++ b/cmake/toolchains/ArmNoneEabi-clang.cmake
@@ -2,15 +2,11 @@ include_guard(GLOBAL)
 
 include("${CMAKE_CURRENT_LIST_DIR}/ArmNoneEabi-header.cmake")
 
-# Note: When using a toolchain file, it normally specifies the compiler itself
-# and it is unexpected that somebody tries to overwrite it using e.g. the CC
-# environment variable. However, thats exactly what we are doing at the moment,
-# therefore, we only set a compiler when the CC environment variable is not set.
-# Further note, that we only set the C compiler, since CMake deduces the others
+# NOTE: we only check the C compiler, since CMake deduces the others
 # automatically from it (respecting the order in the project call).
 
 if (NOT DEFINED CMAKE_C_COMPILER AND NOT DEFINED ENV{CC})
-    set(CMAKE_C_COMPILER "/opt/llvm-et-arm/bin/clang")
+    message(FATAL_ERROR "CC environment variable must be set")
 endif ()
 
 set(CMAKE_C_COMPILER_TARGET ${ARM_TARGET_TRIPLE})

--- a/cmake/toolchains/ArmNoneEabi-gcc.cmake
+++ b/cmake/toolchains/ArmNoneEabi-gcc.cmake
@@ -2,15 +2,11 @@ include_guard(GLOBAL)
 
 include("${CMAKE_CURRENT_LIST_DIR}/ArmNoneEabi-header.cmake")
 
-# Note: When using a toolchain file, it normally specifies the compiler itself
-# and it is unexpected that somebody tries to overwrite it using e.g. the CC
-# environment variable. However, thats exactly what we are doing at the moment,
-# therefore, we only set a compiler when the CC environment variable is not set.
-# Further note, that we only set the C compiler, since CMake deduces the others
+# NOTE: we only check the C compiler, since CMake deduces the others
 # automatically from it (respecting the order in the project call).
 
 if (NOT DEFINED CMAKE_C_COMPILER AND NOT DEFINED ENV{CC})
-    set(CMAKE_C_COMPILER "/opt/arm-gnu-toolchain/bin/arm-none-eabi-gcc")
+    message(FATAL_ERROR "CC environment variable must be set")
 endif ()
 
 set(_C_FLAGS "-funsigned-bitfields")


### PR DESCRIPTION
This makes the hardcoded paths in the .cmake files unnecessary. For arm-gcc using PATH would also work, but not for clang because the names of the POSIX and ARM compilers are identical. For the sake of consistency, use the same approach regardless of the compiler.