### PR TITLE
Guard usage of Ethernet busid behind CMake option

### DIFF
--- a/libs/bsw/transportRouterSimple/src/transport/routing/TransportRouterSimple.cpp
+++ b/libs/bsw/transportRouterSimple/src/transport/routing/TransportRouterSimple.cpp
@@ -118,12 +118,14 @@ ITransportMessageProvidingListener::ReceiveResult TransportRouterSimple::message
         forwardMessageToTransportLayer(
             transportMessage, ::busid::SELFDIAG, pNotificationListener, result);
     }
+#ifdef PLATFORM_SUPPORT_ETHERNET
     else if (sourceBusId == ::busid::ETH_0)
     {
         _busIdToReply = sourceBusId;
         forwardMessageToTransportLayer(
             transportMessage, ::busid::SELFDIAG, pNotificationListener, result);
     }
+#endif
     else if (sourceBusId == ::busid::SELFDIAG && _busIdToReply != ::busid::SELFDIAG)
     {
         forwardMessageToTransportLayer(


### PR DESCRIPTION
Guard usage of Ethernet busid behind CMake option

Adding conditional compilation around routing to Ethernet in
`simpleTransportRouter`.

Disabling PLATFORM_SUPPORT_ETHERNET and removing the BusId ETH_0 from a
project's BusId.h would cause the build of the module
`transportRouterSimple` to fail.

Projects without Ethernet support may want to use the
`transportRouterSimple` just for routing between buses CAN
and SELFDIAG.
