### PR TITLE
UART bugfixes for S32K148

### DIFF
--- a/platforms/s32k1xx/bsp/bspUart/src/Uart.cpp
+++ b/platforms/s32k1xx/bsp/bspUart/src/Uart.cpp
@@ -102,6 +102,12 @@ bool Uart::isInitialized() const
 bool Uart::waitForTxReady()
 {
     uint32_t count = 0U;
+
+    if (!isInitialized())
+    {
+        init();
+    }
+
     while (isTxActive(_uartConfig.uart.STAT))
     {
         if (++count > WRITE_TIMEOUT)


### PR DESCRIPTION
Since the new UART BSP interface change, the startup message reads:

```
Mhello
```

instead of expected:

```
MCU watchdog fast tests successful
main(RCM::SRS 0x20)
hello
```

This PR fixes 2 related bugs in the UART driver:

* Too small timeout
* Early printf() needs early init() - alternatively, the init() could be moved to platform specific init code. However, this would change the current approach of init() done in the common refApp code.

(See individual commits in this PR)