### PR TITLE
Add STM32 fault handler and watchdog safety

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ if (BUILD_EXECUTABLE STREQUAL "unitTest")
         add_subdirectory(platforms/stm32/bsp/bspCan/test)
         add_subdirectory(platforms/stm32/bsp/bxCanTransceiver/test)
         add_subdirectory(platforms/stm32/bsp/fdCanTransceiver/test)
+        add_subdirectory(platforms/stm32/safety/safeBspMcuWatchdog/test)
 
     elseif (OPENBSW_PLATFORM STREQUAL "s32k1xx")
 

--- a/platforms/stm32/CMakeLists.txt
+++ b/platforms/stm32/CMakeLists.txt
@@ -20,6 +20,12 @@ if (NOT BUILD_EXECUTABLE STREQUAL "unitTest")
 
     # ETL implementation
     add_subdirectory(etlImpl)
+
+    # Safety modules
+    add_subdirectory(safety)
+
+    # Other modules
+    add_subdirectory(hardFaultHandler)
 else ()
     # Unit-test builds compile the transceivers against mock devices.
     add_subdirectory(bsp)

--- a/platforms/stm32/hardFaultHandler/CMakeLists.txt
+++ b/platforms/stm32/hardFaultHandler/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(hardFaultHandler src/hardFaultHandler.s)
+
+# The .s file uses preprocessor conditionals for the chip family.
+set_source_files_properties(src/hardFaultHandler.s
+                            PROPERTIES COMPILE_OPTIONS "-x;assembler-with-cpp")
+
+set_target_properties(hardFaultHandler PROPERTIES COMPILE_WARNING_AS_ERROR OFF)
+
+target_compile_options(
+    hardFaultHandler
+    PRIVATE "$<$<C_COMPILER_ID:Clang>:-Wno-unused-command-line-argument>")
+
+target_link_libraries(hardFaultHandler PRIVATE bspMcu)

--- a/platforms/stm32/hardFaultHandler/doc/index.rst
+++ b/platforms/stm32/hardFaultHandler/doc/index.rst
@@ -1,0 +1,37 @@
+..
+   *******************************************************************************
+   Copyright (c) 2026 An Dao
+
+   This program and the accompanying materials are made available under the
+   terms of the Apache License Version 2.0 which is available at
+   https://www.apache.org/licenses/LICENSE-2.0
+
+   SPDX-License-Identifier: Apache-2.0
+   *******************************************************************************
+
+hardFaultHandler
+================
+
+Overview
+--------
+
+The ``hardFaultHandler`` module provides a Cortex-M4 hard fault handler that saves a register
+dump to a no-init RAM region. The dump survives a software reset, allowing post-mortem
+analysis of the fault cause after reboot.
+
+The following data is saved to the dump:
+
+- CPU registers of the faulting context (R0-R12, SP, LR, PC, xPSR)
+- LR and PSR at the entry of the exception handler
+- stack contents (as much as possible)
+- checksum of the dump
+
+The handler is written in assembly to guarantee correct stack frame extraction from either
+MSP or PSP, depending on which stack was active at the time of the fault.
+
+Integration
+-----------
+
+The board integration must branch the HardFault vector to ``customHardFaultHandler`` and
+provide ``HardFault_Handler_Final``. The dump region must be reserved by the board linker
+script.

--- a/platforms/stm32/hardFaultHandler/module.spec
+++ b/platforms/stm32/hardFaultHandler/module.spec
@@ -1,0 +1,3 @@
+maturity: raw
+unit_test: false
+oss: true

--- a/platforms/stm32/hardFaultHandler/src/hardFaultHandler.s
+++ b/platforms/stm32/hardFaultHandler/src/hardFaultHandler.s
@@ -1,0 +1,144 @@
+// Copyright (c) 2024 Accenture
+// Copyright (c) 2026 An Dao
+//
+// SPDX-License-Identifier: Apache-2.0
+
+.syntax unified
+.arch armv7-m
+
+//------------------------------------------------------------------------------
+// Hard fault register dump for STM32 (Cortex-M4)
+//
+// Dumps all registers + stack snapshot to a fixed NO_INIT RAM location.
+// RAM addresses are chip-specific - configured via defines.
+//------------------------------------------------------------------------------
+
+// Dump location - use top of SRAM for both F4 (320KB) and G4 (128KB).
+// The dump region must be reserved by the board linker script (see the board
+// integration).
+// Default: use conservative address that works for G4 (smallest SRAM).
+// G4: SRAM ends at 0x20020000, F4: SRAM ends at 0x20050000
+#if defined(STM32_FAMILY_F4)
+.equ NO_INIT_RAM_START, 0x2004FC00
+#else
+.equ NO_INIT_RAM_START, 0x2001FC00
+#endif
+.equ NO_INIT_RAM_SIZE,  0x400
+.equ DUMP_SIZE,         0x140
+.equ DUMP_START,        NO_INIT_RAM_START + NO_INIT_RAM_SIZE - DUMP_SIZE
+
+// Dump fields offsets
+.equ DUMP_HANDLER_PSR,  0x000
+.equ DUMP_HANDLER_LR,   0x004
+.equ DUMP_ORIGIN_R0,    0x008
+.equ DUMP_ORIGIN_R1,    0x00C
+.equ DUMP_ORIGIN_R2,    0x010
+.equ DUMP_ORIGIN_R3,    0x014
+.equ DUMP_ORIGIN_R4,    0x018
+.equ DUMP_ORIGIN_R5,    0x01C
+.equ DUMP_ORIGIN_R6,    0x020
+.equ DUMP_ORIGIN_R7,    0x024
+.equ DUMP_ORIGIN_R8,    0x028
+.equ DUMP_ORIGIN_R9,    0x02C
+.equ DUMP_ORIGIN_R10,   0x030
+.equ DUMP_ORIGIN_R11,   0x034
+.equ DUMP_ORIGIN_R12,   0x038
+.equ DUMP_ORIGIN_SP,    0x03C
+.equ DUMP_ORIGIN_LR,    0x040
+.equ DUMP_ORIGIN_PC,    0x044
+.equ DUMP_ORIGIN_PSR,   0x048
+.equ DUMP_STACK_START,  0x04C
+.equ DUMP_STACK_END,    0x13C
+.equ DUMP_CHECKSUM,     0x13C
+
+// Stack frame offsets
+.equ FRAME_R0,   0x00
+.equ FRAME_R1,   0x04
+.equ FRAME_R2,   0x08
+.equ FRAME_R3,   0x0C
+.equ FRAME_R12,  0x10
+.equ FRAME_LR,   0x14
+.equ FRAME_PC,   0x18
+.equ FRAME_PSR,  0x1C
+.equ FRAME_SIZE, 0x20
+
+//------------------------------------------------------------------------------
+// WARNING:
+// R4-R11 must not be used before they are written to the dump, since they are
+// not saved in stack. Stack must not be used.
+//------------------------------------------------------------------------------
+
+.text
+.globl customHardFaultHandler
+.type customHardFaultHandler, %function
+
+customHardFaultHandler:
+
+    // Save flags for dump in advance
+    mrs     R12, XPSR
+
+    // Save PSR and LR
+    ldr     R2, = DUMP_START
+    str     R12, [R2, #DUMP_HANDLER_PSR]
+    str     LR,  [R2, #DUMP_HANDLER_LR]
+
+    // Save values of registers which are not framed
+    str     R4,  [R2, #DUMP_ORIGIN_R4]
+    str     R5,  [R2, #DUMP_ORIGIN_R5]
+    str     R6,  [R2, #DUMP_ORIGIN_R6]
+    str     R7,  [R2, #DUMP_ORIGIN_R7]
+    str     R8,  [R2, #DUMP_ORIGIN_R8]
+    str     R9,  [R2, #DUMP_ORIGIN_R9]
+    str     R10, [R2, #DUMP_ORIGIN_R10]
+    str     R11, [R2, #DUMP_ORIGIN_R11]
+
+    // Analyze exception return code, calculate the value of SP which was
+    // active at the moment of exception, and save it
+    tst     LR, 4
+    ite     eq
+    mrseq   R1, MSP
+    mrsne   R1, PSP
+    add     R0, R1, FRAME_SIZE
+    str     R0, [R2, #DUMP_ORIGIN_SP]
+
+    // Save value of registers which are framed
+    ldr     R0, [R1, #FRAME_R0]
+    str     R0, [R2, #DUMP_ORIGIN_R0]
+    ldr     R0, [R1, #FRAME_R1]
+    str     R0, [R2, #DUMP_ORIGIN_R1]
+    ldr     R0, [R1, #FRAME_R2]
+    str     R0, [R2, #DUMP_ORIGIN_R2]
+    ldr     R0, [R1, #FRAME_R3]
+    str     R0, [R2, #DUMP_ORIGIN_R3]
+    ldr     R0, [R1, #FRAME_R12]
+    str     R0, [R2, #DUMP_ORIGIN_R12]
+    ldr     R0, [R1, #FRAME_LR]
+    str     R0, [R2, #DUMP_ORIGIN_LR]
+    ldr     R0, [R1, #FRAME_PC]
+    str     R0, [R2, #DUMP_ORIGIN_PC]
+    ldr     R0, [R1, #FRAME_PSR]
+    str     R0, [R2, #DUMP_ORIGIN_PSR]
+
+    // Add some stack contents to dump
+    add     R1, FRAME_SIZE
+    add     R2, DUMP_STACK_START
+    add     R3, R2, DUMP_STACK_END - DUMP_STACK_START
+    1:
+    ldr     R0, [R1], 4
+    str     R0, [R2], 4
+    cmp     R2, R3
+    bne     1b
+
+    // Calculate and save checksum
+    mov     R1, 0
+    ldr     R2, = DUMP_START
+    ldr     R3, = DUMP_START + DUMP_CHECKSUM
+    1:
+    ldr     R0, [R2], 4
+    add     R1, R0
+    cmp     R2, R3
+    bne     1b
+    str     R1, [R3]
+
+    // Complete HardFault handling
+    b       HardFault_Handler_Final

--- a/platforms/stm32/safety/CMakeLists.txt
+++ b/platforms/stm32/safety/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(safeBspMcuWatchdog)

--- a/platforms/stm32/safety/safeBspMcuWatchdog/CMakeLists.txt
+++ b/platforms/stm32/safety/safeBspMcuWatchdog/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(safeBspMcuWatchdog src/watchdog/Watchdog.cpp)
+target_include_directories(safeBspMcuWatchdog PUBLIC include)
+target_link_libraries(
+    safeBspMcuWatchdog
+    PUBLIC bspMcu
+    PRIVATE platform)

--- a/platforms/stm32/safety/safeBspMcuWatchdog/doc/index.rst
+++ b/platforms/stm32/safety/safeBspMcuWatchdog/doc/index.rst
@@ -1,0 +1,36 @@
+..
+   *******************************************************************************
+   Copyright (c) 2026 An Dao
+
+   This program and the accompanying materials are made available under the
+   terms of the Apache License Version 2.0 which is available at
+   https://www.apache.org/licenses/LICENSE-2.0
+
+   SPDX-License-Identifier: Apache-2.0
+   *******************************************************************************
+
+safeBspMcuWatchdog
+==================
+
+Overview
+--------
+
+The ``safeBspMcuWatchdog`` module provides the STM32 IWDG (independent
+watchdog) driver behind the same ``safety::bsp::Watchdog`` API as the
+S32K1xx module of the same name.
+
+IWDG specifics:
+
+- Clocked by the untrimmed LSI oscillator (~32 kHz nominal, 17--47 kHz
+  across devices and conditions), independent of the system clock.
+- 12-bit downcounter with a /4../256 prescaler; timeouts from 1 ms up to
+  ~32 s at 32 kHz.
+- Once started the watchdog cannot be stopped; ``disableWatchdog()`` is
+  therefore a documented no-op.
+
+``enableWatchdog()`` computes the smallest prescaler that fits the requested
+timeout, writes the configuration with bounded waits on the ``PVU``/``RVU``
+update flags, and starts the counter. ``checkWatchdogConfiguration()``
+verifies the programmed prescaler and reload against an expected timeout.
+``isResetFromWatchdog()`` and ``clearResetFlag()`` expose the
+``RCC_CSR_IWDGRSTF`` reset-cause flag.

--- a/platforms/stm32/safety/safeBspMcuWatchdog/include/watchdog/Watchdog.h
+++ b/platforms/stm32/safety/safeBspMcuWatchdog/include/watchdog/Watchdog.h
@@ -1,0 +1,90 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#pragma once
+
+#include <platform/estdint.h>
+
+namespace safety
+{
+namespace bsp
+{
+
+// IWDG driver for STM32; the board safety manager services it cyclically.
+//
+// STM32 IWDG specifics:
+//   - LSI clock ~32 kHz (not trimmed - 17..47 kHz depending on device)
+//   - 12-bit reload register (0..4095)
+//   - Once started, cannot be disabled (hardware limitation)
+//   - Kick sequence: write 0xAAAA to KR
+//   - Unlock sequence: write 0x5555 to KR, then configure PR + RLR
+//   - Start sequence: write 0xCCCC to KR
+class Watchdog
+{
+public:
+    Watchdog() = default;
+
+    explicit Watchdog(uint32_t const timeout, uint32_t const clockSpeed = DEFAULT_CLOCK_SPEED)
+    {
+        enableWatchdog(timeout, false, clockSpeed);
+    }
+
+    /**
+     * \brief Enable the IWDG with the given timeout.
+     * \param timeout      Timeout in milliseconds (max ~32 s at 32 kHz LSI).
+     * \param interruptActive  Ignored on STM32 (IWDG has no interrupt mode).
+     * \param clockSpeed   LSI clock speed in Hz (default 32000).
+     */
+    static void enableWatchdog(
+        uint32_t timeout, bool interruptActive = false, uint32_t clockSpeed = DEFAULT_CLOCK_SPEED);
+
+    /**
+     * \brief Cannot disable the STM32 IWDG once started.  This is a no-op.
+     */
+    static void disableWatchdog();
+
+    /**
+     * \brief Kick (service) the IWDG by writing 0xAAAA to KR.
+     */
+    static void serviceWatchdog();
+
+    /**
+     * \brief Check that the IWDG prescaler and reload match the expected timeout.
+     * \return true if the configuration is consistent.
+     */
+    static bool
+    checkWatchdogConfiguration(uint32_t timeout, uint32_t clockSpeed = DEFAULT_CLOCK_SPEED);
+
+    /**
+     * \brief Check if the last reset was caused by the IWDG.
+     * \return true if RCC_CSR_IWDGRSTF is set.
+     */
+    static bool isResetFromWatchdog();
+
+    /**
+     * \brief Clear the IWDG reset flag in RCC_CSR.
+     */
+    static void clearResetFlag();
+
+    static uint32_t getWatchdogServiceCounter();
+
+    static constexpr uint32_t DEFAULT_TIMEOUT     = 250U;   ///< 250 ms
+    static constexpr uint32_t DEFAULT_CLOCK_SPEED = 32000U; ///< LSI ~32 kHz
+
+private:
+    static uint32_t watchdogServiceCounter;
+
+    /// Compute prescaler divider and reload value for a given timeout.
+    static void computePrescalerAndReload(
+        uint32_t timeoutMs, uint32_t clockHz, uint8_t& prescalerCode, uint16_t& reload);
+};
+
+} // namespace bsp
+} // namespace safety

--- a/platforms/stm32/safety/safeBspMcuWatchdog/module.spec
+++ b/platforms/stm32/safety/safeBspMcuWatchdog/module.spec
@@ -1,0 +1,2 @@
+maturity: raw
+oss: true

--- a/platforms/stm32/safety/safeBspMcuWatchdog/src/watchdog/Watchdog.cpp
+++ b/platforms/stm32/safety/safeBspMcuWatchdog/src/watchdog/Watchdog.cpp
@@ -1,0 +1,131 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include <watchdog/Watchdog.h>
+
+#include <mcu/mcu.h>
+
+namespace safety
+{
+namespace bsp
+{
+
+uint32_t Watchdog::watchdogServiceCounter = 0U;
+
+// Bounded busy-wait for the IWDG PR/RLR update handshake. A PR/RLR update
+// synchronizes into the LSI clock domain within 5 LSI cycles (~156 us at
+// 32 kHz); 100k iterations is orders of magnitude above that. A plain cycle
+// count is used instead of bsp::isEqualAfterTimeout so this register-level
+// driver stays free of the bsp timer dependency - enableWatchdog() runs
+// during early board bring-up, before the system timer is guaranteed to be
+// running.
+static constexpr uint32_t SYNC_TIMEOUT_CYCLES = 100000U;
+
+void Watchdog::computePrescalerAndReload(
+    uint32_t timeoutMs, uint32_t clockHz, uint8_t& prescalerCode, uint16_t& reload)
+{
+    // IWDG prescaler dividers: /4, /8, /16, /32, /64, /128, /256
+    // prescalerCode 0..6 -> divider = 4 << code
+    //
+    // timeout_ms = (reload + 1) * divider * 1000 / clockHz
+    // reload = (timeout_ms * clockHz) / (divider * 1000) - 1
+
+    static uint16_t const dividers[] = {4, 8, 16, 32, 64, 128, 256};
+
+    for (uint8_t code = 0U; code < 7U; code++)
+    {
+        uint32_t ticks = (timeoutMs * (clockHz / 1000U)) / dividers[code];
+        if (ticks == 0U)
+        {
+            ticks = 1U;
+        }
+        if (ticks <= 4096U)
+        {
+            prescalerCode = code;
+            reload        = static_cast<uint16_t>(ticks - 1U);
+            return;
+        }
+    }
+
+    // Largest possible: prescaler /256, reload 4095
+    prescalerCode = 6U;
+    reload        = 4095U;
+}
+
+void Watchdog::enableWatchdog(uint32_t timeout, bool /*interruptActive*/, uint32_t clockSpeed)
+{
+    uint8_t prescalerCode;
+    uint16_t reload;
+    computePrescalerAndReload(timeout, clockSpeed, prescalerCode, reload);
+
+    // Unlock IWDG registers
+    IWDG->KR = 0x5555U;
+
+    // A write to PR/RLR is ignored while the corresponding update flag is
+    // still set from a previous write, so wait (bounded) for the flag to
+    // clear before each write. On timeout proceed anyway - the watchdog must
+    // be started; checkWatchdogConfiguration() exposes a configuration that
+    // did not take effect.
+    uint32_t syncTimeout = SYNC_TIMEOUT_CYCLES;
+    while (((IWDG->SR & IWDG_SR_PVU) != 0U) && (syncTimeout != 0U))
+    {
+        --syncTimeout;
+    }
+    IWDG->PR = prescalerCode;
+
+    syncTimeout = SYNC_TIMEOUT_CYCLES;
+    while (((IWDG->SR & IWDG_SR_RVU) != 0U) && (syncTimeout != 0U))
+    {
+        --syncTimeout;
+    }
+    IWDG->RLR = reload;
+
+    // Start the watchdog (irreversible)
+    IWDG->KR = 0xCCCCU;
+
+    serviceWatchdog();
+}
+
+void Watchdog::disableWatchdog()
+{
+    // STM32 IWDG cannot be disabled once started.
+    // This is intentionally a no-op.
+}
+
+void Watchdog::serviceWatchdog()
+{
+    IWDG->KR = 0xAAAAU;
+    watchdogServiceCounter++;
+}
+
+bool Watchdog::checkWatchdogConfiguration(uint32_t timeout, uint32_t clockSpeed)
+{
+    uint8_t expectedPrescaler;
+    uint16_t expectedReload;
+    computePrescalerAndReload(timeout, clockSpeed, expectedPrescaler, expectedReload);
+
+    uint32_t actualPrescaler = IWDG->PR & 0x7U;
+    uint32_t actualReload    = IWDG->RLR & 0xFFFU;
+
+    return (actualPrescaler == expectedPrescaler) && (actualReload == expectedReload);
+}
+
+bool Watchdog::isResetFromWatchdog() { return (RCC->CSR & RCC_CSR_IWDGRSTF) != 0U; }
+
+void Watchdog::clearResetFlag()
+{
+    // Writing RMVF bit clears all reset flags
+    RCC->CSR |= RCC_CSR_RMVF;
+}
+
+uint32_t Watchdog::getWatchdogServiceCounter() { return watchdogServiceCounter; }
+
+} // namespace bsp
+} // namespace safety

--- a/platforms/stm32/safety/safeBspMcuWatchdog/src/watchdog/Watchdog.cpp
+++ b/platforms/stm32/safety/safeBspMcuWatchdog/src/watchdog/Watchdog.cpp
@@ -39,7 +39,7 @@ void Watchdog::computePrescalerAndReload(
 
     static uint16_t const dividers[] = {4, 8, 16, 32, 64, 128, 256};
 
-    for (uint8_t code = 0U; code < 7U; code++)
+    for (size_t code = 0U; code < sizeof(dividers) / sizeof(dividers[0]); code++)
     {
         uint32_t ticks = (timeoutMs * (clockHz / 1000U)) / dividers[code];
         if (ticks == 0U)
@@ -48,7 +48,7 @@ void Watchdog::computePrescalerAndReload(
         }
         if (ticks <= 4096U)
         {
-            prescalerCode = code;
+            prescalerCode = static_cast<uint8_t>(code);
             reload        = static_cast<uint16_t>(ticks - 1U);
             return;
         }

--- a/platforms/stm32/safety/safeBspMcuWatchdog/test/CMakeLists.txt
+++ b/platforms/stm32/safety/safeBspMcuWatchdog/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(WatchdogTest src/WatchdogTest.cpp)
+
+target_include_directories(WatchdogTest PRIVATE include ../include ../src)
+
+target_link_libraries(WatchdogTest PRIVATE platform gmock gtest_main)
+
+gtest_discover_tests(WatchdogTest PROPERTIES LABELS "WatchdogTest")

--- a/platforms/stm32/safety/safeBspMcuWatchdog/test/include/mcu/mcu.h
+++ b/platforms/stm32/safety/safeBspMcuWatchdog/test/include/mcu/mcu.h
@@ -1,0 +1,11 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#pragma once

--- a/platforms/stm32/safety/safeBspMcuWatchdog/test/src/WatchdogTest.cpp
+++ b/platforms/stm32/safety/safeBspMcuWatchdog/test/src/WatchdogTest.cpp
@@ -1,0 +1,966 @@
+/********************************************************************************
+ * Copyright (c) 2026 An Dao
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+// Uses fake IWDG_TypeDef and RCC_TypeDef structs so register writes go
+// to testable memory instead of real hardware.
+
+#include <cstdint>
+#include <cstring>
+
+#ifndef __IO
+#define __IO volatile
+#endif
+
+// Select G4 code path
+#define STM32G474xx
+
+// --- Fake IWDG_TypeDef ---
+typedef struct
+{
+    __IO uint32_t KR;
+    __IO uint32_t PR;
+    __IO uint32_t RLR;
+    __IO uint32_t SR;
+    __IO uint32_t WINR;
+} IWDG_TypeDef;
+
+// --- Fake RCC_TypeDef (STM32G4 layout) ---
+typedef struct
+{
+    __IO uint32_t CR;
+    __IO uint32_t ICSCR;
+    __IO uint32_t CFGR;
+    __IO uint32_t PLLCFGR;
+    uint32_t RESERVED0;
+    uint32_t RESERVED1;
+    __IO uint32_t CIER;
+    __IO uint32_t CIFR;
+    __IO uint32_t CICR;
+    uint32_t RESERVED2;
+    __IO uint32_t AHB1RSTR;
+    __IO uint32_t AHB2RSTR;
+    __IO uint32_t AHB3RSTR;
+    uint32_t RESERVED3;
+    __IO uint32_t APB1RSTR1;
+    __IO uint32_t APB1RSTR2;
+    __IO uint32_t APB2RSTR;
+    uint32_t RESERVED4;
+    __IO uint32_t AHB1ENR;
+    __IO uint32_t AHB2ENR;
+    __IO uint32_t AHB3ENR;
+    uint32_t RESERVED5;
+    __IO uint32_t APB1ENR1;
+    __IO uint32_t APB1ENR2;
+    __IO uint32_t APB2ENR;
+    uint32_t RESERVED6;
+    __IO uint32_t AHB1SMENR;
+    __IO uint32_t AHB2SMENR;
+    __IO uint32_t AHB3SMENR;
+    uint32_t RESERVED7;
+    __IO uint32_t APB1SMENR1;
+    __IO uint32_t APB1SMENR2;
+    __IO uint32_t APB2SMENR;
+    uint32_t RESERVED8;
+    __IO uint32_t CCIPR;
+    uint32_t RESERVED9;
+    __IO uint32_t BDCR;
+    __IO uint32_t CSR;
+    __IO uint32_t CRRCR;
+    __IO uint32_t CCIPR2;
+} RCC_TypeDef;
+
+// --- Static fake peripherals ---
+static IWDG_TypeDef fakeIwdg;
+static RCC_TypeDef fakeRcc;
+
+// --- Override hardware macros ---
+#define IWDG (&fakeIwdg)
+#define RCC  (&fakeRcc)
+
+// IWDG SR bit definitions
+#define IWDG_SR_PVU (1U << 0)
+#define IWDG_SR_RVU (1U << 1)
+
+// RCC CSR bit definitions
+#define RCC_CSR_IWDGRSTF (1U << 29)
+#define RCC_CSR_RMVF     (1U << 23)
+
+// Provide platform/estdint.h types
+#ifndef PLATFORM_ESTDINT_H
+#define PLATFORM_ESTDINT_H
+#include <cstdint>
+#endif
+
+// Include production code (header + implementation directly)
+#include <watchdog/Watchdog.cpp>
+#include <watchdog/Watchdog.h>
+
+#include <gtest/gtest.h>
+
+using namespace safety::bsp;
+
+class WatchdogTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        std::memset(&fakeIwdg, 0, sizeof(fakeIwdg));
+        std::memset(&fakeRcc, 0, sizeof(fakeRcc));
+        // Reset the static service counter by calling enable + reading
+        // We will use a helper to reset state between tests
+    }
+};
+
+// computePrescalerAndReload tests (verified through enableWatchdog PR/RLR)
+
+TEST_F(WatchdogTest, enableWatchdog_1ms_32000Hz)
+{
+    // timeout=1ms, clock=32000 => ticks = (1 * 32) / 4 = 8, prescaler=0, reload=7
+    Watchdog::enableWatchdog(1U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 7U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_100ms_32000Hz)
+{
+    // timeout=100ms, clock=32000 => ticks = (100 * 32) / 4 = 800, prescaler=0, reload=799
+    Watchdog::enableWatchdog(100U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 799U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_250ms_32000Hz)
+{
+    // timeout=250ms, clock=32000 => ticks = (250 * 32) / 4 = 2000, prescaler=0, reload=1999
+    Watchdog::enableWatchdog(250U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 1999U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_500ms_32000Hz)
+{
+    // timeout=500ms, clock=32000 => ticks = (500 * 32) / 4 = 4000, prescaler=0, reload=3999
+    Watchdog::enableWatchdog(500U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_1000ms_32000Hz)
+{
+    // timeout=1000ms, clock=32000 => ticks = (1000 * 32) / 4 = 8000 > 4096
+    // Try prescaler 1 (/8): ticks = (1000 * 32) / 8 = 4000, prescaler=1, reload=3999
+    Watchdog::enableWatchdog(1000U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 1U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_2000ms_32000Hz)
+{
+    // ticks@/4 = 16000; /8 = 8000; /16 = 4000 => prescaler=2, reload=3999
+    Watchdog::enableWatchdog(2000U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 2U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_4000ms_32000Hz)
+{
+    // ticks@/4=32000; /8=16000; /16=8000; /32=4000 => prescaler=3, reload=3999
+    Watchdog::enableWatchdog(4000U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 3U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_8000ms_32000Hz)
+{
+    // /64 = 4000 => prescaler=4, reload=3999
+    Watchdog::enableWatchdog(8000U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 4U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_16000ms_32000Hz)
+{
+    // /128 = 4000 => prescaler=5, reload=3999
+    Watchdog::enableWatchdog(16000U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 5U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_32000ms_32000Hz)
+{
+    // /256 = 4000 => prescaler=6, reload=3999
+    Watchdog::enableWatchdog(32000U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 6U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_MaxTimeout_Clamps)
+{
+    // Extremely large timeout, should clamp to prescaler=6, reload=4095
+    Watchdog::enableWatchdog(100000U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 6U);
+    EXPECT_EQ(fakeIwdg.RLR, 4095U);
+}
+
+// --- Different clock speeds ---
+
+TEST_F(WatchdogTest, enableWatchdog_250ms_40000Hz)
+{
+    // ticks = (250 * 40) / 4 = 2500, prescaler=0, reload=2499
+    Watchdog::enableWatchdog(250U, false, 40000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 2499U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_1000ms_40000Hz)
+{
+    // ticks@/4 = 10000 > 4096; /8 = 5000 > 4096; /16 = 2500 => prescaler=2, reload=2499
+    Watchdog::enableWatchdog(1000U, false, 40000U);
+    EXPECT_EQ(fakeIwdg.PR, 2U);
+    EXPECT_EQ(fakeIwdg.RLR, 2499U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_100ms_128000Hz)
+{
+    // ticks = (100 * 128) / 4 = 3200, prescaler=0, reload=3199
+    Watchdog::enableWatchdog(100U, false, 128000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 3199U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_250ms_128000Hz)
+{
+    // ticks@/4 = 8000; /8 = 4000 => prescaler=1, reload=3999
+    Watchdog::enableWatchdog(250U, false, 128000U);
+    EXPECT_EQ(fakeIwdg.PR, 1U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_1000ms_128000Hz)
+{
+    // ticks@/4=32000; /8=16000; /16=8000; /32=4000 => prescaler=3, reload=3999
+    Watchdog::enableWatchdog(1000U, false, 128000U);
+    EXPECT_EQ(fakeIwdg.PR, 3U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_500ms_128000Hz)
+{
+    // ticks@/4=16000; /8=8000; /16=4000 => prescaler=2, reload=3999
+    Watchdog::enableWatchdog(500U, false, 128000U);
+    EXPECT_EQ(fakeIwdg.PR, 2U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+// --- Prescaler code boundary: each prescaler code (0-6) ---
+
+TEST_F(WatchdogTest, prescalerCode0_SmallTimeout)
+{
+    // 10ms at 32kHz: ticks = (10*32)/4 = 80 => code 0, reload=79
+    Watchdog::enableWatchdog(10U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 79U);
+}
+
+TEST_F(WatchdogTest, prescalerCode0_AtLimit)
+{
+    // 512ms at 32kHz: ticks = (512*32)/4 = 4096 => code 0, reload=4095
+    Watchdog::enableWatchdog(512U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 4095U);
+}
+
+TEST_F(WatchdogTest, prescalerCode1_JustOverCode0)
+{
+    // 513ms at 32kHz: ticks@/4 = 4104 > 4096; /8 = 2052 => code 1, reload=2051
+    Watchdog::enableWatchdog(513U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 1U);
+    EXPECT_EQ(fakeIwdg.RLR, 2051U);
+}
+
+TEST_F(WatchdogTest, prescalerCode2_Boundary)
+{
+    // 1025ms at 32kHz: ticks@/4=8200; /8=4100>4096; /16=2050 => code 2, reload=2049
+    Watchdog::enableWatchdog(1025U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 2U);
+    EXPECT_EQ(fakeIwdg.RLR, 2049U);
+}
+
+TEST_F(WatchdogTest, prescalerCode3_Boundary)
+{
+    // 2049ms at 32kHz: ticks = (2049*32)/32 = 2049, reload = 2049-1 = 2048
+    Watchdog::enableWatchdog(2049U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 3U);
+    EXPECT_EQ(fakeIwdg.RLR, 2048U);
+}
+
+TEST_F(WatchdogTest, prescalerCode4_Boundary)
+{
+    // 4097ms at 32kHz: ticks=(4097*32)/64=2048, reload=2048-1=2047
+    Watchdog::enableWatchdog(4097U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 4U);
+    EXPECT_EQ(fakeIwdg.RLR, 2047U);
+}
+
+TEST_F(WatchdogTest, prescalerCode5_Boundary)
+{
+    // 8193ms at 32kHz: (8193*32)/64=4096 fits code 4; need >4096 to force code 5
+    // Use 8194ms: (8194*32)/64=4097>4096 -> code 5, ticks=(8194*32)/128=2048, rlr=2047
+    Watchdog::enableWatchdog(8194U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 5U);
+    EXPECT_EQ(fakeIwdg.RLR, 2047U);
+}
+
+TEST_F(WatchdogTest, prescalerCode6_Boundary)
+{
+    // 16385ms: (16385*32)/128=4096 fits code 5; need >4096 to force code 6
+    // 16386*32/128=4096 still fits code 5. Use 16389: (16389*32)/128=4100>4096 -> code 6
+    // ticks=(16389*32)/256=2049, rlr=2048
+    Watchdog::enableWatchdog(16389U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 6U);
+    EXPECT_EQ(fakeIwdg.RLR, 2047U);
+}
+
+// enableWatchdog: KR unlock/start sequence
+
+TEST_F(WatchdogTest, enableWatchdog_WritesUnlockKey)
+{
+    // We check that KR received the start key last (0xCCCC written, then 0xAAAA from
+    // serviceWatchdog)
+    Watchdog::enableWatchdog(250U, false, 32000U);
+    // After enableWatchdog, the last KR write was serviceWatchdog => 0xAAAA
+    EXPECT_EQ(fakeIwdg.KR, 0xAAAAU);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_SetsPrescaler)
+{
+    Watchdog::enableWatchdog(250U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_SetsReload)
+{
+    Watchdog::enableWatchdog(250U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.RLR, 1999U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_DefaultClockSpeed)
+{
+    Watchdog::enableWatchdog(250U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 1999U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_IgnoresInterruptFlag)
+{
+    Watchdog::enableWatchdog(250U, true, 32000U);
+    // Same result regardless of interruptActive
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 1999U);
+}
+
+// serviceWatchdog tests
+
+TEST_F(WatchdogTest, serviceWatchdog_WritesKickKey)
+{
+    Watchdog::serviceWatchdog();
+    EXPECT_EQ(fakeIwdg.KR, 0xAAAAU);
+}
+
+TEST_F(WatchdogTest, serviceWatchdog_IncrementsCounter)
+{
+    uint32_t before = Watchdog::getWatchdogServiceCounter();
+    Watchdog::serviceWatchdog();
+    EXPECT_EQ(Watchdog::getWatchdogServiceCounter(), before + 1U);
+}
+
+TEST_F(WatchdogTest, serviceWatchdog_MultipleKicks)
+{
+    uint32_t before = Watchdog::getWatchdogServiceCounter();
+    Watchdog::serviceWatchdog();
+    Watchdog::serviceWatchdog();
+    Watchdog::serviceWatchdog();
+    EXPECT_EQ(Watchdog::getWatchdogServiceCounter(), before + 3U);
+    EXPECT_EQ(fakeIwdg.KR, 0xAAAAU);
+}
+
+TEST_F(WatchdogTest, serviceWatchdog_KRAlwaysKickValue)
+{
+    fakeIwdg.KR = 0x1234U;
+    Watchdog::serviceWatchdog();
+    EXPECT_EQ(fakeIwdg.KR, 0xAAAAU);
+}
+
+TEST_F(WatchdogTest, serviceWatchdog_TenKicks)
+{
+    uint32_t before = Watchdog::getWatchdogServiceCounter();
+    for (int i = 0; i < 10; i++)
+    {
+        Watchdog::serviceWatchdog();
+    }
+    EXPECT_EQ(Watchdog::getWatchdogServiceCounter(), before + 10U);
+}
+
+// checkWatchdogConfiguration tests
+
+TEST_F(WatchdogTest, checkConfig_MatchingConfig_ReturnsTrue)
+{
+    // Set up fake IWDG to match 250ms at 32kHz: PR=0, RLR=1999
+    fakeIwdg.PR  = 0U;
+    fakeIwdg.RLR = 1999U;
+    EXPECT_TRUE(Watchdog::checkWatchdogConfiguration(250U, 32000U));
+}
+
+TEST_F(WatchdogTest, checkConfig_MismatchedPR_ReturnsFalse)
+{
+    fakeIwdg.PR  = 1U; // Wrong prescaler
+    fakeIwdg.RLR = 1999U;
+    EXPECT_FALSE(Watchdog::checkWatchdogConfiguration(250U, 32000U));
+}
+
+TEST_F(WatchdogTest, checkConfig_MismatchedRLR_ReturnsFalse)
+{
+    fakeIwdg.PR  = 0U;
+    fakeIwdg.RLR = 2000U; // Wrong reload
+    EXPECT_FALSE(Watchdog::checkWatchdogConfiguration(250U, 32000U));
+}
+
+TEST_F(WatchdogTest, checkConfig_BothMismatched_ReturnsFalse)
+{
+    fakeIwdg.PR  = 3U;
+    fakeIwdg.RLR = 500U;
+    EXPECT_FALSE(Watchdog::checkWatchdogConfiguration(250U, 32000U));
+}
+
+TEST_F(WatchdogTest, checkConfig_1000ms_32kHz_Match)
+{
+    fakeIwdg.PR  = 1U;
+    fakeIwdg.RLR = 3999U;
+    EXPECT_TRUE(Watchdog::checkWatchdogConfiguration(1000U, 32000U));
+}
+
+TEST_F(WatchdogTest, checkConfig_100ms_128kHz_Match)
+{
+    fakeIwdg.PR  = 0U;
+    fakeIwdg.RLR = 3199U;
+    EXPECT_TRUE(Watchdog::checkWatchdogConfiguration(100U, 128000U));
+}
+
+TEST_F(WatchdogTest, checkConfig_DefaultClockSpeed)
+{
+    fakeIwdg.PR  = 0U;
+    fakeIwdg.RLR = 1999U;
+    EXPECT_TRUE(Watchdog::checkWatchdogConfiguration(250U));
+}
+
+TEST_F(WatchdogTest, checkConfig_ExtraBitsInPR_Masked)
+{
+    // PR has bits above bit 2 set - should be masked to 3 bits
+    fakeIwdg.PR  = 0U | (0xF0U);
+    fakeIwdg.RLR = 1999U;
+    // checkWatchdogConfiguration masks PR with 0x7
+    EXPECT_TRUE(Watchdog::checkWatchdogConfiguration(250U, 32000U));
+}
+
+TEST_F(WatchdogTest, checkConfig_ExtraBitsInRLR_Masked)
+{
+    // RLR has bits above bit 11 set - should be masked to 12 bits
+    fakeIwdg.PR  = 0U;
+    fakeIwdg.RLR = 1999U | (0xF000U);
+    // checkWatchdogConfiguration masks RLR with 0xFFF
+    EXPECT_TRUE(Watchdog::checkWatchdogConfiguration(250U, 32000U));
+}
+
+TEST_F(WatchdogTest, checkConfig_500ms_40kHz_Match)
+{
+    // 500ms@40kHz: /4 => ticks=5000>4096; /8=>2500 => PR=1, RLR=2499
+    fakeIwdg.PR  = 1U;
+    fakeIwdg.RLR = 2499U;
+    EXPECT_TRUE(Watchdog::checkWatchdogConfiguration(500U, 40000U));
+}
+
+TEST_F(WatchdogTest, checkConfig_AfterEnable_Consistent)
+{
+    Watchdog::enableWatchdog(500U, false, 32000U);
+    EXPECT_TRUE(Watchdog::checkWatchdogConfiguration(500U, 32000U));
+}
+
+TEST_F(WatchdogTest, checkConfig_AfterEnable_DifferentTimeout_False)
+{
+    Watchdog::enableWatchdog(500U, false, 32000U);
+    EXPECT_FALSE(Watchdog::checkWatchdogConfiguration(250U, 32000U));
+}
+
+// isResetFromWatchdog tests
+
+TEST_F(WatchdogTest, isResetFromWatchdog_FlagSet)
+{
+    fakeRcc.CSR = RCC_CSR_IWDGRSTF;
+    EXPECT_TRUE(Watchdog::isResetFromWatchdog());
+}
+
+TEST_F(WatchdogTest, isResetFromWatchdog_FlagCleared)
+{
+    fakeRcc.CSR = 0U;
+    EXPECT_FALSE(Watchdog::isResetFromWatchdog());
+}
+
+TEST_F(WatchdogTest, isResetFromWatchdog_OtherBitsSet)
+{
+    fakeRcc.CSR = 0xFFFFFFFFU & ~RCC_CSR_IWDGRSTF;
+    EXPECT_FALSE(Watchdog::isResetFromWatchdog());
+}
+
+TEST_F(WatchdogTest, isResetFromWatchdog_AllBitsSet)
+{
+    fakeRcc.CSR = 0xFFFFFFFFU;
+    EXPECT_TRUE(Watchdog::isResetFromWatchdog());
+}
+
+TEST_F(WatchdogTest, isResetFromWatchdog_OnlyIwdgBit)
+{
+    fakeRcc.CSR = RCC_CSR_IWDGRSTF;
+    EXPECT_TRUE(Watchdog::isResetFromWatchdog());
+}
+
+// clearResetFlag tests
+
+TEST_F(WatchdogTest, clearResetFlag_SetsRMVF)
+{
+    fakeRcc.CSR = 0U;
+    Watchdog::clearResetFlag();
+    EXPECT_NE(fakeRcc.CSR & RCC_CSR_RMVF, 0U);
+}
+
+TEST_F(WatchdogTest, clearResetFlag_PreservesOtherBits)
+{
+    fakeRcc.CSR = RCC_CSR_IWDGRSTF;
+    Watchdog::clearResetFlag();
+    EXPECT_NE(fakeRcc.CSR & RCC_CSR_RMVF, 0U);
+    EXPECT_NE(fakeRcc.CSR & RCC_CSR_IWDGRSTF, 0U);
+}
+
+TEST_F(WatchdogTest, clearResetFlag_MultipleCalls)
+{
+    fakeRcc.CSR = 0U;
+    Watchdog::clearResetFlag();
+    Watchdog::clearResetFlag();
+    EXPECT_NE(fakeRcc.CSR & RCC_CSR_RMVF, 0U);
+}
+
+// getWatchdogServiceCounter tests
+
+TEST_F(WatchdogTest, getWatchdogServiceCounter_IncrementsOnService)
+{
+    uint32_t prev = Watchdog::getWatchdogServiceCounter();
+    Watchdog::serviceWatchdog();
+    EXPECT_EQ(Watchdog::getWatchdogServiceCounter(), prev + 1U);
+}
+
+TEST_F(WatchdogTest, getWatchdogServiceCounter_EnableAlsoKicks)
+{
+    uint32_t prev = Watchdog::getWatchdogServiceCounter();
+    Watchdog::enableWatchdog(250U, false, 32000U);
+    // enableWatchdog calls serviceWatchdog once at the end
+    EXPECT_EQ(Watchdog::getWatchdogServiceCounter(), prev + 1U);
+}
+
+TEST_F(WatchdogTest, getWatchdogServiceCounter_ConsistentAfterMultipleCalls)
+{
+    uint32_t prev = Watchdog::getWatchdogServiceCounter();
+    for (uint32_t i = 0; i < 20; i++)
+    {
+        Watchdog::serviceWatchdog();
+    }
+    EXPECT_EQ(Watchdog::getWatchdogServiceCounter(), prev + 20U);
+}
+
+// disableWatchdog tests (no-op verification)
+
+TEST_F(WatchdogTest, disableWatchdog_DoesNotChangeKR)
+{
+    fakeIwdg.KR = 0x1234U;
+    Watchdog::disableWatchdog();
+    EXPECT_EQ(fakeIwdg.KR, 0x1234U);
+}
+
+TEST_F(WatchdogTest, disableWatchdog_DoesNotChangePR)
+{
+    fakeIwdg.PR = 3U;
+    Watchdog::disableWatchdog();
+    EXPECT_EQ(fakeIwdg.PR, 3U);
+}
+
+TEST_F(WatchdogTest, disableWatchdog_DoesNotChangeRLR)
+{
+    fakeIwdg.RLR = 2000U;
+    Watchdog::disableWatchdog();
+    EXPECT_EQ(fakeIwdg.RLR, 2000U);
+}
+
+TEST_F(WatchdogTest, disableWatchdog_DoesNotChangeSR)
+{
+    fakeIwdg.SR = 0x3U;
+    Watchdog::disableWatchdog();
+    EXPECT_EQ(fakeIwdg.SR, 0x3U);
+}
+
+TEST_F(WatchdogTest, disableWatchdog_DoesNotChangeServiceCounter)
+{
+    uint32_t prev = Watchdog::getWatchdogServiceCounter();
+    Watchdog::disableWatchdog();
+    EXPECT_EQ(Watchdog::getWatchdogServiceCounter(), prev);
+}
+
+// Edge case: timeout 0
+
+TEST_F(WatchdogTest, enableWatchdog_Timeout0)
+{
+    // timeout=0ms, clock=32000 => ticks = 0, forced to 1, prescaler=0, reload=0
+    Watchdog::enableWatchdog(0U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 0U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_Timeout0_128kHz)
+{
+    Watchdog::enableWatchdog(0U, false, 128000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 0U);
+}
+
+// Edge case: very large timeout overflows to max
+
+TEST_F(WatchdogTest, enableWatchdog_Overflow_50000ms)
+{
+    Watchdog::enableWatchdog(50000U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 6U);
+    EXPECT_EQ(fakeIwdg.RLR, 4095U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_Overflow_128kHz_50000ms)
+{
+    Watchdog::enableWatchdog(50000U, false, 128000U);
+    EXPECT_EQ(fakeIwdg.PR, 6U);
+    EXPECT_EQ(fakeIwdg.RLR, 4095U);
+}
+
+// Constructor test
+
+TEST_F(WatchdogTest, constructor_CallsEnableWatchdog)
+{
+    uint32_t prev = Watchdog::getWatchdogServiceCounter();
+    Watchdog wdt(250U, 32000U);
+    // Constructor calls enableWatchdog which calls serviceWatchdog
+    EXPECT_EQ(Watchdog::getWatchdogServiceCounter(), prev + 1U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 1999U);
+}
+
+TEST_F(WatchdogTest, constructor_DefaultClock)
+{
+    Watchdog wdt(100U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 799U);
+}
+
+// Full sequence tests
+
+TEST_F(WatchdogTest, fullSequence_EnableCheckService)
+{
+    Watchdog::enableWatchdog(250U, false, 32000U);
+    EXPECT_TRUE(Watchdog::checkWatchdogConfiguration(250U, 32000U));
+    uint32_t prev = Watchdog::getWatchdogServiceCounter();
+    Watchdog::serviceWatchdog();
+    EXPECT_EQ(Watchdog::getWatchdogServiceCounter(), prev + 1U);
+    EXPECT_EQ(fakeIwdg.KR, 0xAAAAU);
+}
+
+TEST_F(WatchdogTest, fullSequence_EnableServiceDisableService)
+{
+    Watchdog::enableWatchdog(500U, false, 32000U);
+    Watchdog::serviceWatchdog();
+    Watchdog::disableWatchdog(); // no-op
+    // Registers should still be from enableWatchdog
+    EXPECT_TRUE(Watchdog::checkWatchdogConfiguration(500U, 32000U));
+    Watchdog::serviceWatchdog();
+    EXPECT_EQ(fakeIwdg.KR, 0xAAAAU);
+}
+
+TEST_F(WatchdogTest, fullSequence_CheckResetFlagFlow)
+{
+    fakeRcc.CSR = RCC_CSR_IWDGRSTF;
+    EXPECT_TRUE(Watchdog::isResetFromWatchdog());
+    Watchdog::clearResetFlag();
+    EXPECT_NE(fakeRcc.CSR & RCC_CSR_RMVF, 0U);
+}
+
+// Additional prescaler/reload combination tests
+
+TEST_F(WatchdogTest, prescaler_5ms_32kHz)
+{
+    // ticks = (5*32)/4 = 40 => code 0, reload=39
+    Watchdog::enableWatchdog(5U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 39U);
+}
+
+TEST_F(WatchdogTest, prescaler_50ms_32kHz)
+{
+    // ticks = (50*32)/4 = 400 => code 0, reload=399
+    Watchdog::enableWatchdog(50U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 399U);
+}
+
+TEST_F(WatchdogTest, prescaler_200ms_32kHz)
+{
+    // ticks = (200*32)/4 = 1600 => code 0, reload=1599
+    Watchdog::enableWatchdog(200U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 1599U);
+}
+
+TEST_F(WatchdogTest, prescaler_3000ms_32kHz)
+{
+    // ticks@/4=24000; /8=12000; /16=6000>4096; /32=3000 => code 3, reload=2999
+    Watchdog::enableWatchdog(3000U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 3U);
+    EXPECT_EQ(fakeIwdg.RLR, 2999U);
+}
+
+TEST_F(WatchdogTest, prescaler_10000ms_32kHz)
+{
+    // /64=5000>4096; /128=2500 => code 5, reload=2499
+    Watchdog::enableWatchdog(10000U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 5U);
+    EXPECT_EQ(fakeIwdg.RLR, 2499U);
+}
+
+TEST_F(WatchdogTest, prescaler_20000ms_32kHz)
+{
+    // /128=5000>4096; /256=2500 => code 6, reload=2499
+    Watchdog::enableWatchdog(20000U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 6U);
+    EXPECT_EQ(fakeIwdg.RLR, 2499U);
+}
+
+TEST_F(WatchdogTest, prescaler_2ms_40kHz)
+{
+    // ticks = (2*40)/4 = 20 => code 0, reload=19
+    Watchdog::enableWatchdog(2U, false, 40000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 19U);
+}
+
+TEST_F(WatchdogTest, prescaler_10ms_128kHz)
+{
+    // ticks = (10*128)/4 = 320 => code 0, reload=319
+    Watchdog::enableWatchdog(10U, false, 128000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 319U);
+}
+
+TEST_F(WatchdogTest, prescaler_2000ms_128kHz)
+{
+    // /4=64000; /8=32000; /16=16000; /32=8000; /64=4000 => code 4, reload=3999
+    Watchdog::enableWatchdog(2000U, false, 128000U);
+    EXPECT_EQ(fakeIwdg.PR, 4U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+TEST_F(WatchdogTest, prescaler_4000ms_128kHz)
+{
+    // /64=8000; /128=4000 => code 5, reload=3999
+    Watchdog::enableWatchdog(4000U, false, 128000U);
+    EXPECT_EQ(fakeIwdg.PR, 5U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+TEST_F(WatchdogTest, prescaler_8000ms_128kHz)
+{
+    // /128=8000; /256=4000 => code 6, reload=3999
+    Watchdog::enableWatchdog(8000U, false, 128000U);
+    EXPECT_EQ(fakeIwdg.PR, 6U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+// Re-enable with different timeouts
+
+TEST_F(WatchdogTest, reEnable_DifferentTimeout)
+{
+    Watchdog::enableWatchdog(250U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 1999U);
+
+    // Re-enable with larger timeout
+    Watchdog::enableWatchdog(1000U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 1U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+TEST_F(WatchdogTest, reEnable_SmallToLarge)
+{
+    Watchdog::enableWatchdog(1U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.RLR, 7U);
+
+    Watchdog::enableWatchdog(32000U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 6U);
+    EXPECT_EQ(fakeIwdg.RLR, 3999U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_300ms_32kHz)
+{
+    // ticks = (300*32)/4 = 2400 => code 0, reload=2399
+    Watchdog::enableWatchdog(300U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 2399U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_400ms_32kHz)
+{
+    // ticks = (400*32)/4 = 3200 => code 0, reload=3199
+    Watchdog::enableWatchdog(400U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 3199U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_150ms_40kHz)
+{
+    // ticks = (150*40)/4 = 1500 => code 0, reload=1499
+    Watchdog::enableWatchdog(150U, false, 40000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 1499U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_50ms_40kHz)
+{
+    // ticks = (50*40)/4 = 500 => code 0, reload=499
+    Watchdog::enableWatchdog(50U, false, 40000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 499U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_2000ms_40kHz)
+{
+    // /4=20000; /8=10000; /16=5000>4096; /32=2500 => code 3, reload=2499
+    Watchdog::enableWatchdog(2000U, false, 40000U);
+    EXPECT_EQ(fakeIwdg.PR, 3U);
+    EXPECT_EQ(fakeIwdg.RLR, 2499U);
+}
+
+TEST_F(WatchdogTest, checkConfig_2000ms_40kHz_Match)
+{
+    fakeIwdg.PR  = 3U;
+    fakeIwdg.RLR = 2499U;
+    EXPECT_TRUE(Watchdog::checkWatchdogConfiguration(2000U, 40000U));
+}
+
+TEST_F(WatchdogTest, checkConfig_2000ms_40kHz_WrongPR)
+{
+    fakeIwdg.PR  = 2U;
+    fakeIwdg.RLR = 2499U;
+    EXPECT_FALSE(Watchdog::checkWatchdogConfiguration(2000U, 40000U));
+}
+
+TEST_F(WatchdogTest, checkConfig_2000ms_40kHz_WrongRLR)
+{
+    fakeIwdg.PR  = 3U;
+    fakeIwdg.RLR = 2498U;
+    EXPECT_FALSE(Watchdog::checkWatchdogConfiguration(2000U, 40000U));
+}
+
+TEST_F(WatchdogTest, checkConfig_32000ms_32kHz_Match)
+{
+    fakeIwdg.PR  = 6U;
+    fakeIwdg.RLR = 3999U;
+    EXPECT_TRUE(Watchdog::checkWatchdogConfiguration(32000U, 32000U));
+}
+
+TEST_F(WatchdogTest, checkConfig_1ms_32kHz_Match)
+{
+    fakeIwdg.PR  = 0U;
+    fakeIwdg.RLR = 7U;
+    EXPECT_TRUE(Watchdog::checkWatchdogConfiguration(1U, 32000U));
+}
+
+TEST_F(WatchdogTest, serviceWatchdog_AfterDisable_StillWorks)
+{
+    Watchdog::disableWatchdog();
+    uint32_t prev = Watchdog::getWatchdogServiceCounter();
+    Watchdog::serviceWatchdog();
+    EXPECT_EQ(Watchdog::getWatchdogServiceCounter(), prev + 1U);
+    EXPECT_EQ(fakeIwdg.KR, 0xAAAAU);
+}
+
+TEST_F(WatchdogTest, disableWatchdog_DoesNotChangeWINR)
+{
+    fakeIwdg.WINR = 0xABCDU;
+    Watchdog::disableWatchdog();
+    EXPECT_EQ(fakeIwdg.WINR, 0xABCDU);
+}
+
+TEST_F(WatchdogTest, isResetFromWatchdog_ZeroCSR)
+{
+    fakeRcc.CSR = 0U;
+    EXPECT_FALSE(Watchdog::isResetFromWatchdog());
+}
+
+TEST_F(WatchdogTest, clearResetFlag_InitiallyZero)
+{
+    fakeRcc.CSR = 0U;
+    Watchdog::clearResetFlag();
+    EXPECT_EQ(fakeRcc.CSR, RCC_CSR_RMVF);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_25ms_32kHz)
+{
+    // ticks = (25*32)/4 = 200 => code 0, reload=199
+    Watchdog::enableWatchdog(25U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 199U);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_75ms_32kHz)
+{
+    // ticks = (75*32)/4 = 600 => code 0, reload=599
+    Watchdog::enableWatchdog(75U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 599U);
+}
+
+TEST_F(WatchdogTest, constructor_500ms_40kHz)
+{
+    Watchdog wdt(500U, 40000U);
+    EXPECT_EQ(fakeIwdg.PR, 1U);
+    EXPECT_EQ(fakeIwdg.RLR, 2499U);
+}
+
+// The PVU/RVU waits are bounded: with the update flags stuck (they never
+// self-clear on the fake registers) enableWatchdog must still return, write
+// the configuration and start the watchdog.
+
+TEST_F(WatchdogTest, enableWatchdog_StuckPVU_BoundedExit)
+{
+    fakeIwdg.SR = IWDG_SR_PVU;
+    Watchdog::enableWatchdog(250U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 1999U);
+    EXPECT_EQ(fakeIwdg.KR, 0xAAAAU);
+}
+
+TEST_F(WatchdogTest, enableWatchdog_StuckPVUandRVU_BoundedExit)
+{
+    fakeIwdg.SR = IWDG_SR_PVU | IWDG_SR_RVU;
+    Watchdog::enableWatchdog(250U, false, 32000U);
+    EXPECT_EQ(fakeIwdg.PR, 0U);
+    EXPECT_EQ(fakeIwdg.RLR, 1999U);
+    EXPECT_EQ(fakeIwdg.KR, 0xAAAAU);
+}

--- a/platforms/stm32/safety/safeBspMcuWatchdog/test/src/WatchdogTest.cpp
+++ b/platforms/stm32/safety/safeBspMcuWatchdog/test/src/WatchdogTest.cpp
@@ -401,7 +401,7 @@ TEST_F(WatchdogTest, serviceWatchdog_KRAlwaysKickValue)
 TEST_F(WatchdogTest, serviceWatchdog_TenKicks)
 {
     uint32_t before = Watchdog::getWatchdogServiceCounter();
-    for (int i = 0; i < 10; i++)
+    for (size_t i = 0; i < 10; i++)
     {
         Watchdog::serviceWatchdog();
     }
@@ -575,7 +575,7 @@ TEST_F(WatchdogTest, getWatchdogServiceCounter_EnableAlsoKicks)
 TEST_F(WatchdogTest, getWatchdogServiceCounter_ConsistentAfterMultipleCalls)
 {
     uint32_t prev = Watchdog::getWatchdogServiceCounter();
-    for (uint32_t i = 0; i < 20; i++)
+    for (size_t i = 0; i < 20; i++)
     {
         Watchdog::serviceWatchdog();
     }


### PR DESCRIPTION
## Purpose of this PR
- [ ] Bugfix
- [x] New Feature
- [ ] Documentation Update
- [ ] Other

## Description

Fifth PR in the STM32 platform series. Adds the fault handling and watchdog safety platform modules.

### Modules added
| Module | Purpose |
|--------|---------|
| `hardFaultHandler` | Cortex-M4 HardFault handler — saves a register dump (R0–R12, SP, LR, PC, xPSR, handler LR/PSR, stack snapshot, checksum) to a no-init RAM region that survives reset, for post-mortem analysis |
| `safeBspMcuWatchdog` | STM32 IWDG driver behind the same `safety::bsp::Watchdog` API as the S32K1xx module of the same name; PR/RLR updates use bounded waits on the `PVU`/`RVU` sync flags |

Both mirror the `platforms/s32k1xx` layout (`hardFaultHandler`, `safety/safeBspMcuWatchdog`). The board-level `safeLifecycle` glue (SafetyManager) arrives with the G474RE board bring-up PR, which adds the `nucleo_g474re` platform directory it lives in.

### Milestone
`WatchdogTest` (104 cases) runs in the `tests-stm32-debug/-release` CI jobs. On hardware, the fault handler and watchdog activate with the FreeRTOS board config PR.

PR 5 of the series.

## Related Issues
Part of the STM32 platform port — #394.

## Breaking Changes
- [ ] Yes
- [x] No

## Test Plan
1. `cmake --preset tests-stm32-debug && cmake --build --preset tests-stm32-debug && ctest --preset tests-stm32-debug` — 911 tests green, including the bounded-wait timeout paths against stuck update flags
2. Cross-compile check for both device families (`STM32G474xx`, `STM32F413xx`): driver `-fsyntax-only` and fault handler assembled for both `NO_INIT_RAM` variants
3. Validated on NUCLEO-G474RE hardware in a local integration build: IWDG armed and serviced by the 10 ms safety loop; `safety wdg` starvation resets the board and the reboot detects `RCC_CSR_IWDGRSTF`; `safety mpu` hard fault chains through the dump handler to reset with an intact, checksum-consistent dump in no-init RAM

## Regression Tests
Have tests been added/updated? [x] Yes [ ] No
