### PR TITLE
Add STM32 FDCAN transceiver adapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
         add_subdirectory(platforms/stm32/bsp/bspCan/test)
         add_subdirectory(platforms/stm32/bsp/bxCanTransceiver/test)
+        add_subdirectory(platforms/stm32/bsp/fdCanTransceiver/test)
 
     elseif (OPENBSW_PLATFORM STREQUAL "s32k1xx")
 

--- a/platforms/stm32/bsp/CMakeLists.txt
+++ b/platforms/stm32/bsp/CMakeLists.txt
@@ -2,6 +2,7 @@ if (BUILD_EXECUTABLE STREQUAL "unitTest")
     # Unit test builds: only compile transceivers (with mock devices). Skip
     # hardware-dependent modules (bspMcu, bspClock, bspCan, etc.).
     add_subdirectory(bxCanTransceiver)
+    add_subdirectory(fdCanTransceiver)
     add_subdirectory(bspUart)
 else ()
     add_subdirectory(bspMcu)
@@ -15,6 +16,8 @@ else ()
     # CAN transceiver - selected by chip family
     if (CAN_TYPE STREQUAL "BXCAN")
         add_subdirectory(bxCanTransceiver)
+    elseif (CAN_TYPE STREQUAL "FDCAN")
+        add_subdirectory(fdCanTransceiver)
     endif ()
 
     # Aggregated BSP target

--- a/platforms/stm32/bsp/fdCanTransceiver/CMakeLists.txt
+++ b/platforms/stm32/bsp/fdCanTransceiver/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_library(fdCanTransceiver src/can/transceiver/fdcan/FdCanTransceiver.cpp)
+
+if (BUILD_EXECUTABLE STREQUAL "unitTest")
+    target_include_directories(fdCanTransceiver PUBLIC include
+                                                       test/mock/include)
+
+    target_link_libraries(
+        fdCanTransceiver
+        PUBLIC asyncMockImpl
+               bsp
+               cpp2can
+               etl
+               bspIo
+               lifecycle
+               gmock)
+else ()
+    target_include_directories(fdCanTransceiver PUBLIC include)
+
+    target_link_libraries(fdCanTransceiver PUBLIC async bspCan lifecycle
+                                                  cpp2can)
+endif ()

--- a/platforms/stm32/bsp/fdCanTransceiver/doc/index.rst
+++ b/platforms/stm32/bsp/fdCanTransceiver/doc/index.rst
@@ -1,0 +1,50 @@
+..
+   *******************************************************************************
+   Copyright (c) 2026 An Dao
+
+   This program and the accompanying materials are made available under the
+   terms of the Apache License Version 2.0 which is available at
+   https://www.apache.org/licenses/LICENSE-2.0
+
+   SPDX-License-Identifier: Apache-2.0
+   *******************************************************************************
+
+fdCanTransceiver
+================
+
+Overview
+--------
+Implements the OpenBSW ``AbstractCANTransceiver`` interface for the STM32
+FDCAN peripheral. Wraps the register-level ``FdCanDevice`` (``bspCan`` module)
+and adds lifecycle management, async task integration, ISR dispatch and
+bus-off recovery. The peripheral runs in classic CAN mode at 500 kbps.
+
+Lifecycle
+---------
+The transceiver follows the ``AbstractCANTransceiver`` state model
+(``CLOSED`` -> ``INITIALIZED`` -> ``OPEN`` <-> ``MUTED``). ``init()`` and
+``open()`` delegate to ``FdCanDevice::init()`` and ``FdCanDevice::start()``;
+``close()`` stops the device from any state. ``mute()`` and ``unmute()``
+suppress and resume transmission while reception stays active.
+
+TX Path
+-------
+``write(frame)`` transmits fire-and-forget and notifies sent-listeners
+synchronously. ``write(frame, listener)`` queues the job, transmits with the
+TX-complete interrupt enabled, and invokes ``listener.canFrameSent()`` from
+task context (deferred via ``async::execute``) after the TX ISR; further
+queued frames are sent one after another from that callback chain.
+
+RX Path
+-------
+``receiveInterrupt()`` runs in the RX ISR and delegates to
+``FdCanDevice::receiveISR(nullptr)``, accepting all frames into the software
+queue; per-listener filtering happens later in ``notifyListeners()``.
+``receiveTask()`` runs in task context, notifies listeners for each queued
+frame, clears the queue and re-enables the RX interrupt.
+
+Bus-Off Recovery
+----------------
+``cyclicTask()`` polls ``FdCanDevice::isBusOff()`` periodically. On bus-off
+the transceiver transitions from ``OPEN`` to ``MUTED``; once the peripheral
+recovers it returns to ``OPEN``, unless the user explicitly called ``mute()``.

--- a/platforms/stm32/bsp/fdCanTransceiver/include/can/transceiver/fdcan/FdCanTransceiver.h
+++ b/platforms/stm32/bsp/fdCanTransceiver/include/can/transceiver/fdcan/FdCanTransceiver.h
@@ -1,0 +1,109 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#pragma once
+
+#include <async/Async.h>
+#include <async/util/Call.h>
+#include <can/FdCanDevice.h>
+#include <can/canframes/ICANFrameSentListener.h>
+#include <can/transceiver/AbstractCANTransceiver.h>
+
+#include <etl/deque.h>
+
+namespace bios
+{
+
+/**
+ * CAN transceiver for STM32 FDCAN peripheral.
+ *
+ * Wraps FdCanDevice to implement the AbstractCANTransceiver interface.
+ * Operates in classic CAN mode at 500 kbps on STM32G4 family devices.
+ *
+ * \see AbstractCANTransceiver
+ * \see FdCanDevice
+ */
+class FdCanTransceiver : public ::can::AbstractCANTransceiver
+{
+public:
+    FdCanTransceiver(
+        ::async::ContextType context, uint8_t busId, FdCanDevice::Config const& devConfig);
+
+    ErrorCode init() override;
+    ErrorCode open() override;
+    ErrorCode open(::can::CANFrame const& frame) override;
+    ErrorCode close() override;
+    void shutdown() override;
+    ErrorCode mute() override;
+    ErrorCode unmute() override;
+
+    /// Fire-and-forget transmit. Calls notifySentListeners() synchronously.
+    ErrorCode write(::can::CANFrame const& frame) override;
+
+    /// Transmit with deferred callback. Queues {listener, frame} into fTxQueue.
+    /// canFrameSent() fires from task context after TX ISR, NOT from write().
+    ErrorCode write(::can::CANFrame const& frame, ::can::ICANFrameSentListener& listener) override;
+
+    uint32_t getBaudrate() const override;
+    uint16_t getHwQueueTimeout() const override;
+
+    /// Number of TX frames dropped due to HW queue full or TX listener queue full.
+    uint32_t getOverrunCount() const { return fOverrunCount; }
+
+    static uint8_t receiveInterrupt(uint8_t transceiverIndex);
+    static void transmitInterrupt(uint8_t transceiverIndex);
+    static void disableRxInterrupt(uint8_t transceiverIndex);
+    static void enableRxInterrupt(uint8_t transceiverIndex);
+
+    void cyclicTask();
+    void receiveTask();
+
+    /// Underlying FDCAN hardware device. Public for test access.
+    FdCanDevice fDevice;
+
+private:
+    /// TX job queued for async callback.
+    struct TxJobWithCallback
+    {
+        TxJobWithCallback(::can::ICANFrameSentListener& listener, ::can::CANFrame const& frame)
+        : _listener(listener), _frame(frame)
+        {}
+
+        ::can::ICANFrameSentListener& _listener;
+        ::can::CANFrame _frame;
+    };
+
+    /// Depth of the hardware TX path (3-element FDCAN TX FIFO). Also sizes
+    /// the software job queue: one pending listener job per hardware slot.
+    static constexpr uint32_t TX_HW_FIFO_DEPTH = 3U;
+
+    static uint32_t const TX_QUEUE_CAPACITY = TX_HW_FIFO_DEPTH;
+    using TxQueue                           = ::etl::deque<TxJobWithCallback, TX_QUEUE_CAPACITY>;
+
+    /// Called from TX ISR - defers to task context via async::execute.
+    void canFrameSentCallback();
+
+    /// Runs in task context - pops TX queue, calls listener, sends next frame.
+    void canFrameSentAsyncCallback();
+
+    void notifyRegisteredSentListener(::can::CANFrame const& frame) { notifySentListeners(frame); }
+
+    static FdCanTransceiver* fpTransceivers[3];
+
+    ::async::ContextType fContext;
+    ::async::TimeoutType fCyclicTimeout;
+    ::async::Function _cyclicTaskRunner;
+    ::async::Function _canFrameSent;
+    TxQueue fTxQueue;
+    uint32_t fOverrunCount;
+    bool fMuted;
+};
+
+} // namespace bios

--- a/platforms/stm32/bsp/fdCanTransceiver/module.spec
+++ b/platforms/stm32/bsp/fdCanTransceiver/module.spec
@@ -1,0 +1,2 @@
+maturity: raw
+oss: true

--- a/platforms/stm32/bsp/fdCanTransceiver/src/can/transceiver/fdcan/FdCanTransceiver.cpp
+++ b/platforms/stm32/bsp/fdCanTransceiver/src/can/transceiver/fdcan/FdCanTransceiver.cpp
@@ -1,0 +1,308 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include <can/transceiver/fdcan/FdCanTransceiver.h>
+
+#include <can/canframes/ICANFrameSentListener.h>
+
+namespace bios
+{
+
+FdCanTransceiver* FdCanTransceiver::fpTransceivers[3] = {nullptr, nullptr, nullptr};
+
+FdCanTransceiver::FdCanTransceiver(
+    ::async::ContextType context, uint8_t busId, FdCanDevice::Config const& devConfig)
+: AbstractCANTransceiver(busId)
+, fDevice(
+      devConfig,
+      ::etl::delegate<void()>::create<FdCanTransceiver, &FdCanTransceiver::canFrameSentCallback>(
+          *this))
+, fContext(context)
+, fCyclicTimeout()
+, _cyclicTaskRunner(
+      ::async::Function::CallType::create<FdCanTransceiver, &FdCanTransceiver::cyclicTask>(*this))
+, _canFrameSent(::async::Function::CallType::
+                    create<FdCanTransceiver, &FdCanTransceiver::canFrameSentAsyncCallback>(*this))
+, fTxQueue()
+, fOverrunCount(0U)
+, fMuted(false)
+{
+    if (busId < 3U)
+    {
+        fpTransceivers[busId] = this;
+    }
+}
+
+::can::ICanTransceiver::ErrorCode FdCanTransceiver::init()
+{
+    if (getState() != State::CLOSED)
+    {
+        return ErrorCode::CAN_ERR_ILLEGAL_STATE;
+    }
+
+    if (!fDevice.init())
+    {
+        return ErrorCode::CAN_ERR_INIT_FAILED;
+    }
+    setState(State::INITIALIZED);
+    return ErrorCode::CAN_ERR_OK;
+}
+
+::can::ICanTransceiver::ErrorCode FdCanTransceiver::open()
+{
+    State const state = getState();
+    if (state != State::INITIALIZED && state != State::CLOSED)
+    {
+        return ErrorCode::CAN_ERR_ILLEGAL_STATE;
+    }
+
+    if (state == State::CLOSED)
+    {
+        if (!fDevice.init())
+        {
+            return ErrorCode::CAN_ERR_INIT_FAILED;
+        }
+    }
+
+    if (!fDevice.start())
+    {
+        return ErrorCode::CAN_ERR_ILLEGAL_STATE;
+    }
+    setState(State::OPEN);
+    fMuted = false;
+
+    // Auto-schedule bus-off polling.
+    ::async::scheduleAtFixedRate(
+        fContext, _cyclicTaskRunner, fCyclicTimeout, 10U, ::async::TimeUnit::MILLISECONDS);
+
+    return ErrorCode::CAN_ERR_OK;
+}
+
+::can::ICanTransceiver::ErrorCode FdCanTransceiver::open(::can::CANFrame const& /* frame */)
+{
+    return open();
+}
+
+::can::ICanTransceiver::ErrorCode FdCanTransceiver::close()
+{
+    if (getState() == State::CLOSED)
+    {
+        return ErrorCode::CAN_ERR_OK;
+    }
+
+    fCyclicTimeout.cancel();
+    fDevice.stop();
+    setState(State::CLOSED);
+    return ErrorCode::CAN_ERR_OK;
+}
+
+void FdCanTransceiver::shutdown() { close(); }
+
+::can::ICanTransceiver::ErrorCode FdCanTransceiver::mute()
+{
+    if (getState() != State::OPEN)
+    {
+        return ErrorCode::CAN_ERR_ILLEGAL_STATE;
+    }
+
+    fMuted = true;
+    setState(State::MUTED);
+    return ErrorCode::CAN_ERR_OK;
+}
+
+::can::ICanTransceiver::ErrorCode FdCanTransceiver::unmute()
+{
+    if (getState() != State::MUTED)
+    {
+        return ErrorCode::CAN_ERR_ILLEGAL_STATE;
+    }
+
+    fMuted = false;
+    setState(State::OPEN);
+    return ErrorCode::CAN_ERR_OK;
+}
+
+::can::ICanTransceiver::ErrorCode FdCanTransceiver::write(::can::CANFrame const& frame)
+{
+    if (getState() != State::OPEN || fMuted)
+    {
+        return ErrorCode::CAN_ERR_TX_OFFLINE;
+    }
+
+    // Transmit without TX-complete interrupt; no deferred callback is needed.
+    if (!fDevice.transmit(frame, false))
+    {
+        fOverrunCount++;
+        return ErrorCode::CAN_ERR_TX_HW_QUEUE_FULL;
+    }
+
+    notifySentListeners(frame);
+    return ErrorCode::CAN_ERR_OK;
+}
+
+::can::ICanTransceiver::ErrorCode
+FdCanTransceiver::write(::can::CANFrame const& frame, ::can::ICANFrameSentListener& listener)
+{
+    if (getState() != State::OPEN || fMuted)
+    {
+        return ErrorCode::CAN_ERR_TX_OFFLINE;
+    }
+
+    if (fTxQueue.full())
+    {
+        fOverrunCount++;
+        notifyRegisteredSentListener(frame);
+        return ErrorCode::CAN_ERR_TX_HW_QUEUE_FULL;
+    }
+
+    bool const wasEmpty = fTxQueue.empty();
+    fTxQueue.emplace_back(listener, frame);
+
+    if (!wasEmpty)
+    {
+        // Next frame will be sent from TX ISR callback chain.
+        return ErrorCode::CAN_ERR_OK;
+    }
+
+    // First sender - transmit with TX-complete interrupt enabled.
+    // Device enables TCE, ISR will fire on completion and invoke callback delegate.
+    if (!fDevice.transmit(frame, true))
+    {
+        fTxQueue.pop_front();
+        fOverrunCount++;
+        notifyRegisteredSentListener(frame);
+        return ErrorCode::CAN_ERR_TX_HW_QUEUE_FULL;
+    }
+
+    // Wait until TX ISR -> fFrameSentCallback -> canFrameSentCallback().
+    return ErrorCode::CAN_ERR_OK;
+}
+
+uint32_t FdCanTransceiver::getBaudrate() const { return fDevice.getBaudrate(); }
+
+uint16_t FdCanTransceiver::getHwQueueTimeout() const
+{
+    // Time for the hardware TX FIFO to drain: TX_HW_FIFO_DEPTH frames x (53 bit
+    // CAN overhead + 64 bit payload) at the configured bit rate, rounded up
+    // to the next millisecond so the timeout is never 0 ms.
+    uint32_t const baudrate = fDevice.getBaudrate();
+    // NOLINTNEXTLINE(clang-analyzer-core.DivideZero): CAN baudrate can never be zero here.
+    return static_cast<uint16_t>(
+        ((TX_HW_FIFO_DEPTH * (53U + 64U) * 1000U) + baudrate - 1U) / baudrate);
+}
+
+uint8_t FdCanTransceiver::receiveInterrupt(uint8_t transceiverIndex)
+{
+    if (transceiverIndex < 3U && fpTransceivers[transceiverIndex] != nullptr)
+    {
+        // Accept all frames at ISR level. Per-listener filtering happens in
+        // notifyListeners() during receiveTask().
+        return fpTransceivers[transceiverIndex]->fDevice.receiveISR(nullptr);
+    }
+    return 0U;
+}
+
+void FdCanTransceiver::transmitInterrupt(uint8_t transceiverIndex)
+{
+    if (transceiverIndex < 3U && fpTransceivers[transceiverIndex] != nullptr)
+    {
+        // Device's transmitISR() disables TCE, clears TC, and invokes the
+        // callback delegate (bound to canFrameSentCallback).
+        fpTransceivers[transceiverIndex]->fDevice.transmitISR();
+    }
+}
+
+void FdCanTransceiver::canFrameSentCallback() { ::async::execute(fContext, _canFrameSent); }
+
+void FdCanTransceiver::canFrameSentAsyncCallback()
+{
+    if (!fTxQueue.empty())
+    {
+        bool sendAgain = false;
+        {
+            TxJobWithCallback& job                 = fTxQueue.front();
+            ::can::CANFrame const& frame           = job._frame;
+            ::can::ICANFrameSentListener& listener = job._listener;
+            fTxQueue.pop_front();
+
+            if (!fTxQueue.empty())
+            {
+                // Send again only if same precondition as for write() is satisfied.
+                State const state = getState();
+                if ((State::OPEN == state) || (State::INITIALIZED == state))
+                {
+                    sendAgain = true;
+                }
+                else
+                {
+                    fTxQueue.clear();
+                }
+            }
+
+            listener.canFrameSent(frame);
+            notifyRegisteredSentListener(frame);
+        }
+
+        if (sendAgain)
+        {
+            ::can::CANFrame const& frame = fTxQueue.front()._frame;
+            // Transmit next queued frame with TX-complete interrupt enabled.
+            if (!fDevice.transmit(frame, true))
+            {
+                fTxQueue.clear();
+            }
+        }
+    }
+}
+
+void FdCanTransceiver::disableRxInterrupt(uint8_t transceiverIndex)
+{
+    if (transceiverIndex < 3U && fpTransceivers[transceiverIndex] != nullptr)
+    {
+        fpTransceivers[transceiverIndex]->fDevice.disableRxInterrupt();
+    }
+}
+
+void FdCanTransceiver::enableRxInterrupt(uint8_t transceiverIndex)
+{
+    if (transceiverIndex < 3U && fpTransceivers[transceiverIndex] != nullptr)
+    {
+        fpTransceivers[transceiverIndex]->fDevice.enableRxInterrupt();
+    }
+}
+
+void FdCanTransceiver::cyclicTask()
+{
+    if (fDevice.isBusOff())
+    {
+        if (getState() == State::OPEN)
+        {
+            setState(State::MUTED);
+        }
+    }
+    else if (getState() == State::MUTED && !fMuted)
+    {
+        setState(State::OPEN);
+    }
+}
+
+void FdCanTransceiver::receiveTask()
+{
+    uint8_t count = fDevice.getRxCount();
+    for (uint8_t i = 0U; i < count; i++)
+    {
+        notifyListeners(fDevice.getRxFrame(i));
+    }
+    fDevice.clearRxQueue();
+    // Re-enable RX FIFO interrupt after draining software queue
+    fDevice.enableRxInterrupt();
+}
+
+} // namespace bios

--- a/platforms/stm32/bsp/fdCanTransceiver/test/CMakeLists.txt
+++ b/platforms/stm32/bsp/fdCanTransceiver/test/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(FdCanTransceiverTest src/can/FdCanTransceiverTest.cpp)
+
+target_link_libraries(
+    FdCanTransceiverTest
+    PRIVATE asyncMockImpl
+            bsp
+            fdCanTransceiver
+            cpp2can
+            bspIo
+            lifecycle
+            bspMock
+            gmock)
+
+gtest_discover_tests(FdCanTransceiverTest PROPERTIES LABELS
+                                                     "FdCanTransceiverTest")

--- a/platforms/stm32/bsp/fdCanTransceiver/test/mock/include/can/FdCanDevice.h
+++ b/platforms/stm32/bsp/fdCanTransceiver/test/mock/include/can/FdCanDevice.h
@@ -1,0 +1,100 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#pragma once
+
+#include <can/canframes/CANFrame.h>
+#include <etl/delegate.h>
+#include <etl/span.h>
+#include <stdint.h>
+
+#include <gmock/gmock.h>
+
+namespace bios
+{
+
+// GMock replacement for the register-level FdCanDevice.
+class FdCanDevice
+{
+public:
+    struct Config
+    {
+        uint32_t baseAddress;
+        uint32_t prescaler;
+        uint32_t nts1;
+        uint32_t nts2;
+        uint32_t nsjw;
+        uint32_t baudrate;
+        uint32_t rxGpioPort;
+        uint8_t rxPin;
+        uint8_t rxAf;
+        uint32_t txGpioPort;
+        uint8_t txPin;
+        uint8_t txAf;
+    };
+
+    static constexpr uint32_t RX_QUEUE_SIZE = 32U;
+
+    explicit FdCanDevice(Config const& config) : fConfig(config)
+    {
+        ON_CALL(*this, init()).WillByDefault(::testing::Return(true));
+        ON_CALL(*this, start()).WillByDefault(::testing::Return(true));
+    }
+
+    FdCanDevice(Config const& config, ::etl::delegate<void()> callback)
+    : fConfig(config), fFrameSentCallback(callback)
+    {
+        ON_CALL(*this, init()).WillByDefault(::testing::Return(true));
+        ON_CALL(*this, start()).WillByDefault(::testing::Return(true));
+    }
+
+    // Plain accessor like the real device - not mocked.
+    uint32_t getBaudrate() const { return fConfig.baudrate; }
+
+    MOCK_METHOD(bool, init, ());
+    MOCK_METHOD(bool, start, ());
+    MOCK_METHOD(void, stop, ());
+    MOCK_METHOD(bool, transmit, (::can::CANFrame const& frame));
+    MOCK_METHOD(bool, transmit, (::can::CANFrame const& frame, bool txInterruptNeeded));
+    MOCK_METHOD(uint8_t, receiveISR, (uint8_t const* filterBitField));
+
+    // Mock transmitISR - tests can set expectations on it.
+    // Default action invokes the stored callback delegate (matching real FdCanDevice).
+    MOCK_METHOD(void, transmitISR, ());
+
+    void setupDefaultTransmitISR()
+    {
+        ON_CALL(*this, transmitISR())
+            .WillByDefault(
+                [this]()
+                {
+                    if (fFrameSentCallback.is_valid())
+                    {
+                        fFrameSentCallback();
+                    }
+                });
+    }
+
+    MOCK_METHOD(bool, isBusOff, (), (const));
+    MOCK_METHOD(uint8_t, getTxErrorCounter, (), (const));
+    MOCK_METHOD(uint8_t, getRxErrorCounter, (), (const));
+    MOCK_METHOD(void, configureAcceptAllFilter, ());
+    MOCK_METHOD(void, configureFilterList, (::etl::span<uint32_t const> idList));
+    MOCK_METHOD(::can::CANFrame const&, getRxFrame, (uint8_t index), (const));
+    MOCK_METHOD(uint8_t, getRxCount, (), (const));
+    MOCK_METHOD(void, clearRxQueue, ());
+    MOCK_METHOD(void, disableRxInterrupt, ());
+    MOCK_METHOD(void, enableRxInterrupt, ());
+
+    Config const fConfig;
+    ::etl::delegate<void()> fFrameSentCallback;
+};
+
+} // namespace bios

--- a/platforms/stm32/bsp/fdCanTransceiver/test/src/can/FdCanTransceiverTest.cpp
+++ b/platforms/stm32/bsp/fdCanTransceiver/test/src/can/FdCanTransceiverTest.cpp
@@ -1,0 +1,920 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "can/transceiver/fdcan/FdCanTransceiver.h"
+
+#include "async/AsyncMock.h"
+#include "can/canframes/ICANFrameSentListener.h"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+using namespace ::can;
+using namespace ::testing;
+using namespace ::bios;
+
+// Mock for ICANFrameSentListener (write-with-listener / DoCAN callback)
+class MockCANFrameSentListener : public ::can::ICANFrameSentListener
+{
+public:
+    MOCK_METHOD(void, canFrameSent, (::can::CANFrame const&), (override));
+};
+
+// Fixture: bare transceiver (CLOSED state)
+class FdCanTransceiverTest : public Test
+{
+public:
+    FdCanTransceiverTest() { fDevConfig.baudrate = 500000U; }
+
+    ::async::AsyncMock fAsyncMock;
+    ::async::ContextType fAsyncContext = 0;
+    uint8_t fBusId                     = 0;
+    FdCanDevice::Config fDevConfig{};
+};
+
+// Fixture: transceiver in INITIALIZED state (auto-executes async)
+class InitedFdCanTransceiverTest : public FdCanTransceiverTest
+{
+public:
+    InitedFdCanTransceiverTest() : fFct(fAsyncContext, fBusId, fDevConfig)
+    {
+        fFct.fDevice.setupDefaultTransmitISR();
+        EXPECT_CALL(fFct.fDevice, init()).Times(AnyNumber());
+        EXPECT_CALL(fFct.fDevice, start()).Times(AnyNumber());
+        EXPECT_CALL(fFct.fDevice, stop()).Times(AnyNumber());
+        EXPECT_CALL(fAsyncMock, execute(fAsyncContext, _))
+            .Times(AnyNumber())
+            .WillRepeatedly([](auto, auto& runnable) { runnable.execute(); });
+
+        EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.init());
+    }
+
+    FdCanTransceiver fFct;
+};
+
+// Fixture: transceiver in INITIALIZED state with manual async control
+// (async::execute is captured but NOT auto-executed)
+class ManualAsyncFdCanTransceiverTest : public FdCanTransceiverTest
+{
+public:
+    ManualAsyncFdCanTransceiverTest() : fFct(fAsyncContext, fBusId, fDevConfig)
+    {
+        fFct.fDevice.setupDefaultTransmitISR();
+        EXPECT_CALL(fFct.fDevice, init()).Times(AnyNumber());
+        EXPECT_CALL(fFct.fDevice, start()).Times(AnyNumber());
+        EXPECT_CALL(fFct.fDevice, stop()).Times(AnyNumber());
+        // Capture async::execute calls but do NOT auto-run them
+        EXPECT_CALL(fAsyncMock, execute(fAsyncContext, _))
+            .Times(AnyNumber())
+            .WillRepeatedly([this](auto, auto& runnable) { fCapturedRunnable = &runnable; });
+
+        EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.init());
+    }
+
+    /// Manually execute the last captured async runnable (simulates task context)
+    void executeAsyncCallback()
+    {
+        ASSERT_NE(nullptr, fCapturedRunnable);
+        fCapturedRunnable->execute();
+        fCapturedRunnable = nullptr;
+    }
+
+    FdCanTransceiver fFct;
+    ::async::RunnableType* fCapturedRunnable = nullptr;
+};
+
+TEST_F(FdCanTransceiverTest, initFromClosed)
+{
+    FdCanTransceiver fct(fAsyncContext, fBusId, fDevConfig);
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fct.init());
+}
+
+TEST_F(FdCanTransceiverTest, initTwiceFails)
+{
+    FdCanTransceiver fct(fAsyncContext, fBusId, fDevConfig);
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fct.init());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_ILLEGAL_STATE, fct.init());
+}
+
+TEST_F(InitedFdCanTransceiverTest, open)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+}
+
+TEST_F(InitedFdCanTransceiverTest, openTwiceFails)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_ILLEGAL_STATE, fFct.open());
+}
+
+TEST_F(InitedFdCanTransceiverTest, openFromClosed)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.close());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+}
+
+TEST_F(InitedFdCanTransceiverTest, closeFromOpen)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.close());
+}
+
+TEST_F(InitedFdCanTransceiverTest, closeFromClosedReturnsOk)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.close());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.close());
+}
+
+TEST_F(InitedFdCanTransceiverTest, muteFromOpen)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.mute());
+}
+
+TEST_F(InitedFdCanTransceiverTest, muteFromInitializedFails)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_ILLEGAL_STATE, fFct.mute());
+}
+
+TEST_F(InitedFdCanTransceiverTest, unmuteFromMuted)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.mute());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.unmute());
+}
+
+TEST_F(InitedFdCanTransceiverTest, unmuteFromOpenFails)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_ILLEGAL_STATE, fFct.unmute());
+}
+
+TEST_F(InitedFdCanTransceiverTest, writeWhenOpen)
+{
+    CANFrame frame;
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame));
+}
+
+TEST_F(InitedFdCanTransceiverTest, writeWhenMutedFails)
+{
+    CANFrame frame;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.mute());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_TX_OFFLINE, fFct.write(frame));
+}
+
+TEST_F(InitedFdCanTransceiverTest, writeWhenFifoFull)
+{
+    CANFrame frame;
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(false));
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_TX_HW_QUEUE_FULL, fFct.write(frame));
+}
+
+TEST_F(InitedFdCanTransceiverTest, getBaudrateComesFromDeviceConfig)
+{
+    EXPECT_EQ(500000U, fFct.getBaudrate());
+}
+
+TEST_F(InitedFdCanTransceiverTest, getHwQueueTimeoutComputedFromBaudrate)
+{
+    // 3 TX FIFO slots x 117 bit = 351000 bit-ms/s, rounded up to a full ms:
+    // 500 kbit/s -> ceil(0.702 ms) = 1 ms (never 0)
+    EXPECT_EQ(1U, fFct.getHwQueueTimeout());
+
+    // 125 kbit/s -> ceil(351000 / 125000) = ceil(2.808) = 3 ms
+    fDevConfig.baudrate = 125000U;
+    FdCanTransceiver slowFct(fAsyncContext, fBusId, fDevConfig);
+    EXPECT_EQ(3U, slowFct.getHwQueueTimeout());
+}
+
+TEST_F(InitedFdCanTransceiverTest, receiveTask)
+{
+    CANFrame frame;
+
+    EXPECT_CALL(fFct.fDevice, getRxCount()).WillOnce(Return(0));
+    EXPECT_CALL(fFct.fDevice, clearRxQueue()).Times(1);
+    EXPECT_CALL(fFct.fDevice, enableRxInterrupt()).Times(1);
+
+    fFct.receiveTask();
+}
+
+TEST_F(InitedFdCanTransceiverTest, cyclicTaskBusOff)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, isBusOff()).WillOnce(Return(true));
+    fFct.cyclicTask();
+
+    // After bus-off, write should fail
+    CANFrame frame;
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_TX_OFFLINE, fFct.write(frame));
+}
+
+TEST_F(InitedFdCanTransceiverTest, cyclicTaskBusRecovery)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, isBusOff()).WillOnce(Return(true)).WillOnce(Return(false));
+
+    fFct.cyclicTask(); // bus-off -> MUTED
+    fFct.cyclicTask(); // bus-on -> OPEN
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+    CANFrame frame;
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame));
+}
+
+TEST_F(InitedFdCanTransceiverTest, shutdown)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    fFct.shutdown();
+}
+
+TEST_F(InitedFdCanTransceiverTest, receiveInterrupt)
+{
+    EXPECT_CALL(fFct.fDevice, receiveISR(_)).WillOnce(Return(0));
+    FdCanTransceiver::receiveInterrupt(fBusId);
+}
+
+TEST_F(InitedFdCanTransceiverTest, transmitInterrupt)
+{
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    FdCanTransceiver::transmitInterrupt(fBusId);
+}
+
+TEST_F(FdCanTransceiverTest, receiveInterruptInvalidIndex)
+{
+    EXPECT_EQ(0U, FdCanTransceiver::receiveInterrupt(3));
+}
+
+TEST_F(InitedFdCanTransceiverTest, write2rOk)
+{
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+}
+
+TEST_F(InitedFdCanTransceiverTest, write2rFail)
+{
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(false));
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_TX_HW_QUEUE_FULL, fFct.write(frame, listener));
+}
+
+TEST_F(InitedFdCanTransceiverTest, write2rWhenMuted)
+{
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.mute());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_TX_OFFLINE, fFct.write(frame, listener));
+}
+
+TEST_F(InitedFdCanTransceiverTest, write2rDoesNotCallListenerSynchronously)
+{
+    CANFrame frame;
+    StrictMock<MockCANFrameSentListener> listener;
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+    // StrictMock: any call to canFrameSent during write() will FAIL
+    EXPECT_CALL(listener, canFrameSent(_)).Times(0);
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+
+    // Verify: listener was NOT called during write()
+    Mock::VerifyAndClearExpectations(&listener);
+
+    // Now allow the callback to happen (TX ISR triggers it)
+    EXPECT_CALL(listener, canFrameSent(_)).Times(AnyNumber());
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    FdCanTransceiver::transmitInterrupt(fBusId);
+}
+
+TEST_F(InitedFdCanTransceiverTest, writeOverFillQueue)
+{
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillRepeatedly(Return(true));
+
+    // Queue capacity is 3; items are popped only in canFrameSentAsyncCallback,
+    // which we never trigger here to simulate queue-full.
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_TX_HW_QUEUE_FULL, fFct.write(frame, listener));
+}
+
+TEST_F(ManualAsyncFdCanTransceiverTest, writeSecondFrameNotTransmittedImmediately)
+{
+    CANFrame frame1;
+    CANFrame frame2;
+    MockCANFrameSentListener listener;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    // Only ONE transmit call expected from the first write()
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame1, listener));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame2, listener));
+
+    // At this point, only frame1 was transmitted to HW; frame2 waits in queue.
+    Mock::VerifyAndClearExpectations(&fFct.fDevice);
+
+    // Now simulate TX ISR for frame1 - this should transmit frame2
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+    EXPECT_CALL(listener, canFrameSent(_)).Times(1);
+
+    FdCanTransceiver::transmitInterrupt(fBusId);
+    // Execute the deferred async callback
+    executeAsyncCallback();
+}
+
+TEST_F(InitedFdCanTransceiverTest, canFrameSentCallbackWithOneFrame)
+{
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+
+    // TX ISR fires -> canFrameSentCallback -> async -> canFrameSentAsyncCallback
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    EXPECT_CALL(listener, canFrameSent(_)).Times(1);
+    FdCanTransceiver::transmitInterrupt(fBusId);
+}
+
+/// Note: S32K allows write in INITIALIZED, our port requires OPEN. Test uses OPEN.
+TEST_F(InitedFdCanTransceiverTest, canFrameSentCallbackWithTwoFramesChained)
+{
+    MockCANFrameSentListener listener;
+    CANFrame frame1;
+    CANFrame frame2;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillRepeatedly(Return(true));
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame1, listener));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame2, listener));
+
+    // TX ISR for frame1 - pops frame1, notifies listener, transmits frame2
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    EXPECT_CALL(listener, canFrameSent(_)).Times(1);
+    FdCanTransceiver::transmitInterrupt(fBusId);
+}
+
+TEST_F(InitedFdCanTransceiverTest, canFrameSentCallbackWithTwoFramesInStateOpen)
+{
+    MockCANFrameSentListener listener;
+    CANFrame frame1;
+    CANFrame frame2;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillRepeatedly(Return(true));
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame1, listener));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame2, listener));
+
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    EXPECT_CALL(listener, canFrameSent(_)).Times(1);
+    FdCanTransceiver::transmitInterrupt(fBusId);
+}
+
+TEST_F(InitedFdCanTransceiverTest, canFrameSentCallbackWithTwoFramesIsAbortedWhenMuted)
+{
+    MockCANFrameSentListener listener;
+    CANFrame frame1;
+    CANFrame frame2;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame1, listener));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame2, listener));
+
+    fFct.mute();
+
+    // TX ISR fires - first frame was already submitted. Callback should pop
+    // frame1 and notify listener, but NOT submit frame2 (muted).
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    EXPECT_CALL(listener, canFrameSent(_)).Times(1);
+    FdCanTransceiver::transmitInterrupt(fBusId);
+}
+
+TEST_F(InitedFdCanTransceiverTest, canFrameSentCallbackWithTwoFramesFailure)
+{
+    MockCANFrameSentListener listener;
+    CANFrame frame1;
+    CANFrame frame2;
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(false)).WillOnce(Return(true));
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    // First write fails at HW level
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_TX_HW_QUEUE_FULL, fFct.write(frame1, listener));
+    // Second write succeeds
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame2, listener));
+
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    EXPECT_CALL(listener, canFrameSent(_)).Times(1);
+    FdCanTransceiver::transmitInterrupt(fBusId);
+}
+
+TEST_F(InitedFdCanTransceiverTest, canFrameSentCallbackWithTwoFramesIsAbortedWhenNextSendFails)
+{
+    MockCANFrameSentListener listener;
+    CANFrame frame1;
+    CANFrame frame2;
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true)).WillOnce(Return(false));
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame1, listener));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame2, listener));
+
+    // TX ISR for frame1 - callback pops frame1, tries to send frame2 but
+    // transmit returns false => aborted, queue cleared
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    EXPECT_CALL(listener, canFrameSent(_)).Times(1);
+    FdCanTransceiver::transmitInterrupt(fBusId);
+}
+
+TEST_F(ManualAsyncFdCanTransceiverTest, canFrameSentCallbackUsesAsyncExecute)
+{
+    CANFrame frame;
+    StrictMock<MockCANFrameSentListener> listener;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+
+    // TX ISR fires - should call async::execute, NOT call listener directly
+    fCapturedRunnable = nullptr;
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    FdCanTransceiver::transmitInterrupt(fBusId);
+
+    // Verify async::execute was called (runnable was captured)
+    EXPECT_NE(nullptr, fCapturedRunnable);
+
+    // Listener not called yet (still in ISR context)
+    Mock::VerifyAndClearExpectations(&listener);
+
+    // Now execute in task context
+    EXPECT_CALL(listener, canFrameSent(_)).Times(1);
+    executeAsyncCallback();
+}
+
+TEST_F(ManualAsyncFdCanTransceiverTest, canFrameSentCallbackRunsInTaskContext)
+{
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+
+    // TX ISR fires
+    fCapturedRunnable = nullptr;
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    FdCanTransceiver::transmitInterrupt(fBusId);
+
+    // At this point, listener should NOT have been called
+    EXPECT_CALL(listener, canFrameSent(_)).Times(0);
+    Mock::VerifyAndClearExpectations(&listener);
+
+    // Execute the deferred callback (task context)
+    EXPECT_CALL(listener, canFrameSent(_)).Times(1);
+    executeAsyncCallback();
+}
+
+TEST_F(InitedFdCanTransceiverTest, receiveInterruptPassesFilterToDevice)
+{
+    EXPECT_CALL(fFct.fDevice, receiveISR(_)).WillOnce(Return(1));
+    FdCanTransceiver::receiveInterrupt(fBusId);
+}
+
+TEST_F(InitedFdCanTransceiverTest, receiveInterruptAcceptsAllFrames)
+{
+    EXPECT_CALL(fFct.fDevice, receiveISR(_)).WillOnce(Return(1)).WillOnce(Return(3));
+
+    EXPECT_EQ(1U, FdCanTransceiver::receiveInterrupt(fBusId));
+    EXPECT_EQ(3U, FdCanTransceiver::receiveInterrupt(fBusId));
+}
+
+TEST_F(InitedFdCanTransceiverTest, receiveTaskNotifiesListenersForEachFrame)
+{
+    CANFrame frame0;
+    CANFrame frame1;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, getRxCount()).WillOnce(Return(2));
+    EXPECT_CALL(fFct.fDevice, getRxFrame(0)).WillOnce(ReturnRef(frame0));
+    EXPECT_CALL(fFct.fDevice, getRxFrame(1)).WillOnce(ReturnRef(frame1));
+    EXPECT_CALL(fFct.fDevice, clearRxQueue()).Times(1);
+    EXPECT_CALL(fFct.fDevice, enableRxInterrupt()).Times(1);
+
+    fFct.receiveTask();
+}
+
+TEST_F(InitedFdCanTransceiverTest, receiveTaskReEnablesInterrupt)
+{
+    EXPECT_CALL(fFct.fDevice, getRxCount()).WillOnce(Return(0));
+    EXPECT_CALL(fFct.fDevice, clearRxQueue()).Times(1);
+    EXPECT_CALL(fFct.fDevice, enableRxInterrupt()).Times(1);
+
+    fFct.receiveTask();
+}
+
+/// Note: upstream AbstractCANTransceiver only calls SystemTimer when
+/// IFilteredCANFrameSentListener is registered. This test verifies the
+/// write succeeds and the transceiver doesn't crash without registered listeners.
+TEST_F(InitedFdCanTransceiverTest, notifyRegisteredSentListenerMatch)
+{
+    CANFrame frame;
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame));
+}
+
+TEST_F(InitedFdCanTransceiverTest, notifyRegisteredSentListenerFromCallback)
+{
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+
+    // TX ISR -> async callback -> pops queue -> calls listener.canFrameSent
+    // Also calls notifyRegisteredSentListener (notifySentListeners)
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    EXPECT_CALL(listener, canFrameSent(_)).Times(1);
+    FdCanTransceiver::transmitInterrupt(fBusId);
+}
+
+TEST_F(
+    ManualAsyncFdCanTransceiverTest, writeWithListenerThenTransmitInterruptTriggersDeferredCallback)
+{
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+
+    // Step 1: TX ISR fires - defers to task context
+    fCapturedRunnable = nullptr;
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    FdCanTransceiver::transmitInterrupt(fBusId);
+
+    ASSERT_NE(nullptr, fCapturedRunnable);
+
+    // Step 2: Task context executes - listener gets called
+    EXPECT_CALL(listener, canFrameSent(_)).Times(1);
+    executeAsyncCallback();
+}
+
+TEST_F(ManualAsyncFdCanTransceiverTest, multipleWriteWithListenerProcessedSerially)
+{
+    CANFrame frame1;
+    CANFrame frame2;
+    MockCANFrameSentListener listener1;
+    MockCANFrameSentListener listener2;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _))
+        .WillOnce(Return(true))  // frame1
+        .WillOnce(Return(true)); // frame2 (from callback chain)
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame1, listener1));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame2, listener2));
+
+    // TX ISR for frame1
+    fCapturedRunnable = nullptr;
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    FdCanTransceiver::transmitInterrupt(fBusId);
+
+    // Execute deferred callback for frame1 - should notify listener1, submit frame2
+    EXPECT_CALL(listener1, canFrameSent(_)).Times(1);
+    EXPECT_CALL(listener2, canFrameSent(_)).Times(0);
+    executeAsyncCallback();
+
+    Mock::VerifyAndClearExpectations(&listener1);
+    Mock::VerifyAndClearExpectations(&listener2);
+
+    // TX ISR for frame2
+    fCapturedRunnable = nullptr;
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    FdCanTransceiver::transmitInterrupt(fBusId);
+
+    // Execute deferred callback for frame2 - should notify listener2
+    EXPECT_CALL(listener2, canFrameSent(_)).Times(1);
+    executeAsyncCallback();
+}
+
+TEST_F(InitedFdCanTransceiverTest, transmitInterruptWithNoPendingListener)
+{
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+
+    // No write(frame, listener) was called - TX ISR should just call transmitISR
+    FdCanTransceiver::transmitInterrupt(fBusId);
+}
+
+TEST_F(FdCanTransceiverTest, transmitInterruptInvalidIndex)
+{
+    // Should not crash - just silently ignored
+    FdCanTransceiver::transmitInterrupt(3);
+    FdCanTransceiver::transmitInterrupt(255);
+}
+
+TEST_F(InitedFdCanTransceiverTest, writeWithListenerWhenNotOpen)
+{
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    // State is INITIALIZED (not OPEN) - write should fail
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_TX_OFFLINE, fFct.write(frame, listener));
+}
+
+TEST_F(InitedFdCanTransceiverTest, closeWithPendingTxQueue)
+{
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+
+    // Close with a pending TX job - should not crash
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.close());
+
+    // TX ISR after close - should not crash or call listener
+    EXPECT_CALL(listener, canFrameSent(_)).Times(0);
+}
+
+TEST_F(InitedFdCanTransceiverTest, muteWithPendingTxQueue)
+{
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+
+    // Mute with a pending TX job - should not crash
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.mute());
+}
+
+TEST_F(InitedFdCanTransceiverTest, disableRxInterruptDelegates)
+{
+    EXPECT_CALL(fFct.fDevice, disableRxInterrupt()).Times(1);
+    FdCanTransceiver::disableRxInterrupt(fBusId);
+}
+
+TEST_F(InitedFdCanTransceiverTest, enableRxInterruptDelegates)
+{
+    EXPECT_CALL(fFct.fDevice, enableRxInterrupt()).Times(1);
+    FdCanTransceiver::enableRxInterrupt(fBusId);
+}
+
+TEST_F(FdCanTransceiverTest, disableRxInterruptInvalidIndex)
+{
+    // Should not crash
+    FdCanTransceiver::disableRxInterrupt(3);
+    FdCanTransceiver::disableRxInterrupt(255);
+}
+
+TEST_F(FdCanTransceiverTest, enableRxInterruptInvalidIndex)
+{
+    // Should not crash
+    FdCanTransceiver::enableRxInterrupt(3);
+    FdCanTransceiver::enableRxInterrupt(255);
+}
+
+TEST_F(FdCanTransceiverTest, writeInClosedState)
+{
+    FdCanTransceiver fct(fAsyncContext, fBusId, fDevConfig);
+    CANFrame frame;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_TX_OFFLINE, fct.write(frame));
+}
+
+TEST_F(InitedFdCanTransceiverTest, writeInInitializedState)
+{
+    CANFrame frame;
+    // State is INITIALIZED - write should fail
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_TX_OFFLINE, fFct.write(frame));
+}
+
+TEST_F(FdCanTransceiverTest, write2rInClosedState)
+{
+    FdCanTransceiver fct(fAsyncContext, fBusId, fDevConfig);
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_TX_OFFLINE, fct.write(frame, listener));
+}
+
+TEST_F(InitedFdCanTransceiverTest, write2rInInitializedState)
+{
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_TX_OFFLINE, fFct.write(frame, listener));
+}
+
+TEST_F(FdCanTransceiverTest, muteInClosedState)
+{
+    FdCanTransceiver fct(fAsyncContext, fBusId, fDevConfig);
+    EXPECT_CALL(fct.fDevice, init()).Times(AnyNumber());
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_ILLEGAL_STATE, fct.mute());
+}
+
+TEST_F(InitedFdCanTransceiverTest, muteInMutedState)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.mute());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_ILLEGAL_STATE, fFct.mute());
+}
+
+TEST_F(FdCanTransceiverTest, unmuteInClosedState)
+{
+    FdCanTransceiver fct(fAsyncContext, fBusId, fDevConfig);
+    EXPECT_CALL(fct.fDevice, init()).Times(AnyNumber());
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_ILLEGAL_STATE, fct.unmute());
+}
+
+TEST_F(InitedFdCanTransceiverTest, unmuteInInitializedState)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_ILLEGAL_STATE, fFct.unmute());
+}
+
+TEST_F(InitedFdCanTransceiverTest, unmuteInOpenState)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_ILLEGAL_STATE, fFct.unmute());
+}
+
+TEST_F(InitedFdCanTransceiverTest, openInOpenState)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_ILLEGAL_STATE, fFct.open());
+}
+
+TEST_F(InitedFdCanTransceiverTest, openInMutedState)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.mute());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_ILLEGAL_STATE, fFct.open());
+}
+
+TEST_F(InitedFdCanTransceiverTest, closeInInitializedState)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.close());
+}
+
+TEST_F(InitedFdCanTransceiverTest, closeInMutedState)
+{
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.mute());
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.close());
+}
+
+TEST_F(InitedFdCanTransceiverTest, busOffDuringPendingTxClearsQueue)
+{
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+
+    // Bus-off detected by cyclicTask
+    EXPECT_CALL(fFct.fDevice, isBusOff()).WillOnce(Return(true));
+    fFct.cyclicTask();
+
+    // After bus-off, write with listener should fail
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_TX_OFFLINE, fFct.write(frame, listener));
+}
+
+TEST_F(InitedFdCanTransceiverTest, busRecoveryAfterQueueClear)
+{
+    CANFrame frame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillRepeatedly(Return(true));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+
+    // Bus-off
+    EXPECT_CALL(fFct.fDevice, isBusOff()).WillOnce(Return(true)).WillOnce(Return(false));
+    fFct.cyclicTask(); // OPEN -> MUTED
+
+    // Bus recovery
+    fFct.cyclicTask(); // MUTED -> OPEN
+
+    // New write should succeed
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(frame, listener));
+}
+
+TEST_F(InitedFdCanTransceiverTest, receiveTaskWhileTxPending)
+{
+    CANFrame txFrame;
+    CANFrame rxFrame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(txFrame, listener));
+
+    // RX task runs while TX is pending - should work independently
+    EXPECT_CALL(fFct.fDevice, getRxCount()).WillOnce(Return(1));
+    EXPECT_CALL(fFct.fDevice, getRxFrame(0)).WillOnce(ReturnRef(rxFrame));
+    EXPECT_CALL(fFct.fDevice, clearRxQueue()).Times(1);
+    EXPECT_CALL(fFct.fDevice, enableRxInterrupt()).Times(1);
+    fFct.receiveTask();
+
+    // TX ISR still works after RX task
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    EXPECT_CALL(listener, canFrameSent(_)).Times(1);
+    FdCanTransceiver::transmitInterrupt(fBusId);
+}
+
+TEST_F(InitedFdCanTransceiverTest, transmitInterruptDuringReceiveTask)
+{
+    CANFrame txFrame;
+    MockCANFrameSentListener listener;
+
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.open());
+
+    EXPECT_CALL(fFct.fDevice, transmit(_, _)).WillOnce(Return(true));
+    EXPECT_EQ(ICanTransceiver::ErrorCode::CAN_ERR_OK, fFct.write(txFrame, listener));
+
+    // TX ISR fires
+    EXPECT_CALL(fFct.fDevice, transmitISR());
+    EXPECT_CALL(listener, canFrameSent(_)).Times(1);
+    FdCanTransceiver::transmitInterrupt(fBusId);
+
+    // RX task runs after TX ISR - should still work normally
+    EXPECT_CALL(fFct.fDevice, getRxCount()).WillOnce(Return(0));
+    EXPECT_CALL(fFct.fDevice, clearRxQueue()).Times(1);
+    EXPECT_CALL(fFct.fDevice, enableRxInterrupt()).Times(1);
+    fFct.receiveTask();
+}
+
+} // namespace


### PR DESCRIPTION
FDCAN transceiver adapter for the STM32G4: an `ICanTransceiver` implementation wrapping `FdCanDevice`, completing the CAN stack integration for the G474RE (counterpart to the bxCAN transceiver from #415).

Rebuilt on current `main` as a single self-contained commit — the previously stacked foundation commits are gone; the diff is now the module only (10 files).

### Changes vs. the original draft

- `getBaudrate()` delegates to the device configuration and `getHwQueueTimeout()` is computed from the configured bit rate (rounded up, never 0 ms; documented `TX_HW_FIFO_DEPTH = 3`), mirroring the merged `BxCanTransceiver` — no hardcoded values.
- Test mock aligned with the merged `FdCanDevice` interface: `etl::span` filter list, `Config.baudrate` with accessor.

### Validation

- `tests-stm32-debug`/`-release`: 807/807 tests green locally and in CI (full matrix green on this exact commit: [fork run](https://github.com/nhuvaoanh123/openbsw/actions/runs/29577331052)).
- The module's board-level behavior was exercised on a NUCLEO-G474RE on a live CAN bus (including UDS traffic) during earlier integration testing.