### PR TITLE
Adapt CMake to support multiple executables

### DIFF
--- a/.ci/build.py
+++ b/.ci/build.py
@@ -89,7 +89,7 @@ commands = {
         platforms=["arm"],
         cxxids=["clang"],
         build_dir="build/s32k148-threadx-clang",
-    ),
+    )
 }
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
     #   max-parallel: 1
       matrix:
-        preset: [ "tests-posix-debug", "tests-posix-release", "tests-s32k1xx-debug", "tests-s32k1xx-release", "posix-freertos", "posix-threadx", "posix-freertos-with-tracing", "s32k148-freertos-gcc", "s32k148-threadx-gcc", "s32k148-freertos-clang", "s32k148-threadx-clang" ]
+        preset: [ "tests-posix-debug", "tests-posix-release", "tests-s32k1xx-debug", "tests-s32k1xx-release", "posix-freertos", "posix-threadx", "posix-freertos-with-tracing", "s32k148-freertos-gcc", "s32k148-threadx-gcc", "s32k148-freertos-clang", "s32k148-threadx-clang"]
         platform: [ "arm", "linux" ]
         config: [ "Debug", "Release", "RelWithDebInfo" ]
         cxxid: ["gcc", "clang"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,20 @@ set(BUILD_TARGET_RTOS
     "FREERTOS"
     CACHE STRING "Target RTOS")
 
+set(BUILD_EXECUTABLE
+    ""
+    CACHE STRING "Which build to enable: referenceApp, unitTest")
+
+if (BUILD_EXECUTABLE STREQUAL "referenceApp")
+    # no action for referenceApp build
+elseif (BUILD_EXECUTABLE STREQUAL "unitTest")
+    add_compile_definitions(UNIT_TEST=1)
+endif ()
+
 # Convert target name to lower case to match directory name
 string(TOLOWER "${BUILD_TARGET_PLATFORM}" OPENBSW_TARGET)
-if (BUILD_REFERENCE)
+
+if (BUILD_EXECUTABLE STREQUAL "referenceApp")
     include(executables/referenceApp/platforms/${OPENBSW_TARGET}/Options.cmake)
 endif ()
 
@@ -61,8 +72,6 @@ project(
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
-option(BUILD_UNIT_TESTS "Build unit tests" OFF)
-
 option(BUILD_TRACING "Build CTF tracing" OFF)
 
 add_compile_options(
@@ -73,8 +82,7 @@ add_compile_options(
     "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-error=stringop-overflow;-Wno-error=maybe-uninitialized>"
 )
 
-if (BUILD_UNIT_TESTS)
-    add_compile_definitions(UNIT_TEST=1)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     include(GoogleTest)
     include(CTest)
     include(CodeCoverage)
@@ -85,8 +93,8 @@ if (BUILD_UNIT_TESTS)
     set(OPENBSW_PLATFORM_DIR "${CMAKE_CURRENT_SOURCE_DIR}/platforms/posix")
 endif ()
 
-if (BUILD_REFERENCE)
-    set(OPENBSW_APP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/executables/referenceApp")
+if (BUILD_EXECUTABLE STREQUAL "referenceApp")
+    set(OPENBSW_APP_DIR "${CMAKE_CURRENT_LIST_DIR}/executables/referenceApp")
     if (BUILD_TARGET_PLATFORM STREQUAL "S32K148EVB")
         set(OPENBSW_PLATFORM_DIR
             "${CMAKE_CURRENT_SOURCE_DIR}/platforms/s32k1xx")
@@ -109,7 +117,7 @@ set(INCLUDE_OPENBSW_LIBS_BSP
 add_subdirectory(platforms EXCLUDE_FROM_ALL)
 add_subdirectory(libs EXCLUDE_FROM_ALL)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     add_subdirectory(executables/unitTest EXCLUDE_FROM_ALL)
     target_include_directories(etl BEFORE
@@ -171,7 +179,7 @@ if (BUILD_UNIT_TESTS)
                 "Invalid value for OPENBSW_PLATFORM: ${OPENBSW_PLATFORM}")
     endif ()
 
-elseif (BUILD_REFERENCE)
+elseif (BUILD_EXECUTABLE STREQUAL "referenceApp")
     target_include_directories(etl BEFORE
                                INTERFACE executables/referenceApp/etl_profile)
     add_subdirectory(executables/referenceApp)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,7 +18,7 @@
             "cacheVariables": {
                 "CMAKE_DEFAULT_BUILD_TYPE": "Debug",
                 "CMAKE_CONFIGURATION_TYPES": "Debug",
-                "BUILD_UNIT_TESTS": "ON",
+                "BUILD_EXECUTABLE": "unitTest",
                 "OPENBSW_PLATFORM": "posix"
             }
         },
@@ -31,7 +31,7 @@
             "cacheVariables": {
                 "CMAKE_DEFAULT_BUILD_TYPE": "Release",
                 "CMAKE_CONFIGURATION_TYPES": "Release",
-                "BUILD_UNIT_TESTS": "ON",
+                "BUILD_EXECUTABLE": "unitTest",
                 "OPENBSW_PLATFORM": "posix"
             }
         },
@@ -44,7 +44,7 @@
             "cacheVariables": {
                 "CMAKE_DEFAULT_BUILD_TYPE": "Debug",
                 "CMAKE_CONFIGURATION_TYPES": "Debug",
-                "BUILD_UNIT_TESTS": "ON",
+                "BUILD_EXECUTABLE": "unitTest",
                 "OPENBSW_PLATFORM": "s32k1xx"
             }
         },
@@ -57,20 +57,8 @@
             "cacheVariables": {
                 "CMAKE_DEFAULT_BUILD_TYPE": "Release",
                 "CMAKE_CONFIGURATION_TYPES": "Release",
-                "BUILD_UNIT_TESTS": "ON",
+                "BUILD_EXECUTABLE": "unitTest",
                 "OPENBSW_PLATFORM": "s32k1xx"
-            }
-        },
-        {
-            "name": "posix",
-            "displayName": "POSIX-compliant configuration",
-            "description": "Configure for POSIX-compliant environment",
-            "inherits": "_config-base",
-            "binaryDir": "${sourceDir}/build/${presetName}",
-            "cacheVariables": {
-                "BUILD_REFERENCE": "ON",
-                "BUILD_TARGET_PLATFORM": "POSIX",
-                "BUILD_TARGET_RTOS": "FREERTOS"
             }
         },
         {
@@ -80,7 +68,7 @@
             "inherits": "_config-base",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
-                "BUILD_REFERENCE": "ON",
+                "BUILD_EXECUTABLE": "referenceApp",
                 "BUILD_TARGET_PLATFORM": "POSIX",
                 "BUILD_TARGET_RTOS": "FREERTOS"
             }
@@ -92,28 +80,9 @@
             "inherits": "_config-base",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
-                "BUILD_REFERENCE": "ON",
+                "BUILD_EXECUTABLE": "referenceApp",
                 "BUILD_TARGET_PLATFORM": "POSIX",
                 "BUILD_TARGET_RTOS": "THREADX"
-            }
-        },
-        {
-            "name": "s32k148-gcc",
-            "generator": "Ninja Multi-Config",
-            "displayName": "S32K148 configuration (GCC)",
-            "description": "Configure for S32K148 platform using ARM GCC toolchain",
-            "inherits": "_config-base",
-            "toolchainFile": "${sourceDir}/cmake/toolchains/ArmNoneEabi-gcc.cmake",
-            "binaryDir": "${sourceDir}/build/${presetName}",
-            "cacheVariables": {
-                "BUILD_REFERENCE": "ON",
-                "BUILD_TARGET_PLATFORM": "S32K148EVB",
-                "BUILD_TARGET_RTOS": "FREERTOS",
-                "CMAKE_ASM_FLAGS_RELWITHDEBINFO": "-g3",
-                "CMAKE_CONFIGURATION_TYPES": "RelWithDebInfo;Debug;Release",
-                "CMAKE_C_FLAGS_RELWITHDEBINFO": "-g3 -O2 -DNDEBUG",
-                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-g3 -O2 -DNDEBUG",
-                "CMAKE_DEFAULT_BUILD_TYPE": "RelWithDebInfo"
             }
         },
         {
@@ -125,7 +94,7 @@
             "toolchainFile": "${sourceDir}/cmake/toolchains/ArmNoneEabi-gcc.cmake",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
-                "BUILD_REFERENCE": "ON",
+                "BUILD_EXECUTABLE": "referenceApp",
                 "BUILD_TARGET_PLATFORM": "S32K148EVB",
                 "BUILD_TARGET_RTOS": "FREERTOS",
                 "CMAKE_ASM_FLAGS_RELWITHDEBINFO": "-g3",
@@ -144,34 +113,13 @@
             "toolchainFile": "${sourceDir}/cmake/toolchains/ArmNoneEabi-gcc.cmake",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
-                "BUILD_REFERENCE": "ON",
+                "BUILD_EXECUTABLE": "referenceApp",
                 "BUILD_TARGET_PLATFORM": "S32K148EVB",
                 "BUILD_TARGET_RTOS": "THREADX",
                 "CMAKE_ASM_FLAGS_RELWITHDEBINFO": "-g3",
                 "CMAKE_CONFIGURATION_TYPES": "RelWithDebInfo;Debug;Release",
                 "CMAKE_C_FLAGS_RELWITHDEBINFO": "-g3 -O2 -DNDEBUG",
                 "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-g3 -O2 -DNDEBUG",
-                "CMAKE_DEFAULT_BUILD_TYPE": "RelWithDebInfo"
-            }
-        },
-        {
-            "name": "s32k148-clang",
-            "generator": "Ninja Multi-Config",
-            "displayName": "S32K148 configuration (Clang)",
-            "description": "Configure for S32K148 platform using ARM Clang toolchain",
-            "inherits": "_config-base",
-            "toolchainFile": "${sourceDir}/cmake/toolchains/ArmNoneEabi-clang.cmake",
-            "binaryDir": "${sourceDir}/build/${presetName}",
-            "cacheVariables": {
-                "BUILD_REFERENCE": "ON",
-                "BUILD_TARGET_PLATFORM": "S32K148EVB",
-                "BUILD_TARGET_RTOS": "FREERTOS",
-                "CMAKE_ASM_FLAGS_RELWITHDEBINFO": "-g3",
-                "CMAKE_CONFIGURATION_TYPES": "RelWithDebInfo;Debug;Release",
-                "CMAKE_C_FLAGS_RELEASE": "-Os -DNDEBUG",
-                "CMAKE_CXX_FLAGS_RELEASE": "-Os -DNDEBUG",
-                "CMAKE_C_FLAGS_RELWITHDEBINFO": "-g3 -Os -DNDEBUG",
-                "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-g3 -Os -DNDEBUG",
                 "CMAKE_DEFAULT_BUILD_TYPE": "RelWithDebInfo"
             }
         },
@@ -184,7 +132,7 @@
             "toolchainFile": "${sourceDir}/cmake/toolchains/ArmNoneEabi-clang.cmake",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
-                "BUILD_REFERENCE": "ON",
+                "BUILD_EXECUTABLE": "referenceApp",
                 "BUILD_TARGET_PLATFORM": "S32K148EVB",
                 "BUILD_TARGET_RTOS": "FREERTOS",
                 "CMAKE_ASM_FLAGS_RELWITHDEBINFO": "-g3",
@@ -205,7 +153,7 @@
             "toolchainFile": "${sourceDir}/cmake/toolchains/ArmNoneEabi-clang.cmake",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
-                "BUILD_REFERENCE": "ON",
+                "BUILD_EXECUTABLE": "referenceApp",
                 "BUILD_TARGET_PLATFORM": "S32K148EVB",
                 "BUILD_TARGET_RTOS": "THREADX",
                 "CMAKE_ASM_FLAGS_RELWITHDEBINFO": "-g3",
@@ -248,12 +196,6 @@
             "configuration": "Release"
         },
         {
-            "name": "posix",
-            "displayName": "build POSIX",
-            "description": "Build reference application for POSIX-compliant environment (Release by default; for Debug use --config Debug)",
-            "configurePreset": "posix"
-        },
-        {
             "name": "posix-freertos",
             "displayName": "build POSIX-FREERTOS",
             "description": "Build reference application for POSIX-compliant environment (Release by default; for Debug use --config Debug)",
@@ -266,12 +208,6 @@
             "configurePreset": "posix-threadx"
         },
         {
-            "name": "s32k148-gcc",
-            "displayName": "S32K148 build (GCC)",
-            "description": "Build reference application for S32K148 platform with Clang (Release by default; for Debug use --config Debug)",
-            "configurePreset": "s32k148-gcc"
-        },
-        {
             "name": "s32k148-freertos-gcc",
             "displayName": "S32K148 FreeRTOS build (GCC)",
             "description": "Build reference application for S32K148 platform with Clang (Release by default; for Debug use --config Debug)",
@@ -282,12 +218,6 @@
             "displayName": "S32K148 ThreadX build (GCC)",
             "description": "Build reference application for S32K148 platform with Clang (Release by default; for Debug use --config Debug)",
             "configurePreset": "s32k148-threadx-gcc"
-        },
-        {
-            "name": "s32k148-clang",
-            "displayName": "S32K148 build (Clang)",
-            "description": "Build reference application for S32K148 platform with Clang (Release by default; for Debug use --config Debug)",
-            "configurePreset": "s32k148-clang"
         },
         {
             "name": "s32k148-freertos-clang",

--- a/libs/3rdparty/CMakeLists.txt
+++ b/libs/3rdparty/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     add_subdirectory(googletest)
 
     # add the custom extensions for unit tests

--- a/libs/3rdparty/freeRtos/CMakeLists.txt
+++ b/libs/3rdparty/freeRtos/CMakeLists.txt
@@ -17,6 +17,6 @@ target_link_libraries(
 
 target_compile_options(freeRtos PRIVATE -Wno-unused-variable)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     add_subdirectory(mock)
 endif ()

--- a/libs/bsp/bspCharInputOutput/CMakeLists.txt
+++ b/libs/bsp/bspCharInputOutput/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories(bspCharInputOutput PUBLIC include)
 
 target_link_libraries(bspCharInputOutput PUBLIC bsp bspConfiguration printf)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     add_library(bspCharInputOutputMock INTERFACE)
 
     target_include_directories(bspCharInputOutputMock INTERFACE mock/include)

--- a/libs/bsp/bspInterrupts/CMakeLists.txt
+++ b/libs/bsp/bspInterrupts/CMakeLists.txt
@@ -4,6 +4,6 @@ target_include_directories(bspInterrupts INTERFACE include)
 
 target_link_libraries(bspInterrupts INTERFACE bspInterruptsImpl)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     add_subdirectory(mock)
 endif ()

--- a/libs/bsw/async/CMakeLists.txt
+++ b/libs/bsw/async/CMakeLists.txt
@@ -4,7 +4,7 @@ target_include_directories(async INTERFACE include)
 
 target_link_libraries(async INTERFACE asyncPlatform asyncBinding)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     add_subdirectory(mock)
 

--- a/libs/bsw/asyncFreeRtos/CMakeLists.txt
+++ b/libs/bsw/asyncFreeRtos/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(
               common
               timer)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     target_link_libraries(asyncFreeRtos INTERFACE freeRtosMock)
 else ()
     target_link_libraries(asyncFreeRtos INTERFACE freeRtos)
@@ -40,7 +40,7 @@ target_link_libraries(
     freeRtosConfiguration INTERFACE asyncCoreConfiguration
                                     freeRtosCoreConfiguration platform)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     # These compile definitions apply to all unit test
     add_library(asyncBinding INTERFACE)
 

--- a/libs/bsw/asyncImpl/CMakeLists.txt
+++ b/libs/bsw/asyncImpl/CMakeLists.txt
@@ -4,7 +4,7 @@ target_include_directories(asyncImpl INTERFACE include)
 
 target_link_libraries(asyncImpl INTERFACE etl platform)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     add_library(asyncImplMock INTERFACE)
 

--- a/libs/bsw/asyncThreadX/CMakeLists.txt
+++ b/libs/bsw/asyncThreadX/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(
               common
               timer)
 
-if (NOT BUILD_UNIT_TESTS)
+if (NOT BUILD_EXECUTABLE STREQUAL "unitTest")
     target_link_libraries(asyncThreadX INTERFACE threadX)
 endif ()
 
@@ -36,18 +36,9 @@ target_link_libraries(
     threadXConfiguration INTERFACE asyncCoreConfiguration platform
                                    threadXCoreConfiguration)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     # These compile definitions apply to all unit test
     target_compile_definitions(
         asyncThreadX INTERFACE ASYNC_LOOPER_DISABLE
                                ASYNC_TIMEOUTMANAGER2_DISABLE)
-
-    # add_library(asyncBinding INTERFACE)
-
-    # target_include_directories(asyncBinding INTERFACE test/include)
-
-    # add_library(asyncCoreConfiguration INTERFACE)
-
-    # target_include_directories(asyncCoreConfiguration INTERFACE test/include)
-
 endif ()

--- a/libs/bsw/bsp/CMakeLists.txt
+++ b/libs/bsw/bsp/CMakeLists.txt
@@ -4,7 +4,7 @@ target_include_directories(bsp INTERFACE include)
 
 target_link_libraries(bsp INTERFACE common platform etl)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     add_subdirectory(mock)
 

--- a/libs/bsw/cpp2can/CMakeLists.txt
+++ b/libs/bsw/cpp2can/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(
     PUBLIC common etl util
     PRIVATE bsp bspInterrupts)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     add_library(cpp2canMock
                 mock/src/can/transceiver/AbstractCANTransceiverMock.cpp)
 

--- a/libs/bsw/docan/CMakeLists.txt
+++ b/libs/bsw/docan/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(
            transport
            util)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     add_library(docanMock INTERFACE)
 

--- a/libs/bsw/io/CMakeLists.txt
+++ b/libs/bsw/io/CMakeLists.txt
@@ -4,7 +4,7 @@ target_include_directories(io PUBLIC include)
 
 target_link_libraries(io PUBLIC etl platform util)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     add_library(ioMock INTERFACE)
 
     target_include_directories(ioMock INTERFACE mock/include)

--- a/libs/bsw/lifecycle/CMakeLists.txt
+++ b/libs/bsw/lifecycle/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(lifecycle PUBLIC include)
 
 target_link_libraries(lifecycle PUBLIC async util etl)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     add_library(lifecycleMock INTERFACE)
 

--- a/libs/bsw/logger/CMakeLists.txt
+++ b/libs/bsw/logger/CMakeLists.txt
@@ -4,7 +4,8 @@ add_library(logger src/logger/DefaultLoggerCommand.cpp
 target_include_directories(logger PUBLIC include)
 
 target_link_libraries(logger PUBLIC util)
-if (BUILD_UNIT_TESTS)
+
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     add_library(loggerMock INTERFACE)
 
     target_include_directories(loggerMock INTERFACE mock/include)

--- a/libs/bsw/storage/CMakeLists.txt
+++ b/libs/bsw/storage/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(storage.extraSources)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     add_library(storageMock INTERFACE)
 
     target_include_directories(storageMock INTERFACE mock/include)

--- a/libs/bsw/transport/CMakeLists.txt
+++ b/libs/bsw/transport/CMakeLists.txt
@@ -5,7 +5,7 @@ target_include_directories(transport PUBLIC include)
 
 target_link_libraries(transport PUBLIC common etl util async)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     add_library(transportMock
                 mock/gmock/src/TransportMessageProvidingListenerMock.cpp)
 

--- a/libs/bsw/uds/CMakeLists.txt
+++ b/libs/bsw/uds/CMakeLists.txt
@@ -59,7 +59,7 @@ target_link_libraries(
            transportConfiguration
            udsConfiguration)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     add_subdirectory(mock)
 

--- a/libs/bsw/util/CMakeLists.txt
+++ b/libs/bsw/util/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories(util PUBLIC include)
 
 target_link_libraries(util PUBLIC etl platform)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     add_library(utilMock mock/gmock/src/util/StdIoMock.cpp
                          mock/gmock/src/util/logger/TestConsoleLogger.cpp)
 

--- a/platforms/posix/bsp/bspInterruptsImpl/CMakeLists.txt
+++ b/platforms/posix/bsp/bspInterruptsImpl/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (NOT BUILD_UNIT_TESTS)
+if (NOT BUILD_EXECUTABLE STREQUAL "unitTest")
     set(bspInterruptsImplName "bspInterruptsImpl")
 else ()
     # For unit tests, the mock implementation from bspInterrupts is used. To

--- a/platforms/s32k1xx/bsp/bspInterruptsImpl/CMakeLists.txt
+++ b/platforms/s32k1xx/bsp/bspInterruptsImpl/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (NOT BUILD_UNIT_TESTS)
+if (NOT BUILD_EXECUTABLE STREQUAL "unitTest")
     set(bspInterruptsImplName "bspInterruptsImpl")
 else ()
     # For unit tests, the mock implementation from bspInterrupts is used. To

--- a/platforms/s32k1xx/bsp/bspIo/CMakeLists.txt
+++ b/platforms/s32k1xx/bsp/bspIo/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(
            etl
            platform)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     add_library(bspIoMock mock/gmock/src/IoMock.cpp)
 
     target_include_directories(bspIoMock PUBLIC mock/gmock/include)

--- a/platforms/s32k1xx/bsp/canflex2Transceiver/CMakeLists.txt
+++ b/platforms/s32k1xx/bsp/canflex2Transceiver/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(canflex2Transceiver
             src/can/transceiver/canflex2/CanFlex2Transceiver.cpp)
 
-if (BUILD_UNIT_TESTS)
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
     target_include_directories(canflex2Transceiver PUBLIC include
                                                           test/mock/include)
 


### PR DESCRIPTION
Adapt CMake to support multiple executables

Before this change, the boolean variables BUILD_REFERENCE and
BUILD_UNIT_TESTS were used to select either the reference app or the unit tests.
These variable are replaced by BUILD_EXECUTABLE which is now a string variable.
It can be set to "referenceApp", "unitTest" or any string referring to other(future)
executables.
