### PR TITLE
Add STM32 BSP peripheral drivers

### DIFF
--- a/doc/dev/modules/stm32.rst
+++ b/doc/dev/modules/stm32.rst
@@ -19,4 +19,4 @@ BSP
     :maxdepth: 1
     :glob:
 
-    ../../../platforms/stm32/bsp/**/doc/index
+    ../../../platforms/stm32/**/doc/index

--- a/platforms/stm32/CMakeLists.txt
+++ b/platforms/stm32/CMakeLists.txt
@@ -17,4 +17,7 @@ if (NOT BUILD_EXECUTABLE STREQUAL "unitTest")
     endif ()
 
     add_subdirectory(bsp)
+
+    # ETL implementation
+    add_subdirectory(etlImpl)
 endif ()

--- a/platforms/stm32/bsp/CMakeLists.txt
+++ b/platforms/stm32/bsp/CMakeLists.txt
@@ -1,1 +1,17 @@
 add_subdirectory(bspMcu)
+add_subdirectory(bspClock)
+add_subdirectory(bspInterruptsImpl)
+add_subdirectory(bspUart)
+add_subdirectory(bspTimer)
+add_subdirectory(bspIo)
+
+# Aggregated BSP target
+add_library(socBsp INTERFACE)
+target_link_libraries(
+    socBsp
+    INTERFACE bspClock
+              bspInterruptsImpl
+              bspIo
+              bspMcu
+              bspTimer
+              bspUart)

--- a/platforms/stm32/bsp/bspClock/CMakeLists.txt
+++ b/platforms/stm32/bsp/bspClock/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Clock configuration - chip-specific source selected by STM32_FAMILY
+if (STM32_FAMILY STREQUAL "F4")
+    add_library(bspClock src/clockConfig_f4.cpp)
+elseif (STM32_FAMILY STREQUAL "G4")
+    add_library(bspClock src/clockConfig_g4.cpp)
+endif ()
+
+target_include_directories(bspClock PUBLIC include)
+
+target_link_libraries(bspClock PRIVATE bspMcu)

--- a/platforms/stm32/bsp/bspClock/doc/index.rst
+++ b/platforms/stm32/bsp/bspClock/doc/index.rst
@@ -1,0 +1,43 @@
+..
+   *******************************************************************************
+   Copyright (c) 2026 An Dao
+
+   This program and the accompanying materials are made available under the
+   terms of the Apache License Version 2.0 which is available at
+   https://www.apache.org/licenses/LICENSE-2.0
+
+   SPDX-License-Identifier: Apache-2.0
+   *******************************************************************************
+
+bspClock
+========
+
+Overview
+--------
+
+The ``bspClock`` module configures the system clock PLL for STM32F4 and STM32G4
+targets. Each family has its own translation unit (``clockConfig_f4.cpp``,
+``clockConfig_g4.cpp``); the public API is a single ``extern "C"`` function
+``configurePll()`` declared in ``clock/clockConfig.h``. It is called from the
+startup code before ``main()`` and must not use heap, RTOS primitives, or BSW
+services. On a PLL or oscillator timeout the system stays on HSI 16 MHz and
+``SystemCoreClock`` is not updated.
+
+STM32F4 (STM32F413ZH) -- 96 MHz
+-------------------------------
+
+- Clock source: HSE 8 MHz bypass (ST-LINK MCO on NUCLEO-F413ZH)
+- PLL: M = 8, N = 384, P = 4 -> SYSCLK = 96 MHz
+- AHB = 96 MHz, APB1 = 48 MHz (max 50 MHz per datasheet), APB2 = 96 MHz
+- Flash latency: 3 wait states at 3.3 V, prefetch and caches enabled
+
+STM32G4 (STM32G474RE) -- 170 MHz
+--------------------------------
+
+- Clock source: HSI 16 MHz. HSE is not used because solder bridge SB15 may
+  not route the ST-LINK V3 MCO to PH0/OSC_IN on all NUCLEO-G474RE revisions.
+- PLL: M = 4, N = 85, R = 2 -> SYSCLK = 170 MHz (voltage Range 1 boost mode)
+- AHB = APB1 = APB2 = 170 MHz
+- Flash latency: 4 wait states; ``FLASH_ACR`` is written read-modify-write to
+  preserve ``DBG_SWEN``. The switch above 150 MHz follows the AHB prescaler
+  transition sequence from RM0440 section 6.1.5.

--- a/platforms/stm32/bsp/bspClock/include/clock/clockConfig.h
+++ b/platforms/stm32/bsp/bspClock/include/clock/clockConfig.h
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// Implemented per target in clockConfig_*.cpp. Called from startup code
+// before main(); must not use heap, RTOS primitives, or BSW services.
+void configurePll(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/platforms/stm32/bsp/bspClock/module.spec
+++ b/platforms/stm32/bsp/bspClock/module.spec
@@ -1,0 +1,3 @@
+maturity: raw
+unit_test: false
+oss: true

--- a/platforms/stm32/bsp/bspClock/src/clockConfig_f4.cpp
+++ b/platforms/stm32/bsp/bspClock/src/clockConfig_f4.cpp
@@ -1,0 +1,71 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include <mcu/mcu.h>
+
+uint32_t SystemCoreClock = 16000000U; // Default HSI, updated by configurePll()
+
+// Clock stabilization timeout (~100 ms at 16 MHz HSI = 1.6M cycles).
+static constexpr uint32_t CLK_TIMEOUT = 1600000U;
+
+extern "C" void configurePll()
+{
+    // Enable HSE bypass (8 MHz from ST-LINK)
+    RCC->CR |= RCC_CR_HSEBYP | RCC_CR_HSEON;
+    {
+        uint32_t t = CLK_TIMEOUT;
+        while ((RCC->CR & RCC_CR_HSERDY) == 0U)
+        {
+            --t;
+            if (t == 0U)
+            {
+                return;
+            }
+        }
+    }
+
+    // Configure PLL: HSE / M=8 * N=384 / P=4 = 96 MHz
+    RCC->PLLCFGR = (8U << RCC_PLLCFGR_PLLM_Pos)     // M = 8 -> VCO input = 1 MHz
+                   | (384U << RCC_PLLCFGR_PLLN_Pos) // N = 384 -> VCO = 384 MHz
+                   | (1U << RCC_PLLCFGR_PLLP_Pos)   // P = 4 (register value 1) -> 96 MHz
+                   | RCC_PLLCFGR_PLLSRC_HSE;
+
+    RCC->CR |= RCC_CR_PLLON;
+    {
+        uint32_t t = CLK_TIMEOUT;
+        while ((RCC->CR & RCC_CR_PLLRDY) == 0U)
+        {
+            --t;
+            if (t == 0U)
+            {
+                return;
+            }
+        }
+    }
+
+    // Flash latency 3 WS for 96 MHz @ 3.3V
+    FLASH->ACR = FLASH_ACR_LATENCY_3WS | FLASH_ACR_PRFTEN | FLASH_ACR_ICEN | FLASH_ACR_DCEN;
+
+    // AHB = SYSCLK, APB1 = SYSCLK/2, APB2 = SYSCLK
+    RCC->CFGR = RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_SW_PLL;
+    {
+        uint32_t t = CLK_TIMEOUT;
+        while ((RCC->CFGR & RCC_CFGR_SWS) != RCC_CFGR_SWS_PLL)
+        {
+            --t;
+            if (t == 0U)
+            {
+                return;
+            }
+        }
+    }
+
+    SystemCoreClock = 96000000U;
+}

--- a/platforms/stm32/bsp/bspClock/src/clockConfig_g4.cpp
+++ b/platforms/stm32/bsp/bspClock/src/clockConfig_g4.cpp
@@ -1,0 +1,105 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include <mcu/mcu.h>
+
+uint32_t SystemCoreClock = 16000000U; // Default HSI, updated by configurePll()
+
+// Clock stabilization timeout (~100 ms at 16 MHz HSI = 1.6M cycles).
+// On timeout the system stays on HSI 16 MHz and SystemCoreClock is NOT
+// updated, indicating to downstream code that PLL init failed.
+static constexpr uint32_t CLK_TIMEOUT = 1600000U;
+
+extern "C" void configurePll()
+{
+    RCC->APB1ENR1 |= RCC_APB1ENR1_PWREN;
+    uint32_t volatile dummy = RCC->APB1ENR1; // Read-back for clock enable delay
+    (void)dummy;
+
+    // Enable Range 1 boost mode (required for >150 MHz)
+    PWR->CR5 &= ~PWR_CR5_R1MODE;
+    // Wait for voltage scaling to stabilize
+    {
+        uint32_t t = CLK_TIMEOUT;
+        while ((PWR->SR2 & PWR_SR2_VOSF) != 0U)
+        {
+            --t;
+            if (t == 0U)
+            {
+                return;
+            }
+        }
+    }
+
+    // Configure PLL: HSI / M=4 * N=85 / R=2 = 170 MHz.
+    // HSI instead of HSE: NUCLEO-G474RE solder bridge SB15 may not route
+    // ST-LINK V3 MCO to PH0/OSC_IN on all board revisions.
+    RCC->PLLCFGR = (3U << RCC_PLLCFGR_PLLM_Pos)    // M = 4 (register value M-1 = 3)
+                   | (85U << RCC_PLLCFGR_PLLN_Pos) // N = 85
+                   | RCC_PLLCFGR_PLLSRC_HSI
+                   | RCC_PLLCFGR_PLLREN; // Enable PLL R output (SYSCLK source)
+
+    RCC->CR |= RCC_CR_PLLON;
+    {
+        uint32_t t = CLK_TIMEOUT;
+        while ((RCC->CR & RCC_CR_PLLRDY) == 0U)
+        {
+            --t;
+            if (t == 0U)
+            {
+                return;
+            }
+        }
+    }
+
+    // Flash latency 4 WS for 170 MHz @ 3.3V boost mode
+    // Preserve DBG_SWEN (bit 18) - clearing it kills SWD debug flash access
+    {
+        uint32_t acr = FLASH->ACR;
+        acr &= ~FLASH_ACR_LATENCY_Msk; // Clear only latency bits, keep DBG_SWEN etc
+        acr |= FLASH_ACR_LATENCY_4WS | FLASH_ACR_PRFTEN | FLASH_ACR_ICEN | FLASH_ACR_DCEN;
+        FLASH->ACR = acr;
+    }
+    // Verify flash latency readback before switching clock (RM0440 section 3.3.3)
+    {
+        uint32_t t = CLK_TIMEOUT;
+        while ((FLASH->ACR & FLASH_ACR_LATENCY) != FLASH_ACR_LATENCY_4WS)
+        {
+            --t;
+            if (t == 0U)
+            {
+                return;
+            }
+        }
+    }
+
+    // Boost-mode >150 MHz transition: set AHB prescaler /2 before clock switch
+    RCC->CFGR = RCC_CFGR_HPRE_DIV2 | RCC_CFGR_SW_PLL;
+    {
+        uint32_t t = CLK_TIMEOUT;
+        while ((RCC->CFGR & RCC_CFGR_SWS) != RCC_CFGR_SWS_PLL)
+        {
+            --t;
+            if (t == 0U)
+            {
+                return;
+            }
+        }
+    }
+
+    // Wait >= 1 us for voltage regulator to settle at new frequency
+    // At 170/2 = 85 MHz, 100 cycles > 1 us
+    for (uint32_t volatile i = 0U; i < 100U; i++) {}
+
+    // Restore AHB prescaler to /1
+    RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_HPRE_Msk) | RCC_CFGR_HPRE_DIV1;
+
+    SystemCoreClock = 170000000U;
+}

--- a/platforms/stm32/bsp/bspInterruptsImpl/CMakeLists.txt
+++ b/platforms/stm32/bsp/bspInterruptsImpl/CMakeLists.txt
@@ -1,0 +1,18 @@
+if (NOT BUILD_EXECUTABLE STREQUAL "unitTest")
+    set(bspInterruptsImplName "bspInterruptsImpl")
+else ()
+    set(bspInterruptsImplName "bspInterruptsImplUt")
+endif ()
+
+add_library(${bspInterruptsImplName} src/interrupt_manager.c)
+
+target_include_directories(${bspInterruptsImplName} PUBLIC include)
+
+if (BUILD_TARGET_RTOS STREQUAL "FREERTOS")
+    target_include_directories(${bspInterruptsImplName} PUBLIC freertos/include)
+elseif (BUILD_TARGET_RTOS STREQUAL "THREADX")
+    target_include_directories(${bspInterruptsImplName} PUBLIC threadx/include)
+    target_link_libraries(${bspInterruptsImplName} PUBLIC threadX)
+endif ()
+
+target_link_libraries(${bspInterruptsImplName} PRIVATE bspMcu platform)

--- a/platforms/stm32/bsp/bspInterruptsImpl/doc/index.rst
+++ b/platforms/stm32/bsp/bspInterruptsImpl/doc/index.rst
@@ -1,0 +1,111 @@
+..
+   *******************************************************************************
+   Copyright (c) 2026 An Dao
+
+   This program and the accompanying materials are made available under the
+   terms of the Apache License Version 2.0 which is available at
+   https://www.apache.org/licenses/LICENSE-2.0
+
+   SPDX-License-Identifier: Apache-2.0
+   *******************************************************************************
+
+bspInterruptsImpl
+=================
+
+Overview
+--------
+
+The ``bspInterruptsImpl`` module provides interrupt management for STM32
+Cortex-M4 targets. It implements global interrupt disable/enable primitives and
+integrates with FreeRTOS for context-safe critical sections.
+
+Global Interrupt Disable / Enable
+---------------------------------
+
+The header ``interrupts/disableEnableAllInterrupts.h`` provides two inline
+assembly functions:
+
+``disableAllInterrupts()``
+    Executes ``CPSID I`` to set the ``PRIMASK`` register, masking all
+    interrupts except NMI and HardFault. Followed by ``ISB``, ``DSB``, and
+    ``DMB`` barrier instructions to ensure the mask takes effect before any
+    subsequent memory access or instruction fetch.
+
+``enableAllInterrupts()``
+    Executes ``ISB``, ``DSB``, and ``DMB`` barriers first, then ``CPSIE I`` to
+    clear ``PRIMASK`` and re-enable interrupts. The barrier-before-enable
+    ordering ensures all pending memory operations complete before interrupts
+    can fire.
+
+Both functions are declared ``static inline`` with
+``__attribute__((always_inline))`` to guarantee zero-overhead inlining at every
+call site.
+
+PRIMASK vs BASEPRI
+------------------
+
+The Cortex-M4 offers two mechanisms for interrupt masking:
+
+**PRIMASK (bare-metal variant)**
+    Setting PRIMASK to 1 disables all configurable interrupts (priority levels
+    0--15). Only NMI (priority -2) and HardFault (priority -1) remain active.
+    This is the approach used by ``disableAllInterrupts()`` /
+    ``enableAllInterrupts()`` and is suitable for bare-metal critical sections
+    where no RTOS is running.
+
+**BASEPRI (FreeRTOS variant)**
+    FreeRTOS uses ``BASEPRI`` instead of ``PRIMASK`` for its critical sections.
+    Setting ``BASEPRI`` to ``configMAX_SYSCALL_INTERRUPT_PRIORITY`` masks only
+    interrupts at or below that priority threshold, leaving higher-priority
+    (lower numeric value) interrupts unmasked. This allows time-critical ISRs
+    (e.g., motor control, safety watchdog) to preempt FreeRTOS critical
+    sections.
+
+    FreeRTOS-aware critical section macros (``taskENTER_CRITICAL`` /
+    ``taskEXIT_CRITICAL``) use this BASEPRI approach internally. The
+    ``bspInterruptsImpl`` module provides the ``SuspendResumeAllInterruptsScopedLock``
+    RAII wrapper for C++ code that needs interrupt-safe sections compatible with
+    both variants.
+
+NVIC Priority Configuration
+---------------------------
+
+The STM32 Cortex-M4 implements 4-bit priority grouping (``__NVIC_PRIO_BITS = 4``
+from the CMSIS device header), yielding 16 priority levels (0 = highest,
+15 = lowest).
+
+Priority assignment guidelines:
+
+- Priorities 0--3: Reserved for time-critical hardware ISRs that must not be
+  blocked by FreeRTOS critical sections (above
+  ``configMAX_SYSCALL_INTERRUPT_PRIORITY``).
+- Priorities 4--15: Available for ISRs that may call FreeRTOS API functions
+  (``xSemaphoreGiveFromISR``, ``xQueueSendFromISR``, etc.).
+
+The FreeRTOS Cortex-M4 port layer uses the CMSIS ``__enable_irq()`` /
+``__disable_irq()`` intrinsics directly for global interrupt control.
+
+Scoped Lock
+-----------
+
+The ``SuspendResumeAllInterruptsScopedLock`` class (from the ``interrupts``
+namespace) provides RAII-style interrupt locking:
+
+.. code-block:: cpp
+
+   {
+       const ESR_UNUSED interrupts::SuspendResumeAllInterruptsScopedLock lock;
+       // Critical section -- interrupts disabled
+   }
+   // Interrupts restored to previous state
+
+This pattern is used throughout the BSP (e.g., ``bspTimer`` tick accumulation)
+to ensure interrupt state is always restored, even if an early return or
+exception occurs.
+
+Dependencies
+------------
+
+- ARM Cortex-M4 ``PRIMASK`` and ``BASEPRI`` special registers
+- CMSIS ``__enable_irq()`` / ``__disable_irq()`` intrinsics
+- FreeRTOS ``configMAX_SYSCALL_INTERRUPT_PRIORITY`` (when FreeRTOS is active)

--- a/platforms/stm32/bsp/bspInterruptsImpl/freertos/include/interrupts/suspendResumeAllInterrupts.h
+++ b/platforms/stm32/bsp/bspInterruptsImpl/freertos/include/interrupts/suspendResumeAllInterrupts.h
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#pragma once
+
+#include "platform/estdint.h"
+
+typedef int32_t OldIntEnabledStatusValueType;
+#define getOldIntEnabledStatusValueAndSuspendAllInterrupts \
+    getMachineStateRegisterValueAndSuspendAllInterrupts
+
+// clang-format off
+static inline __attribute__((always_inline))
+uint32_t getMachineStateRegisterValueAndSuspendAllInterrupts(void)
+{
+   uint32_t _PRIMASK;
+   __asm volatile ("    mrs     %0, PRIMASK\n"
+                   "    cpsid   i\n"
+                   : "=r" (_PRIMASK));
+    return(_PRIMASK);
+}
+static inline __attribute__((always_inline))
+void resumeAllInterrupts(uint32_t oldMachineStateRegisterValue)
+{
+    __asm volatile ("      msr     PRIMASK,%[Input]\n"
+                    ::[Input] "r" (oldMachineStateRegisterValue)
+                  );
+}
+
+// clang-format on

--- a/platforms/stm32/bsp/bspInterruptsImpl/include/interrupts/disableEnableAllInterrupts.h
+++ b/platforms/stm32/bsp/bspInterruptsImpl/include/interrupts/disableEnableAllInterrupts.h
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#pragma once
+
+// clang-format off
+static inline __attribute__((always_inline))
+void disableAllInterrupts(void)
+{
+asm(
+"cpsid   i;"
+"ISB;"
+"DSB;"
+"DMB;"
+);
+}
+static inline __attribute__((always_inline))
+void enableAllInterrupts(void)
+{
+asm (
+"ISB;"
+"DSB;"
+"DMB;"
+"cpsie   i;"
+);
+}
+
+// clang-format on

--- a/platforms/stm32/bsp/bspInterruptsImpl/module.spec
+++ b/platforms/stm32/bsp/bspInterruptsImpl/module.spec
@@ -1,0 +1,3 @@
+maturity: raw
+unit_test: false
+oss: true

--- a/platforms/stm32/bsp/bspInterruptsImpl/src/interrupt_manager.c
+++ b/platforms/stm32/bsp/bspInterruptsImpl/src/interrupt_manager.c
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include <mcu/mcu.h>
+
+// Placeholder - interrupt manager for STM32.
+// NVIC priorities are configured by the application during board bring-up.

--- a/platforms/stm32/bsp/bspInterruptsImpl/threadx/include/interrupts/suspendResumeAllInterrupts.h
+++ b/platforms/stm32/bsp/bspInterruptsImpl/threadx/include/interrupts/suspendResumeAllInterrupts.h
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#pragma once
+
+#include <platform/estdint.h>
+
+#include <tx_api.h>
+
+static inline __attribute__((always_inline)) void setThreadXInitialized(){};
+
+typedef uint32_t OldIntEnabledStatusValueType;
+
+#define getMachineStateRegisterValueAndSuspendAllInterrupts \
+    getOldIntEnabledStatusValueAndSuspendAllInterrupts
+
+static inline __attribute__((always_inline)) OldIntEnabledStatusValueType
+getOldIntEnabledStatusValueAndSuspendAllInterrupts(void)
+{
+    return tx_interrupt_control(TX_INT_DISABLE);
+}
+
+static inline __attribute__((always_inline)) void
+resumeAllInterrupts(OldIntEnabledStatusValueType const oldIntEnabledStatusValue)
+{
+    tx_interrupt_control(oldIntEnabledStatusValue);
+}

--- a/platforms/stm32/bsp/bspIo/CMakeLists.txt
+++ b/platforms/stm32/bsp/bspIo/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(bspIo src/io/Gpio.cpp)
+target_include_directories(bspIo PUBLIC include)
+target_link_libraries(
+    bspIo
+    PUBLIC bspMcu
+    PRIVATE platform)

--- a/platforms/stm32/bsp/bspIo/doc/index.rst
+++ b/platforms/stm32/bsp/bspIo/doc/index.rst
@@ -1,0 +1,33 @@
+..
+   *******************************************************************************
+   Copyright (c) 2026 An Dao
+
+   This program and the accompanying materials are made available under the
+   terms of the Apache License Version 2.0 which is available at
+   https://www.apache.org/licenses/LICENSE-2.0
+
+   SPDX-License-Identifier: Apache-2.0
+   *******************************************************************************
+
+bspIo Driver
+============
+
+Overview
+--------
+
+The ``bspIo`` module provides a register-level GPIO driver for STM32 targets.
+The driver is the stateless ``bios::Gpio`` class, which wraps the GPIO
+peripheral registers (``MODER``, ``OTYPER``, ``OSPEEDR``, ``PUPDR``, ``AFR``,
+``IDR``, ``BSRR``, ``ODR``) behind typed accessors.
+
+A pin is described by a ``GpioConfig`` struct: port, pin number, mode
+(input / output / alternate / analog), output type, speed, pull resistor,
+and alternate function number. ``Gpio::configure()`` applies a complete
+``GpioConfig`` in one call and enables the port clock via
+``Gpio::enablePortClock()``. Individual setters
+(``setMode``, ``setOutputType``, ``setSpeed``, ``setPull``,
+``setAlternateFunction``) and the pin accessors (``readPin``, ``writePin``,
+``togglePin``) are available for dynamic use.
+
+Pin assignments are a board decision and are supplied by the board
+configuration, not by this module.

--- a/platforms/stm32/bsp/bspIo/include/io/Gpio.h
+++ b/platforms/stm32/bsp/bspIo/include/io/Gpio.h
@@ -1,0 +1,80 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#pragma once
+
+#include <mcu/mcu.h>
+#include <stdint.h>
+
+namespace bios
+{
+
+// MODER register values
+enum class GpioMode : uint8_t
+{
+    INPUT     = 0U,
+    OUTPUT    = 1U,
+    ALTERNATE = 2U,
+    ANALOG    = 3U
+};
+
+// OTYPER register values
+enum class GpioOutputType : uint8_t
+{
+    PUSH_PULL  = 0U,
+    OPEN_DRAIN = 1U
+};
+
+// OSPEEDR register values
+enum class GpioSpeed : uint8_t
+{
+    LOW       = 0U,
+    MEDIUM    = 1U,
+    HIGH      = 2U,
+    VERY_HIGH = 3U
+};
+
+// PUPDR register values
+enum class GpioPull : uint8_t
+{
+    NONE = 0U,
+    UP   = 1U,
+    DOWN = 2U
+};
+
+struct GpioConfig
+{
+    GPIO_TypeDef* port;
+    uint8_t pin; // 0-15
+    GpioMode mode;
+    GpioOutputType otype;
+    GpioSpeed speed;
+    GpioPull pull;
+    uint8_t af; // Alternate function number (0-15)
+};
+
+class Gpio
+{
+public:
+    Gpio() = delete;
+
+    static void enablePortClock(GPIO_TypeDef* port);
+    static void configure(GpioConfig const& cfg);
+    static void setMode(GPIO_TypeDef* port, uint8_t pin, GpioMode mode);
+    static void setOutputType(GPIO_TypeDef* port, uint8_t pin, GpioOutputType otype);
+    static void setSpeed(GPIO_TypeDef* port, uint8_t pin, GpioSpeed speed);
+    static void setPull(GPIO_TypeDef* port, uint8_t pin, GpioPull pull);
+    static void setAlternateFunction(GPIO_TypeDef* port, uint8_t pin, uint8_t af);
+    static bool readPin(GPIO_TypeDef* port, uint8_t pin);
+    static void writePin(GPIO_TypeDef* port, uint8_t pin, bool high);
+    static void togglePin(GPIO_TypeDef* port, uint8_t pin);
+};
+
+} // namespace bios

--- a/platforms/stm32/bsp/bspIo/module.spec
+++ b/platforms/stm32/bsp/bspIo/module.spec
@@ -1,0 +1,3 @@
+maturity: raw
+unit_test: false
+oss: true

--- a/platforms/stm32/bsp/bspIo/src/io/Gpio.cpp
+++ b/platforms/stm32/bsp/bspIo/src/io/Gpio.cpp
@@ -1,0 +1,175 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include <io/Gpio.h>
+
+namespace bios
+{
+
+void Gpio::enablePortClock(GPIO_TypeDef* port)
+{
+#if defined(STM32G474xx)
+    if (port == GPIOA)
+    {
+        RCC->AHB2ENR |= RCC_AHB2ENR_GPIOAEN;
+    }
+    else if (port == GPIOB)
+    {
+        RCC->AHB2ENR |= RCC_AHB2ENR_GPIOBEN;
+    }
+    else if (port == GPIOC)
+    {
+        RCC->AHB2ENR |= RCC_AHB2ENR_GPIOCEN;
+    }
+#if defined(GPIOD)
+    else if (port == GPIOD)
+    {
+        RCC->AHB2ENR |= RCC_AHB2ENR_GPIODEN;
+    }
+#endif
+#if defined(GPIOE)
+    else if (port == GPIOE)
+    {
+        RCC->AHB2ENR |= RCC_AHB2ENR_GPIOEEN;
+    }
+#endif
+#if defined(GPIOF)
+    else if (port == GPIOF)
+    {
+        RCC->AHB2ENR |= RCC_AHB2ENR_GPIOFEN;
+    }
+#endif
+#if defined(GPIOG)
+    else if (port == GPIOG)
+    {
+        RCC->AHB2ENR |= RCC_AHB2ENR_GPIOGEN;
+    }
+#endif
+#elif defined(STM32F413xx)
+    if (port == GPIOA)
+    {
+        RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN;
+    }
+    else if (port == GPIOB)
+    {
+        RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN;
+    }
+    else if (port == GPIOC)
+    {
+        RCC->AHB1ENR |= RCC_AHB1ENR_GPIOCEN;
+    }
+    else if (port == GPIOD)
+    {
+        RCC->AHB1ENR |= RCC_AHB1ENR_GPIODEN;
+    }
+#if defined(GPIOE)
+    else if (port == GPIOE)
+    {
+        RCC->AHB1ENR |= RCC_AHB1ENR_GPIOEEN;
+    }
+#endif
+#if defined(GPIOF)
+    else if (port == GPIOF)
+    {
+        RCC->AHB1ENR |= RCC_AHB1ENR_GPIOFEN;
+    }
+#endif
+#if defined(GPIOG)
+    else if (port == GPIOG)
+    {
+        RCC->AHB1ENR |= RCC_AHB1ENR_GPIOGEN;
+    }
+#endif
+#if defined(GPIOH)
+    else if (port == GPIOH)
+    {
+        RCC->AHB1ENR |= RCC_AHB1ENR_GPIOHEN;
+    }
+#endif
+#endif
+    // Read-back for clock stabilization
+    uint32_t volatile dummy;
+    (void)dummy;
+#if defined(STM32G474xx)
+    dummy = RCC->AHB2ENR;
+#elif defined(STM32F413xx)
+    dummy = RCC->AHB1ENR;
+#endif
+    (void)dummy;
+}
+
+void Gpio::configure(GpioConfig const& cfg)
+{
+    enablePortClock(cfg.port);
+    setMode(cfg.port, cfg.pin, cfg.mode);
+    setOutputType(cfg.port, cfg.pin, cfg.otype);
+    setSpeed(cfg.port, cfg.pin, cfg.speed);
+    setPull(cfg.port, cfg.pin, cfg.pull);
+    if ((cfg.mode == GpioMode::ALTERNATE) && (cfg.af <= 15U))
+    {
+        setAlternateFunction(cfg.port, cfg.pin, cfg.af);
+    }
+}
+
+void Gpio::setMode(GPIO_TypeDef* port, uint8_t pin, GpioMode mode)
+{
+    uint32_t pos = pin * 2U;
+    port->MODER  = (port->MODER & ~(3U << pos)) | (static_cast<uint32_t>(mode) << pos);
+}
+
+void Gpio::setOutputType(GPIO_TypeDef* port, uint8_t pin, GpioOutputType otype)
+{
+    if (otype == GpioOutputType::OPEN_DRAIN)
+    {
+        port->OTYPER |= (1U << pin);
+    }
+    else
+    {
+        port->OTYPER &= ~(1U << pin);
+    }
+}
+
+void Gpio::setSpeed(GPIO_TypeDef* port, uint8_t pin, GpioSpeed speed)
+{
+    uint32_t pos  = pin * 2U;
+    port->OSPEEDR = (port->OSPEEDR & ~(3U << pos)) | (static_cast<uint32_t>(speed) << pos);
+}
+
+void Gpio::setPull(GPIO_TypeDef* port, uint8_t pin, GpioPull pull)
+{
+    uint32_t pos = pin * 2U;
+    port->PUPDR  = (port->PUPDR & ~(3U << pos)) | (static_cast<uint32_t>(pull) << pos);
+}
+
+void Gpio::setAlternateFunction(GPIO_TypeDef* port, uint8_t pin, uint8_t af)
+{
+    uint8_t afrIdx    = (pin < 8U) ? 0U : 1U;
+    uint8_t afrPin    = (pin < 8U) ? pin : (pin - 8U);
+    uint32_t pos      = afrPin * 4U;
+    port->AFR[afrIdx] = (port->AFR[afrIdx] & ~(0xFU << pos)) | (static_cast<uint32_t>(af) << pos);
+}
+
+bool Gpio::readPin(GPIO_TypeDef* port, uint8_t pin) { return (port->IDR & (1U << pin)) != 0U; }
+
+void Gpio::writePin(GPIO_TypeDef* port, uint8_t pin, bool high)
+{
+    if (high)
+    {
+        port->BSRR = (1U << pin);
+    }
+    else
+    {
+        port->BSRR = (1U << (pin + 16U));
+    }
+}
+
+void Gpio::togglePin(GPIO_TypeDef* port, uint8_t pin) { port->ODR ^= (1U << pin); }
+
+} // namespace bios

--- a/platforms/stm32/bsp/bspTimer/CMakeLists.txt
+++ b/platforms/stm32/bsp/bspTimer/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(bspTimer src/bsp/SystemTimer/SystemTimer.cpp)
+
+target_link_libraries(bspTimer PUBLIC bsp bspMcu bspInterrupts)

--- a/platforms/stm32/bsp/bspTimer/doc/index.rst
+++ b/platforms/stm32/bsp/bspTimer/doc/index.rst
@@ -1,0 +1,35 @@
+..
+   *******************************************************************************
+   Copyright (c) 2026 An Dao
+
+   This program and the accompanying materials are made available under the
+   terms of the Apache License Version 2.0 which is available at
+   https://www.apache.org/licenses/LICENSE-2.0
+
+   SPDX-License-Identifier: Apache-2.0
+   *******************************************************************************
+
+bspTimer
+========
+
+Overview
+--------
+
+The ``bspTimer`` module implements the system timer for STM32 Cortex-M4
+targets using the ARM Data Watchpoint and Trace (DWT) cycle counter
+(``CYCCNT``) -- a core debug unit register available on all Cortex-M4 devices
+-- so no chip-specific peripheral timer is required.
+
+The 32-bit ``CYCCNT`` is extended to a 64-bit monotonic microsecond counter;
+updates run under ``SuspendResumeAllInterruptsScopedLock``. The core clock
+frequency used for the cycles-to-microseconds conversion is fixed at compile
+time:
+
+- 96 MHz for STM32F4 (STM32F413ZH)
+- 170 MHz for STM32G4 (STM32G474RE)
+
+The family is selected via the ``STM32_FAMILY_F4`` / ``STM32_FAMILY_G4``
+compile definitions from the bspMcu CMake configuration.
+
+The DWT timer is independent of SysTick: FreeRTOS uses SysTick for its tick
+interrupt while the BSP system timer uses DWT for high-resolution timestamps.

--- a/platforms/stm32/bsp/bspTimer/module.spec
+++ b/platforms/stm32/bsp/bspTimer/module.spec
@@ -1,0 +1,3 @@
+maturity: raw
+unit_test: false
+oss: true

--- a/platforms/stm32/bsp/bspTimer/src/bsp/SystemTimer/SystemTimer.cpp
+++ b/platforms/stm32/bsp/bspTimer/src/bsp/SystemTimer/SystemTimer.cpp
@@ -1,0 +1,91 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "bsp/timer/SystemTimer.h"
+
+#include "interrupts/SuspendResumeAllInterruptsScopedLock.h"
+#include "mcu/mcu.h"
+
+namespace
+{
+#if defined(STM32_FAMILY_F4)
+uint32_t const DWT_FREQ_MHZ = 96U; // F413ZH: 96 MHz HCLK
+#elif defined(STM32_FAMILY_G4)
+uint32_t const DWT_FREQ_MHZ = 170U; // G474RE: 170 MHz HCLK
+#else
+#error "Define STM32_FAMILY_F4 or STM32_FAMILY_G4"
+#endif
+
+// One tick equals one microsecond.
+struct
+{
+    uint64_t ticks;
+    uint32_t lastDwt;
+} state = {0, 0};
+
+uint64_t updateTicks()
+{
+    const ESR_UNUSED interrupts::SuspendResumeAllInterruptsScopedLock lock;
+    uint32_t const curDwt    = DWT->CYCCNT;
+    uint32_t const elapsedUs = (curDwt - state.lastDwt) / DWT_FREQ_MHZ;
+    state.ticks += elapsedUs;
+    // Consume only whole microseconds so the sub-microsecond cycle remainder
+    // carries over to the next call. Setting lastDwt to curDwt would discard
+    // up to DWT_FREQ_MHZ - 1 cycles per call, freezing the clock for callers
+    // polling faster than once per microsecond.
+    state.lastDwt += elapsedUs * DWT_FREQ_MHZ;
+    return state.ticks;
+}
+
+} // namespace
+
+extern "C"
+{
+void initSystemTimer()
+{
+    const ESR_UNUSED interrupts::SuspendResumeAllInterruptsScopedLock lock;
+
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+    DWT->CYCCNT = 0U;
+    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+
+    state.ticks   = 0;
+    state.lastDwt = 0;
+}
+
+uint64_t getSystemTicks(void) { return updateTicks(); }
+
+uint32_t getSystemTicks32Bit(void) { return static_cast<uint32_t>(updateTicks()); }
+
+uint64_t getSystemTimeNs(void) { return updateTicks() * 1000U; }
+
+uint64_t getSystemTimeUs(void) { return updateTicks(); }
+
+uint32_t getSystemTimeUs32Bit(void) { return static_cast<uint32_t>(updateTicks()); }
+
+uint64_t getSystemTimeMs(void) { return updateTicks() / 1000U; }
+
+uint32_t getSystemTimeMs32Bit(void) { return static_cast<uint32_t>(updateTicks() / 1000U); }
+
+uint64_t systemTicksToTimeUs(uint64_t const ticks) { return ticks; }
+
+uint64_t systemTicksToTimeNs(uint64_t const ticks) { return ticks * 1000U; }
+
+uint32_t getFastTicks(void) { return DWT->CYCCNT; }
+
+uint32_t getFastTicksPerSecond(void) { return DWT_FREQ_MHZ * 1000000U; }
+
+void sysDelayUs(uint32_t const delay)
+{
+    uint64_t const start = getSystemTimeUs();
+    while (getSystemTimeUs() < start + delay) {}
+}
+
+} // extern "C"

--- a/platforms/stm32/bsp/bspUart/CMakeLists.txt
+++ b/platforms/stm32/bsp/bspUart/CMakeLists.txt
@@ -1,0 +1,13 @@
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
+    # Header-only for unit tests (no hardware-dependent Uart.cpp)
+    add_library(bspUart INTERFACE)
+    target_include_directories(bspUart INTERFACE include)
+    target_link_libraries(bspUart INTERFACE bsp)
+else ()
+    add_library(bspUart src/Uart.cpp)
+    target_include_directories(bspUart PUBLIC include)
+    # bspMcu must be PUBLIC: the public header bsp/UartParams.h includes
+    # mcu/mcu.h and uses device types, so consumers need bspMcu's include paths
+    # and device-macro compile definitions.
+    target_link_libraries(bspUart PUBLIC bsp bspMcu)
+endif ()

--- a/platforms/stm32/bsp/bspUart/doc/index.rst
+++ b/platforms/stm32/bsp/bspUart/doc/index.rst
@@ -1,0 +1,41 @@
+..
+   *******************************************************************************
+   Copyright (c) 2026 An Dao
+
+   This program and the accompanying materials are made available under the
+   terms of the Apache License Version 2.0 which is available at
+   https://www.apache.org/licenses/LICENSE-2.0
+
+   SPDX-License-Identifier: Apache-2.0
+   *******************************************************************************
+
+bspUart Driver
+==============
+
+Overview
+--------
+
+The ``bspUart`` module provides a polling-mode UART driver for debug console
+output on STM32 targets. It is used by the logger subsystem and the command
+shell for human-readable output over the ST-LINK Virtual COM Port (VCP). The
+driver is the ``bsp::Uart`` class and satisfies the ``UartConcept``
+compile-time interface check (``BSP_UART_CONCEPT_CHECKER``).
+
+All I/O is synchronous polling; no DMA or interrupts are used, which avoids
+NVIC configuration dependencies at the cost of blocking the caller during
+transmission.
+
+Configuration
+-------------
+
+Each UART instance is described by a ``UartConfig`` struct in a compile-time
+table (``_uartConfigs[]``): USART peripheral, GPIO port and TX/RX pins,
+alternate function number, and baud rate register value (typically 115200
+baud for the debug console).
+
+Board configuration:
+
+- **NUCLEO-F413ZH** -- USART3 on PD8 (TX) / PD9 (RX), AF7. VCP via ST-LINK
+  V2-1.
+- **NUCLEO-G474RE** -- USART2 on PA2 (TX) / PA3 (RX), AF7. VCP via ST-LINK
+  V3.

--- a/platforms/stm32/bsp/bspUart/include/bsp/Uart.h
+++ b/platforms/stm32/bsp/bspUart/include/bsp/Uart.h
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#pragma once
+
+#include <bsp/uart/UartConcept.h>
+
+namespace bsp
+{
+
+class Uart
+{
+public:
+    enum class Id : size_t;
+
+    size_t write(::etl::span<uint8_t const> const data);
+    size_t read(::etl::span<uint8_t> data);
+    void init();
+    bool isInitialized() const;
+    bool waitForTxReady();
+
+    static Uart& getInstance(Id id);
+
+    struct UartConfig;
+    Uart(Uart::Id id);
+
+private:
+    bool writeByte(uint8_t data);
+
+    UartConfig const& _uartConfig;
+    static UartConfig const _uartConfigs[];
+};
+
+BSP_UART_CONCEPT_CHECKER(Uart)
+
+} // namespace bsp

--- a/platforms/stm32/bsp/bspUart/include/bsp/UartParams.h
+++ b/platforms/stm32/bsp/bspUart/include/bsp/UartParams.h
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#pragma once
+
+#include "bsp/Uart.h"
+
+#include <mcu/mcu.h>
+
+namespace bsp
+{
+
+struct Uart::UartConfig
+{
+    USART_TypeDef* usart;
+    GPIO_TypeDef* gpioPort;
+    uint8_t txPin;
+    uint8_t rxPin;
+    uint8_t af;
+    uint32_t brr;
+    uint32_t rccGpioEnBit;
+    uint32_t rccUsartEnBit;
+    uint32_t volatile* rccGpioEnReg;
+    uint32_t volatile* rccUsartEnReg;
+};
+
+} // namespace bsp

--- a/platforms/stm32/bsp/bspUart/module.spec
+++ b/platforms/stm32/bsp/bspUart/module.spec
@@ -1,0 +1,3 @@
+maturity: raw
+unit_test: false
+oss: true

--- a/platforms/stm32/bsp/bspUart/src/Uart.cpp
+++ b/platforms/stm32/bsp/bspUart/src/Uart.cpp
@@ -1,0 +1,128 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "bsp/UartParams.h"
+
+using bsp::Uart;
+
+static uint32_t const WRITE_TIMEOUT = 100000U;
+
+// STM32F4 uses SR/DR registers, STM32G4 uses ISR/TDR/RDR registers
+#if defined(STM32F413xx)
+#define UART_TX_EMPTY_FLAG    USART_SR_TXE
+#define UART_RX_READY_FLAG    USART_SR_RXNE
+#define UART_GET_STATUS(u)    ((u)->SR)
+#define UART_WRITE_DATA(u, d) ((u)->DR = (d))
+#define UART_READ_DATA(u)     ((u)->DR & 0xFFU)
+#elif defined(STM32G474xx)
+#define UART_TX_EMPTY_FLAG    USART_ISR_TXE
+#define UART_RX_READY_FLAG    USART_ISR_RXNE_RXFNE
+#define UART_GET_STATUS(u)    ((u)->ISR)
+#define UART_WRITE_DATA(u, d) ((u)->TDR = (d))
+#define UART_READ_DATA(u)     ((u)->RDR & 0xFFU)
+#endif
+
+static void configureGpio(Uart::UartConfig const& cfg)
+{
+    *cfg.rccGpioEnReg |= cfg.rccGpioEnBit;
+
+    cfg.gpioPort->MODER &= ~(3U << (cfg.txPin * 2U));
+    cfg.gpioPort->MODER |= (2U << (cfg.txPin * 2U));
+    uint32_t const txAfrIdx = cfg.txPin / 8U;
+    uint32_t const txAfrPos = (cfg.txPin % 8U) * 4U;
+    cfg.gpioPort->AFR[txAfrIdx] &= ~(0xFU << txAfrPos);
+    cfg.gpioPort->AFR[txAfrIdx] |= (static_cast<uint32_t>(cfg.af) << txAfrPos);
+
+    cfg.gpioPort->MODER &= ~(3U << (cfg.rxPin * 2U));
+    cfg.gpioPort->MODER |= (2U << (cfg.rxPin * 2U));
+    uint32_t const rxAfrIdx = cfg.rxPin / 8U;
+    uint32_t const rxAfrPos = (cfg.rxPin % 8U) * 4U;
+    cfg.gpioPort->AFR[rxAfrIdx] &= ~(0xFU << rxAfrPos);
+    cfg.gpioPort->AFR[rxAfrIdx] |= (static_cast<uint32_t>(cfg.af) << rxAfrPos);
+}
+
+Uart::Uart(Uart::Id id) : _uartConfig(_uartConfigs[static_cast<size_t>(id)]) {}
+
+void Uart::init()
+{
+    configureGpio(_uartConfig);
+
+    *_uartConfig.rccUsartEnReg |= _uartConfig.rccUsartEnBit;
+
+    // BRR must be written while UE is cleared
+    _uartConfig.usart->CR1 = 0;
+    _uartConfig.usart->BRR = _uartConfig.brr;
+    _uartConfig.usart->CR1 = USART_CR1_TE | USART_CR1_RE | USART_CR1_UE;
+}
+
+bool Uart::isInitialized() const
+{
+    return (_uartConfig.usart->CR1 & (USART_CR1_TE | USART_CR1_RE)) != 0;
+}
+
+bool Uart::waitForTxReady()
+{
+    uint32_t count = 0U;
+
+    if (!isInitialized())
+    {
+        init();
+    }
+
+    while ((UART_GET_STATUS(_uartConfig.usart) & UART_TX_EMPTY_FLAG) == 0)
+    {
+        ++count;
+        if (count > WRITE_TIMEOUT)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool Uart::writeByte(uint8_t data)
+{
+    if ((UART_GET_STATUS(_uartConfig.usart) & UART_TX_EMPTY_FLAG) != 0)
+    {
+        UART_WRITE_DATA(_uartConfig.usart, static_cast<uint32_t>(data) & 0xFFU);
+        return waitForTxReady();
+    }
+    return false;
+}
+
+size_t Uart::write(::etl::span<uint8_t const> const data)
+{
+    size_t counter = 0;
+
+    while (counter < data.size())
+    {
+        if (!writeByte(data[counter]))
+        {
+            break;
+        }
+        counter++;
+    }
+
+    return counter;
+}
+
+size_t Uart::read(::etl::span<uint8_t> data)
+{
+    size_t bytesRead = 0;
+
+    while ((UART_GET_STATUS(_uartConfig.usart) & UART_RX_READY_FLAG) != 0
+           && bytesRead < data.size())
+    {
+        data[bytesRead] = static_cast<uint8_t>(UART_READ_DATA(_uartConfig.usart));
+        bytesRead++;
+    }
+
+    return bytesRead;
+}

--- a/platforms/stm32/etlImpl/CMakeLists.txt
+++ b/platforms/stm32/etlImpl/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(etlImpl src/print.cpp src/clocks.cpp)
+
+target_link_libraries(etlImpl PRIVATE etl bsp util)

--- a/platforms/stm32/etlImpl/src/clocks.cpp
+++ b/platforms/stm32/etlImpl/src/clocks.cpp
@@ -1,0 +1,30 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include <bsp/timer/SystemTimer.h>
+#include <etl/chrono.h>
+
+extern "C"
+{
+etl::chrono::high_resolution_clock::rep etl_get_high_resolution_clock()
+{
+    return etl::chrono::high_resolution_clock::rep{static_cast<int64_t>(getSystemTimeNs())};
+}
+
+etl::chrono::system_clock::rep etl_get_system_clock()
+{
+    return etl::chrono::system_clock::rep(static_cast<int64_t>(getSystemTimeUs()));
+}
+
+etl::chrono::steady_clock::rep etl_get_steady_clock()
+{
+    return etl::chrono::steady_clock::rep(static_cast<int64_t>(getSystemTimeMs() / 1000));
+}
+}

--- a/platforms/stm32/etlImpl/src/print.cpp
+++ b/platforms/stm32/etlImpl/src/print.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include <etl/print.h>
+#include <util/stream/BspStubs.h>
+
+extern "C" void etl_putchar(int c) { putByteToStdout(static_cast<uint8_t>(c)); }


### PR DESCRIPTION
Adds the STM32 BSP peripheral driver modules on top of the merged MCU foundation (#413):

- `bspClock` — clock tree / PLL configuration for STM32F4 (F413ZH, 96 MHz) and STM32G4 (G474RE, 170 MHz), with HSI fallback if the PLL fails to lock
- `bspUart` — polling UART driver used for the debug console (ST-LINK VCP)
- `bspIo` — register-level GPIO driver (`bios::Gpio`)
- `bspTimer` — system timer built on the DWT cycle counter, implementing the `SystemTimer` BSP API
- `bspInterruptsImpl` — interrupt disable/suspend primitives (FreeRTOS and ThreadX variants)
- `etlImpl` — ETL platform glue (clocks, print)

Each module ships with `module.spec` and a documentation introduction per the module guidelines. Pin assignments and other board decisions are left to the board configuration, which follows in the next PRs of the series together with the executables that consume these drivers.

All sources compile standalone against `main` for both `STM32F413xx` and `STM32G474xx` with arm-none-eabi-gcc (`-Wall -Wextra -Werror`).
