### PR TITLE
Fix ENET ISR race during Ethernet driver initialization

### DIFF
--- a/executables/referenceApp/platforms/s32k148evb/main/src/systems/S32K148EvbEthernetSystem.cpp
+++ b/executables/referenceApp/platforms/s32k148evb/main/src/systems/S32K148EvbEthernetSystem.cpp
@@ -112,7 +112,6 @@ S32K148EvbEthernetSystem::S32K148EvbEthernetSystem(
 void S32K148EvbEthernetSystem::init()
 {
     _tja1101LinkStatus = false;
-    pEnetDriver        = &_driver;
     configureEnetPins();
     _driver.init();
     _tja1101.start();
@@ -122,6 +121,7 @@ void S32K148EvbEthernetSystem::init()
 void S32K148EvbEthernetSystem::run()
 {
     _driver.start();
+    pEnetDriver = &_driver;
     ::async::scheduleAtFixedRate(
         _context, *this, _timeout, ETHERNET_CYCLE_TIME, ::async::TimeUnit::MILLISECONDS);
     _tja1101LinkStatus = _tja1101.isLinkUp();


### PR DESCRIPTION
Fix ENET ISR race during Ethernet driver initialization

The ENET ISR could access the Ethernet driver before it was fully initialized.

The ethernet driver pointer (pEnetDriver) was assigned during init(),
which exposed the driver to interrupts before driver.start() completed.

If an ENET interrupt occurred during this window, the ISR could call interruptGroup0() on a
partially initialized driver, leading to undefined behaviour which resulted in HardFault or sometimes
system reset.

Move the assignment of pEnetDriver from init() to run() so the driver is only exposed to the ISR
after driver.start() completes.
