### PR TITLE
Keep lwIP netif persistent across lifecycle transitions

### DIFF
--- a/executables/referenceApp/application/src/systems/EthernetSystem.cpp
+++ b/executables/referenceApp/application/src/systems/EthernetSystem.cpp
@@ -112,26 +112,6 @@ EthernetSystem::EthernetSystem(
 void EthernetSystem::init()
 {
     lwip_init();
-
-    for (size_t i = 0; i < netifs.netifs.size(); ++i)
-    {
-        if (!lwipnetif::initNetifIp4(
-                netifs.netifs[i], netifs.ip4Configs[i], netifs.networkInterfaceConfigsIp4[i], this))
-        {
-            continue;
-        }
-        netifs.netifStates[i].state = ::lwipnetif::State::Initialised;
-        netifs.netifs[i].linkoutput = &linkoutput;
-
-        ::lwiputils::initNetifDriverParameters(::ethX::MAC_ADDRESS, netifs.netifs[i]);
-
-        auto const lwipNetif = &netifs.netifs[i];
-#if LWIP_IGMP
-        netif_set_igmp_mac_filter(lwipNetif, joinMulticastGroupIpV4);
-#endif
-        netif_set_status_callback(lwipNetif, &netifStatusCallback);
-        netif_set_up(lwipNetif);
-    }
     transitionDone();
 }
 
@@ -139,11 +119,45 @@ void EthernetSystem::run()
 {
     for (size_t i = 0; i < netifs.netifStates.size(); ++i)
     {
-        if (netifs.netifStates[i].state == ::lwipnetif::State::Initialised)
+        auto& state = netifs.netifStates[i].state;
+        auto& netif = netifs.netifs[i];
+
+        if (state == ::lwipnetif::State::Uninitialised)
         {
-            ::lwipnetif::start(netifs.netifs[i], netifs.ip4Configs[i]);
-            netifs.netifStates[i].state = ::lwipnetif::State::Started;
+            if (!lwipnetif::initNetifIp4(
+                    netif, netifs.ip4Configs[i], netifs.networkInterfaceConfigsIp4[i], this))
+            {
+                continue;
+            }
+
+            netif.linkoutput = &linkoutput;
+            ::lwiputils::initNetifDriverParameters(::ethX::MAC_ADDRESS, netif);
+#if LWIP_IGMP
+            netif_set_igmp_mac_filter(&netif, joinMulticastGroupIpV4);
+#endif
+
+            state = ::lwipnetif::State::Initialised;
         }
+
+        if (state == ::lwipnetif::State::Initialised)
+        {
+            ::lwipnetif::start(netif, netifs.ip4Configs[i]);
+            state = ::lwipnetif::State::Started;
+        }
+
+        bool phyLink         = ethernetDriverSystem.getLinkStatus(netifs.ports[i]);
+        netifs.linkStatus[i] = phyLink;
+
+        if (phyLink)
+        {
+            netif_set_link_up(&netif);
+        }
+        else
+        {
+            netif_set_link_down(&netif);
+        }
+        netif_set_status_callback(&netif, &netifStatusCallback);
+        netif_set_up(&netif);
     }
 
     ::async::scheduleAtFixedRate(_context, *this, _timeout, 1, ::async::TimeUnit::MILLISECONDS);


### PR DESCRIPTION
Keep lwIP netif persistent across lifecycle transitions

After Lifecycle transition 9 → 4 → 9, UDP multicast join failed with:
igmp_joingroup failed with status -6
because EthernetSystem::init() was only executed once during system lifetime,
while run() is re-executed after lifecycle restart.

Network interface configuration was performed inside init().
During LC restart (4 → 9), init() was not called again, therefore
the lwIP netif was not properly reconfigured.

Moving all netif-specific configuration and activation logic into run() solves the issue.
