### PR TITLE
Define ETL chrono durations explicitly

### DIFF
--- a/executables/referenceApp/etl_profile/etl_profile.h
+++ b/executables/referenceApp/etl_profile/etl_profile.h
@@ -27,4 +27,8 @@
 #define ETL_MINIMAL_ERRORS
 #define ETL_USE_ASSERT_FUNCTION
 
+#define ETL_CHRONO_HIGH_RESOLUTION_CLOCK_DURATION etl::chrono::nanoseconds
+#define ETL_CHRONO_SYSTEM_CLOCK_DURATION          etl::chrono::microseconds
+#define ETL_CHRONO_STEADY_CLOCK_DURATION          etl::chrono::seconds
+
 #endif // ETL_PROFILE_H

--- a/executables/unitTest/etl_profile/etl_profile.h
+++ b/executables/unitTest/etl_profile/etl_profile.h
@@ -26,4 +26,8 @@
 
 #define ETL_THROW_EXCEPTIONS
 
+#define ETL_CHRONO_HIGH_RESOLUTION_CLOCK_DURATION etl::chrono::nanoseconds
+#define ETL_CHRONO_SYSTEM_CLOCK_DURATION          etl::chrono::microseconds
+#define ETL_CHRONO_STEADY_CLOCK_DURATION          etl::chrono::seconds
+
 #endif // ETL_PROFILE_H


### PR DESCRIPTION
In ETL, the default durations for high_resolution_clock, system_clock and steady_clock are all nanoseconds.

In OpenBSW, the implementation of the clocks is based on different durations (nanoseconds, microseconds and seconds, respectively). Therefore, define them explicitly now.