### PR TITLE
Fix IncomingDiagConnection's _identifiers access

### DIFF
--- a/libs/bsw/uds/include/uds/connection/IncomingDiagConnection.h
+++ b/libs/bsw/uds/include/uds/connection/IncomingDiagConnection.h
@@ -81,10 +81,6 @@ public:
                                         &IncomingDiagConnection::triggerNextNestedRequest>(*this))
     {
         _context = diagContext;
-        for (uint8_t cnt = 0U; cnt < _identifiers.capacity(); cnt++)
-        {
-            _identifiers[cnt] = 0U;
-        }
     }
 
     /**


### PR DESCRIPTION
When activating bounds checking in ETL, access of etl::vector _identifiers beyond its size() is not allowed. We need to remove initialization of _identifiers for its complete capacity().

This is safe since later resize() operations initialize values anyway if necessary.