### PR TITLE
CI: exclude test and mock paths from clang-tidy workflow

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -90,10 +90,10 @@ jobs:
 
           if [[ "${CLANG_TIDY_MODE}" == "full" ]]; then
             DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) DOCKER_HISTORY=/dev/null docker compose run --rm development \
-              python3 .ci/clang-tidy.py --build_directory=build/tests/${{ matrix.platform }}/${{ matrix.config }} --output_file=ct-findings.yaml --exclude="3rdparty" --ignore-checks="clang-diagnostic-error"
+              python3 .ci/clang-tidy.py --build_directory=build/tests/${{ matrix.platform }}/${{ matrix.config }} --output_file=ct-findings.yaml --exclude="3rdparty|/test/|/mock/" --ignore-checks="clang-diagnostic-error"
           else
             DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) DOCKER_HISTORY=/dev/null docker compose run --rm development \
-              python3 .ci/clang-tidy.py --build_directory=build/tests/${{ matrix.platform }}/${{ matrix.config }} --output_file=ct-findings.yaml --exclude="3rdparty" --ignore-checks="clang-diagnostic-error" --file-list=.clang-tidy-changed-files.txt
+              python3 .ci/clang-tidy.py --build_directory=build/tests/${{ matrix.platform }}/${{ matrix.config }} --output_file=ct-findings.yaml --exclude="3rdparty|/test/|/mock/" --ignore-checks="clang-diagnostic-error" --file-list=.clang-tidy-changed-files.txt
           fi
 
       - name: Skip clang-tidy because no C/C++ files changed


### PR DESCRIPTION
## Purpose of this PR
- [ ] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [x] Other (Please specify)

**Description**
This PR adjusts the clang-tidy GitHub Actions workflow to exclude `test` and `mock` paths in addition to third-party code.

That keeps the workflow focused on production-code checks and aligns the exclusion scope across the full and non-full clang-tidy runs.

**Related Issues**
N/A

**Breaking Changes**
- [ ] Yes 
- [x] No

If there are breaking changes, please explain what they are and how they may impact existing
functionality.

**Test Plan**
- `python3 - <<'PY'`
- `import yaml; yaml.safe_load(open('.github/workflows/clang-tidy.yml', 'r', encoding='utf-8').read())`
- `PY`
- Result: YAML syntax validated locally.
- Validation gap: the GitHub Actions workflow itself was not executed locally.

**Regression Tests**
Have tests been added/updated? [ ] Yes [x] No
