### PR TITLE
Remove unused DoIP include

### DIFF
--- a/executables/referenceApp/application/src/systems/UdsSystem.cpp
+++ b/executables/referenceApp/application/src/systems/UdsSystem.cpp
@@ -2,11 +2,11 @@
 
 #include "systems/UdsSystem.h"
 
-#include "busid/BusId.h"
-#include "lifecycle/LifecycleManager.h"
-#include "systems/DoIpServerSystem.h"
-#include "transport/ITransportSystem.h"
-#include "transport/TransportConfiguration.h"
+#include <busid/BusId.h>
+#include <etl/array.h>
+#include <lifecycle/LifecycleManager.h>
+#include <transport/ITransportSystem.h>
+#include <transport/TransportConfiguration.h>
 
 namespace uds
 {
@@ -14,7 +14,7 @@ uint8_t const responseData22Cf01[]
     = {0x01, 0x02, 0x00, 0x02, 0x22, 0x02, 0x16, 0x0F, 0x01, 0x00, 0x00, 0x6D,
        0x2F, 0x00, 0x00, 0x01, 0x06, 0x00, 0x00, 0x8F, 0xE0, 0x00, 0x00, 0x01};
 
-estd::array<uint8_t, 3> storedData2eCf03 = {0};
+etl::array<uint8_t, 3> storedData2eCf03 = {0};
 
 UdsSystem::UdsSystem(
     lifecycle::LifecycleManager& lManager,


### PR DESCRIPTION
Remove unused DoIP include

This removes an include that breaks the build in case
PLATFORM_SUPPORT_ETHERNET is off.

Also includes a change from estd::array to etl::array.
