### PR TITLE
Fix StringBufferOutputStream destructor

### DIFF
--- a/libs/bsw/util/include/util/stream/StringBufferOutputStream.h
+++ b/libs/bsw/util/include/util/stream/StringBufferOutputStream.h
@@ -32,6 +32,8 @@ public:
     char const* getString();
 
 private:
+    void finalizeBuffer() noexcept;
+
     ::etl::span<char> _buffer;
     char const* _endOfString;
     char const* _ellipsis;

--- a/libs/bsw/util/include/util/stream/StringBufferOutputStream.h
+++ b/libs/bsw/util/include/util/stream/StringBufferOutputStream.h
@@ -20,7 +20,7 @@ class StringBufferOutputStream : public IOutputStream
 public:
     explicit StringBufferOutputStream(
         ::etl::span<char> buf, char const* endOfString = nullptr, char const* ellipsis = nullptr);
-    ~StringBufferOutputStream();
+    ~StringBufferOutputStream() noexcept;
 
     bool isEof() const override;
     void write(uint8_t data) override;

--- a/libs/bsw/util/src/util/stream/StringBufferOutputStream.cpp
+++ b/libs/bsw/util/src/util/stream/StringBufferOutputStream.cpp
@@ -14,6 +14,19 @@ namespace util
 {
 namespace stream
 {
+namespace
+{
+size_t boundedStringLength(char const* const value, size_t const maxLength) noexcept
+{
+    size_t length = 0U;
+    while ((length < maxLength) && (value[length] != '\0'))
+    {
+        ++length;
+    }
+    return length;
+}
+} // namespace
+
 StringBufferOutputStream::StringBufferOutputStream(
     ::etl::span<char> const buf, char const* const endOfString, char const* const ellipsis)
 : IOutputStream()
@@ -24,22 +37,7 @@ StringBufferOutputStream::StringBufferOutputStream(
 , _overflow(false)
 {}
 
-StringBufferOutputStream::~StringBufferOutputStream() noexcept
-{
-    try
-    {
-        (void)getString();
-    }
-    catch (...)
-    {
-        if (_buffer.size() > 0U)
-        {
-            _buffer[0] = '\0';
-        }
-        _currentIndex = 0U;
-        _overflow     = false;
-    }
-}
+StringBufferOutputStream::~StringBufferOutputStream() noexcept { finalizeBuffer(); }
 
 bool StringBufferOutputStream::isEof() const { return (_currentIndex + 1U) >= _buffer.size(); }
 
@@ -80,22 +78,44 @@ void StringBufferOutputStream::reset()
     _overflow     = false;
 }
 
+void StringBufferOutputStream::finalizeBuffer() noexcept
+{
+    size_t const bufferSize = _buffer.size();
+    if (bufferSize == 0U)
+    {
+        return;
+    }
+
+    size_t const endOfStringLen = boundedStringLength(_endOfString, bufferSize - 1U);
+    size_t const requiredSuffix = endOfStringLen + 1U;
+    size_t writeIndex           = _currentIndex;
+
+    if (_overflow || ((writeIndex + requiredSuffix) > bufferSize))
+    {
+        size_t const availableForEllipsis = bufferSize - requiredSuffix;
+        size_t const ellipsisLen          = boundedStringLength(_ellipsis, availableForEllipsis);
+        writeIndex                        = availableForEllipsis - ellipsisLen;
+
+        if (ellipsisLen > 0U)
+        {
+            (void)::etl::mem_copy(_ellipsis, ellipsisLen, _buffer.data() + writeIndex);
+            writeIndex += ellipsisLen;
+        }
+
+        _currentIndex = writeIndex;
+    }
+
+    if (endOfStringLen > 0U)
+    {
+        (void)::etl::mem_copy(_endOfString, endOfStringLen, _buffer.data() + writeIndex);
+    }
+
+    _buffer[writeIndex + endOfStringLen] = '\0';
+}
+
 char const* StringBufferOutputStream::getString()
 {
-    auto const dataBuffer = _buffer.reinterpret_as<uint8_t>();
-    size_t const eolLen   = ::etl::strlen(_endOfString, _buffer.size()) + 1U;
-    if (_overflow || ((eolLen + _currentIndex) > _buffer.size()))
-    {
-        size_t const ellipsisLen = ::etl::strlen(_ellipsis, _buffer.size());
-        _currentIndex            = _buffer.size() - (eolLen + ellipsisLen);
-        (void)::etl::copy(
-            ::etl::span<char const>(_ellipsis, ellipsisLen).reinterpret_as<uint8_t const>(),
-            dataBuffer.subspan(_currentIndex, ellipsisLen));
-        _currentIndex += ellipsisLen;
-    }
-    (void)::etl::copy(
-        ::etl::span<char const>(_endOfString, eolLen).reinterpret_as<uint8_t const>(),
-        dataBuffer.subspan(_currentIndex, eolLen));
+    finalizeBuffer();
     return _buffer.data();
 }
 

--- a/libs/bsw/util/src/util/stream/StringBufferOutputStream.cpp
+++ b/libs/bsw/util/src/util/stream/StringBufferOutputStream.cpp
@@ -24,7 +24,22 @@ StringBufferOutputStream::StringBufferOutputStream(
 , _overflow(false)
 {}
 
-StringBufferOutputStream::~StringBufferOutputStream() { (void)getString(); }
+StringBufferOutputStream::~StringBufferOutputStream() noexcept
+{
+    try
+    {
+        (void)getString();
+    }
+    catch (...)
+    {
+        if (_buffer.size() > 0U)
+        {
+            _buffer[0] = '\0';
+        }
+        _currentIndex = 0U;
+        _overflow     = false;
+    }
+}
 
 bool StringBufferOutputStream::isEof() const { return (_currentIndex + 1U) >= _buffer.size(); }
 

--- a/libs/bsw/util/test/src/util/stream/StringBufferOutputStreamTest.cpp
+++ b/libs/bsw/util/test/src/util/stream/StringBufferOutputStreamTest.cpp
@@ -133,6 +133,63 @@ TEST(StringBufferOutputStream, testGetBufferIfFull)
     ASSERT_EQ(9U, cut.getBuffer().size());
 }
 
+TEST(StringBufferOutputStream, testGetStringWithEmptyBufferLeavesStorageUntouched)
+{
+    char buffer[1];
+    buffer[0] = 0x17;
+
+    {
+        stream::StringBufferOutputStream cut(::etl::span<char>(buffer).first(0), "\n", "..");
+        ASSERT_EQ(buffer, cut.getString());
+    }
+
+    ASSERT_EQ(0x17, buffer[0]);
+}
+
+TEST(StringBufferOutputStream, testEndOfStringIsTruncatedToFit)
+{
+    char buffer[5];
+    memset(buffer, 0x17, 5);
+
+    stream::StringBufferOutputStream cut(::etl::span<char>(buffer).first(4), "ABCDE");
+
+    ASSERT_EQ(0, strcmp("ABC", cut.getString()));
+    ASSERT_EQ(0x17, buffer[4]);
+}
+
+TEST(StringBufferOutputStream, testEllipsisIsTruncatedToFit)
+{
+    char buffer[7];
+    memset(buffer, 0x17, 7);
+
+    stream::StringBufferOutputStream cut(buffer, "\n", "......");
+    cut.write_string_view(::etl::string_view("abcdefgh"));
+
+    ASSERT_EQ(0, strcmp(".....\n", cut.getString()));
+}
+
+TEST(StringBufferOutputStream, testEllipsisIsOmittedIfNoSpaceIsAvailable)
+{
+    char buffer[2];
+    memset(buffer, 0x17, 2);
+
+    stream::StringBufferOutputStream cut(buffer, "\n", "..");
+    cut.write_string_view(::etl::string_view("ab"));
+
+    ASSERT_EQ(0, strcmp("\n", cut.getString()));
+}
+
+TEST(StringBufferOutputStream, testSuffixCanTriggerTruncationWithoutWriteOverflow)
+{
+    char buffer[6];
+    memset(buffer, 0x17, 6);
+
+    stream::StringBufferOutputStream cut(buffer, "\n", "..");
+    cut.write_string_view(::etl::string_view("abcde"));
+
+    ASSERT_EQ(0, strcmp("ab..\n", cut.getString()));
+}
+
 TEST(StringBufferOutputStream, testDestructorFinalizesBuffer)
 {
     char buffer[10];

--- a/libs/bsw/util/test/src/util/stream/StringBufferOutputStreamTest.cpp
+++ b/libs/bsw/util/test/src/util/stream/StringBufferOutputStreamTest.cpp
@@ -133,6 +133,20 @@ TEST(StringBufferOutputStream, testGetBufferIfFull)
     ASSERT_EQ(9U, cut.getBuffer().size());
 }
 
+TEST(StringBufferOutputStream, testDestructorFinalizesBuffer)
+{
+    char buffer[10];
+    memset(buffer, 0x17, 10);
+
+    {
+        stream::StringBufferOutputStream cut(::etl::span<char>(buffer).first(9), "\n", "..");
+        cut.write_string_view(::etl::string_view("abcdef1234"));
+    }
+
+    ASSERT_EQ(0, strcmp("abcde..\n", buffer));
+    ASSERT_EQ(0x17, buffer[9]);
+}
+
 TEST(StringBufferOutputStream, testMixedUsage)
 {
     stream::declare::StringBufferOutputStream<20> cut("E");


### PR DESCRIPTION
## Purpose of this PR
- [x] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Other (Please specify)

**Description**
This PR makes `StringBufferOutputStream`'s destructor `noexcept` and keeps destruction best-effort by swallowing exceptions from final buffer finalization.

It also adds a regression test that verifies scope-exit destruction still finalizes the buffer content as expected.

**Related Issues**
Here is the issue related to this PR #381

**Breaking Changes**
- [ ] Yes
- [x] No

**Test Plan**
1. Rebuild `utilTest` in `build/tests/posix/Release`.
2. Run `ctest -R '^StringBufferOutputStream\.' --output-on-failure` from `build/tests/posix/Release`.
3. Verify all 13 `StringBufferOutputStream` tests pass, including `StringBufferOutputStream.testDestructorFinalizesBuffer`.

**Regression Tests**
Have tests been added/updated? 
- [x] Yes
- [ ] No
