### PR TITLE
Fix clang-tidy CI scope

### DIFF
--- a/.ci/resolve-clang-tidy-translation-units.py
+++ b/.ci/resolve-clang-tidy-translation-units.py
@@ -13,7 +13,8 @@ Inputs:
 - --output-file: Destination file for resolved translation units.
 
 Behavior:
-- Changed source files (.c/.cc/.cpp) are kept directly.
+- Changed source files (.c/.cc/.cpp) are kept only when they are present in the
+    current build's compile_commands.json.
 - Changed headers (.h/.hh/.hpp/.hxx) are mapped to translation units by parsing
     `ninja -t deps` output and joining dependency targets with compile_commands
     output mappings.
@@ -200,6 +201,14 @@ def parse_ninja_deps(build_directory: Path) -> dict[str, set[Path]]:
     return deps_by_target
 
 
+def filter_built_sources(
+    changed_sources: set[Path], output_to_source: dict[str, Path]
+) -> tuple[set[Path], set[Path]]:
+    """Split changed sources into built and skipped sets for this build."""
+    built_sources = set(output_to_source.values())
+    return changed_sources.intersection(built_sources), changed_sources.difference(built_sources)
+
+
 def resolve_translation_units(
     changed_sources: set[Path],
     changed_headers: set[Path],
@@ -207,7 +216,7 @@ def resolve_translation_units(
     deps_by_target: dict[str, set[Path]],
 ) -> set[Path]:
     """Resolve final source files by expanding changed headers to owning TUs."""
-    resolved_sources = set(changed_sources)
+    resolved_sources, _ = filter_built_sources(changed_sources, output_to_source)
     if not changed_headers:
         return resolved_sources
 
@@ -254,6 +263,21 @@ def main(argv: list[str] | None = None) -> int:
         print(exc, file=sys.stderr)
         return 1
 
+    built_changed_sources, skipped_changed_sources = filter_built_sources(
+        changed_sources, output_to_source
+    )
+    if skipped_changed_sources:
+        print(
+            f"Warning: changed source files not present in compile_commands for {args.build_directory} were skipped:",
+            file=sys.stderr,
+        )
+        for source in sorted(skipped_changed_sources):
+            try:
+                source_display = source.relative_to(repo_root)
+            except ValueError:
+                source_display = source
+            print(f"  {source_display}", file=sys.stderr)
+
     if changed_headers and not output_to_source:
         print(
             "No compile command entries were available to map changed headers to translation units.",
@@ -269,7 +293,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     resolved_sources = resolve_translation_units(
-        changed_sources, changed_headers, output_to_source, deps_by_target
+        built_changed_sources, changed_headers, output_to_source, deps_by_target
     )
 
     write_sources(args.output_file, repo_root, resolved_sources)

--- a/.ci/test/test_resolve_clang_tidy_translation_units.py
+++ b/.ci/test/test_resolve_clang_tidy_translation_units.py
@@ -67,10 +67,12 @@ class TestResolveClangTidyTranslationUnits(unittest.TestCase):
         changed_header = Path("/repo/include/common.hpp")
 
         output_to_source = {
+            "obj/direct.o": Path("/repo/src/direct.cpp"),
             "obj/a.o": Path("/repo/src/a.cpp"),
             "obj/b.o": Path("/repo/src/b.cpp"),
         }
         deps_by_target = {
+            "obj/direct.o": {Path("/repo/src/direct.cpp")},
             "obj/a.o": {changed_header},
             "obj/b.o": {Path("/repo/include/unrelated.hpp")},
         }
@@ -86,6 +88,16 @@ class TestResolveClangTidyTranslationUnits(unittest.TestCase):
             resolved,
             {Path("/repo/src/direct.cpp"), Path("/repo/src/a.cpp")},
         )
+
+    def test_resolve_translation_units_drops_unbuilt_changed_sources(self):
+        resolved = self.module.resolve_translation_units(
+            {Path("/repo/src/direct.cpp")},
+            set(),
+            {"obj/a.o": Path("/repo/src/a.cpp")},
+            {"obj/a.o": {Path("/repo/src/a.cpp")}},
+        )
+
+        self.assertEqual(resolved, set())
 
     def test_parse_ninja_deps_parses_targets_and_dependencies(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -101,7 +101,7 @@ jobs:
         run: echo "Skipping clang-tidy because the diff does not contain modified C/C++ files."
 
       - name: Upload clang-tidy findings
-        if: ${{ steps.clang_tidy.outcome == 'failure' }}
+        if: ${{ always() && steps.clang_tidy.outcome == 'failure' }}
         uses: actions/upload-artifact@v4
         with:
           name: ct-findings-${{ matrix.platform }}-${{ matrix.config }}


### PR DESCRIPTION
## Purpose of this PR
- [x] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Other (Please specify)

**Description**
This PR splits the clang-tidy CI/tooling fixes out of #410 for focused review.

It updates the translation-unit resolver so branch-mode clang-tidy only keeps changed source files that are present in the active build's compile database, emits a warning when changed sources are skipped for the current matrix leg, and keeps the resolver tests aligned with that behavior. It also ensures `ct-findings.yaml` is uploaded when the clang-tidy step fails so failing runs remain diagnosable.

**Related Issues**
Here is the issue related to this PR #410

**Breaking Changes**
- [ ] Yes
- [x] No

If there are breaking changes, please explain what they are and how they may impact existing functionality.

**Test Plan**
`python3 .ci/test/test_resolve_clang_tidy_translation_units.py`

**Regression Tests**
Have tests been added/updated? [x] Yes [ ] No
