### PR TITLE
Clang-tidy: enable cppcoreguidelines-pro-type-vararg

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: >-
     clang-analyzer-*,
     bugprone-*,
     -bugprone-easily-swappable-parameters,
+    cppcoreguidelines-pro-type-vararg,
     llvm-*,-llvm-header-guard,-llvm-include-order,
     google-readability-casting
 ExtraArgs: ['-Wno-unknown-warning-option']

--- a/executables/referenceApp/application/src/logger/logger.cpp
+++ b/executables/referenceApp/application/src/logger/logger.cpp
@@ -6,7 +6,6 @@
 
 #include <lifecycle/LifecycleLogger.h>
 #include <logger/ConsoleLogger.h>
-#include <printf/printf.h>
 #include <safeUtils/SafetyLogger.h>
 #ifdef PLATFORM_SUPPORT_TRANSPORT
 #include <transport/TpRouterLogger.h>
@@ -119,20 +118,17 @@ void flush()
 using ::util::logger::Logger;
 using ::util::logger::LWIP;
 
+// lwIP requires a C-style variadic callback; delegate to Logger's va_list overload.
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
 extern "C" void log_lwipInfo(char const* message, ...)
 {
-    // to print variable argument list
-    // ToDo: use StringWriter or PrintfFormatter available in util
-
-    static char buffer[100];
     va_list ap;
-    /* get the varargs */
     va_start(ap, message);
-    vsnprintf_(buffer, sizeof(buffer), message, ap);
+    Logger::log(LWIP, ::util::logger::LEVEL_INFO, message, ap);
     va_end(ap);
-
-    Logger::info(LWIP, buffer);
 }
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)
 
 extern "C" void log_lwipError(char const* message) { Logger::error(LWIP, message); }
 

--- a/libs/bsp/bspCharInputOutput/src/charInputOutput/bspIo.cpp
+++ b/libs/bsp/bspCharInputOutput/src/charInputOutput/bspIo.cpp
@@ -46,6 +46,8 @@ int vsnprintf(char* buf, size_t const maxsize, char const* fmt, va_list args)
 
 int vsprintf(char* buf, char const* fmt, va_list args) { return vsprintf_(buf, fmt, args); }
 
+// C standard library compatibility wrappers — variadic signatures required by API contract.
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
 int snprintf(char* buf, size_t maxsize, char const* fmt, ...)
 {
     va_list args;
@@ -87,6 +89,8 @@ uint8_t debug_printf(char const* format, ...)
 
     return 0;
 }
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)
 
 #include "charInputOutput/printfPragma.hpp"
 

--- a/libs/bsp/bspInputManager/src/inputManager/DigitalInputTester.cpp
+++ b/libs/bsp/bspInputManager/src/inputManager/DigitalInputTester.cpp
@@ -1,5 +1,7 @@
 // Copyright 2024 Accenture.
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
+
 #include "inputManager/DigitalInputTester.h"
 
 #include "inputManager/DigitalInput.h"
@@ -92,3 +94,5 @@ void DigitalInputTester::executeCommand(::util::command::CommandContext& context
 }
 
 } /* namespace bios */
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsp/bspOutputManager/src/outputManager/OutputTester.cpp
+++ b/libs/bsp/bspOutputManager/src/outputManager/OutputTester.cpp
@@ -1,5 +1,7 @@
 // Copyright 2024 Accenture.
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
+
 #include "outputManager/OutputTester.h"
 
 #include "outputManager/Output.h"
@@ -91,3 +93,5 @@ void OutputTester::executeCommand(::util::command::CommandContext& context, uint
 }
 
 } /* namespace bios */
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsp/bspOutputPwm/src/outputPwm/OutputPwmTester.cpp
+++ b/libs/bsp/bspOutputPwm/src/outputPwm/OutputPwmTester.cpp
@@ -1,5 +1,7 @@
 // Copyright 2024 Accenture.
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
+
 #include "outputPwm/OutputPwmTester.h"
 
 #include "outputPwm/OutputPwm.h"
@@ -126,3 +128,5 @@ void OutputPwmTester::executeCommand(CommandContext& context, uint8_t idx)
 }
 
 } // namespace bios
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/asyncConsole/src/console/AsyncConsole.cpp
+++ b/libs/bsw/asyncConsole/src/console/AsyncConsole.cpp
@@ -1,5 +1,7 @@
 // Copyright 2024 Accenture.
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
+
 #include "console/AsyncConsole.h"
 
 #include "console/SyncCommandWrapper.h"
@@ -99,3 +101,5 @@ void AsyncConsole::terminate(::util::command::ICommand::ExecuteResult result)
 }
 
 } /* namespace console */
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/asyncImpl/examples/src/example.cpp
+++ b/libs/bsw/asyncImpl/examples/src/example.cpp
@@ -6,8 +6,11 @@
 #include "async/util/Call.h"
 
 #include <etl/delegate.h>
+#include <etl/print.h>
 
 #include <cstdio>
+
+extern "C" void etl_putchar(int c) { std::putchar(c); }
 
 namespace asyncNewPlatform
 {
@@ -25,32 +28,38 @@ AsyncImplExample::AsyncImplExample()
 void AsyncImplExample::printBitmask(async::EventMaskType const eventMask)
 {
     size_t const bits = 8;
-    (void)fputs("0b", stdout);
+    ::etl::print("0b");
     for (size_t i = bits; i > 0U; --i)
     {
-        putchar(static_cast<int>('0' + ((eventMask >> (i - 1)) & 1)));
+        ::etl::print("{}", static_cast<unsigned int>((eventMask >> (i - 1U)) & 1U));
     }
 }
 
 void AsyncImplExample::execute(async::RunnableType& runnable)
 {
-    puts("AsyncImplExample::execute() called, Runnable is prepared for execution");
+    ::etl::println("AsyncImplExample::execute() called, Runnable is prepared for execution");
     _runnableExecutor.enqueue(runnable);
 }
 
-void AsyncImplExample::handlerEventA() { puts("AsyncImplExample::handlerEventA() is called."); }
+void AsyncImplExample::handlerEventA()
+{
+    ::etl::println("AsyncImplExample::handlerEventA() is called.");
+}
 
-void AsyncImplExample::handlerEventB() { puts("AsyncImplExample::handlerEventB() is called."); }
+void AsyncImplExample::handlerEventB()
+{
+    ::etl::println("AsyncImplExample::handlerEventB() is called.");
+}
 
 void AsyncImplExample::setEventA()
 {
-    puts("AsyncImplExample::setEventA() is called.");
+    ::etl::println("AsyncImplExample::setEventA() is called.");
     _eventPolicyA.setEvent();
 }
 
 void AsyncImplExample::setEventB()
 {
-    puts("AsyncImplExample::setEventB() is called.");
+    ::etl::println("AsyncImplExample::setEventB() is called.");
     _eventPolicyB.setEvent();
 }
 
@@ -63,11 +72,11 @@ void AsyncImplExample::setEvents(async::EventMaskType const eventMask)
 {
     _eventMask |= eventMask;
 
-    (void)fputs("AsyncImplExample::setEvents() is called with eventMask:", stdout);
+    ::etl::print("AsyncImplExample::setEvents() is called with eventMask:");
     printBitmask(eventMask);
-    (void)fputs(" new eventMask:", stdout);
+    ::etl::print(" new eventMask:");
     printBitmask(_eventMask);
-    putchar('\n');
+    ::etl::println();
 }
 
 /**
@@ -76,22 +85,22 @@ void AsyncImplExample::setEvents(async::EventMaskType const eventMask)
  */
 void AsyncImplExample::dispatch()
 {
-    (void)fputs("AsyncImplExample::dispatch() is called, eventMask:", stdout);
+    ::etl::print("AsyncImplExample::dispatch() is called, eventMask:");
     printBitmask(_eventMask);
-    putchar('\n');
+    ::etl::println();
 
     handleEvents(_eventMask);
     _eventMask = 0;
 
-    (void)fputs("AsyncImplExample::dispatch() reset eventMask, eventMask:", stdout);
+    ::etl::print("AsyncImplExample::dispatch() reset eventMask, eventMask:");
     printBitmask(_eventMask);
-    putchar('\n');
+    ::etl::println();
 }
 } // namespace asyncNewPlatform
 
-void exampleRunnableA() { puts("exampleRunnableA is called."); }
+void exampleRunnableA() { ::etl::println("exampleRunnableA is called."); }
 
-void exampleRunnableB() { puts("exampleRunnableB is called."); }
+void exampleRunnableB() { ::etl::println("exampleRunnableB is called."); }
 
 // NOLINTBEGIN(bugprone-exception-escape): This is just for testing purposes.
 int main()

--- a/libs/bsw/asyncImpl/examples/src/example.cpp
+++ b/libs/bsw/asyncImpl/examples/src/example.cpp
@@ -25,32 +25,32 @@ AsyncImplExample::AsyncImplExample()
 void AsyncImplExample::printBitmask(async::EventMaskType const eventMask)
 {
     size_t const bits = 8;
-    printf("0b");
+    (void)fputs("0b", stdout);
     for (size_t i = bits - 1; i > 0; i--)
     {
-        printf("%d", (eventMask >> (i - 1)) & 1);
+        putchar(static_cast<int>('0' + ((eventMask >> (i - 1)) & 1)));
     }
 }
 
 void AsyncImplExample::execute(async::RunnableType& runnable)
 {
-    printf("AsyncImplExample::execute() called, Runnable is prepared for execution\n");
+    puts("AsyncImplExample::execute() called, Runnable is prepared for execution");
     _runnableExecutor.enqueue(runnable);
 }
 
-void AsyncImplExample::handlerEventA() { printf("AsyncImplExample::handlerEventA() is called.\n"); }
+void AsyncImplExample::handlerEventA() { puts("AsyncImplExample::handlerEventA() is called."); }
 
-void AsyncImplExample::handlerEventB() { printf("AsyncImplExample::handlerEventB() is called.\n"); }
+void AsyncImplExample::handlerEventB() { puts("AsyncImplExample::handlerEventB() is called."); }
 
 void AsyncImplExample::setEventA()
 {
-    printf("AsyncImplExample::setEventA() is called.\n");
+    puts("AsyncImplExample::setEventA() is called.");
     _eventPolicyA.setEvent();
 }
 
 void AsyncImplExample::setEventB()
 {
-    printf("AsyncImplExample::setEventB() is called.\n");
+    puts("AsyncImplExample::setEventB() is called.");
     _eventPolicyB.setEvent();
 }
 
@@ -63,11 +63,11 @@ void AsyncImplExample::setEvents(async::EventMaskType const eventMask)
 {
     _eventMask |= eventMask;
 
-    printf("AsyncImplExample::setEvents() is called with eventMask:");
+    (void)fputs("AsyncImplExample::setEvents() is called with eventMask:", stdout);
     printBitmask(eventMask);
-    printf(" new eventMask:");
+    (void)fputs(" new eventMask:", stdout);
     printBitmask(_eventMask);
-    printf("\n");
+    putchar('\n');
 }
 
 /**
@@ -76,22 +76,22 @@ void AsyncImplExample::setEvents(async::EventMaskType const eventMask)
  */
 void AsyncImplExample::dispatch()
 {
-    printf("AsyncImplExample::dispatch() is called, eventMask:");
+    (void)fputs("AsyncImplExample::dispatch() is called, eventMask:", stdout);
     printBitmask(_eventMask);
-    printf("\n");
+    putchar('\n');
 
     handleEvents(_eventMask);
     _eventMask = 0;
 
-    printf("AsyncImplExample::dispatch() reset eventMask, eventMask:");
+    (void)fputs("AsyncImplExample::dispatch() reset eventMask, eventMask:", stdout);
     printBitmask(_eventMask);
-    printf("\n");
+    putchar('\n');
 }
 } // namespace asyncNewPlatform
 
-void exampleRunnableA() { printf("exampleRunnableA is called.\n"); }
+void exampleRunnableA() { puts("exampleRunnableA is called."); }
 
-void exampleRunnableB() { printf("exampleRunnableB is called.\n"); }
+void exampleRunnableB() { puts("exampleRunnableB is called."); }
 
 // NOLINTBEGIN(bugprone-exception-escape): This is just for testing purposes.
 int main()

--- a/libs/bsw/asyncImpl/examples/src/example.cpp
+++ b/libs/bsw/asyncImpl/examples/src/example.cpp
@@ -26,7 +26,7 @@ void AsyncImplExample::printBitmask(async::EventMaskType const eventMask)
 {
     size_t const bits = 8;
     (void)fputs("0b", stdout);
-    for (size_t i = bits - 1; i > 0; i--)
+    for (size_t i = bits; i > 0U; --i)
     {
         putchar(static_cast<int>('0' + ((eventMask >> (i - 1)) & 1)));
     }

--- a/libs/bsw/cpp2can/mock/src/can/transceiver/AbstractCANTransceiverMock.cpp
+++ b/libs/bsw/cpp2can/mock/src/can/transceiver/AbstractCANTransceiverMock.cpp
@@ -24,6 +24,8 @@ AbstractCANTransceiverMock::AbstractCANTransceiverMock(uint8_t busId)
 
 void AbstractCANTransceiverMock::inject(CANFrame const& frame)
 {
+    // Mock trace output keeps the existing variadic logger API.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     Logger::debug(
         CAN,
         "AbstractCANTransceiverMock::inject(0x%x (%d): <0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, "
@@ -69,6 +71,8 @@ ICanTransceiver::ErrorCode AbstractCANTransceiverMock::openImplementation()
 
 ICanTransceiver::ErrorCode AbstractCANTransceiverMock::writeImplementation(CANFrame const& frame)
 {
+    // Mock trace output keeps the existing variadic logger API.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     Logger::debug(
         CAN,
         "AbstractCANTransceiverMock::write(0x%x (%d): <0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, "
@@ -89,6 +93,8 @@ ICanTransceiver::ErrorCode AbstractCANTransceiverMock::writeImplementation(CANFr
 ICanTransceiver::ErrorCode AbstractCANTransceiverMock::writeImplementation2(
     CANFrame const& frame, ICANFrameSentListener& listener)
 {
+    // Mock trace output keeps the existing variadic logger API.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     Logger::debug(
         CAN,
         "AbstractCANTransceiverMock::write(0x%x (%d): <0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, "

--- a/libs/bsw/io/examples/VariantQueueExample.cpp
+++ b/libs/bsw/io/examples/VariantQueueExample.cpp
@@ -1,12 +1,15 @@
 // Copyright 2024 Accenture.
 
 #include <etl/algorithm.h>
+#include <etl/print.h>
 #include <etl/unaligned_type.h>
 #include <io/VariantQueue.h>
 
 #include <gtest/gtest.h>
 
 #include <cstdio>
+
+extern "C" void etl_putchar(int c) { std::putchar(c); }
 
 namespace
 {
@@ -68,9 +71,9 @@ void read_no_payload()
     // EXAMPLE_START read_no_payload
     struct Visit
     {
-        void operator()(A const& /* a */) { (void)fputs("received A", stdout); }
+        void operator()(A const& /* a */) { ::etl::print("received A"); }
 
-        void operator()(B const& /* b */) { (void)fputs("received B", stdout); }
+        void operator()(B const& /* b */) { ::etl::print("received B"); }
     };
 
     MyQueue queue;
@@ -92,12 +95,12 @@ void read_with_payload()
     {
         void operator()(A const& /* a */, ::etl::span<uint8_t const> /* payload */)
         {
-            (void)fputs("received A", stdout);
+            ::etl::print("received A");
         }
 
         void operator()(B const& /* b */, ::etl::span<uint8_t const> /* payload */)
         {
-            (void)fputs("received B", stdout);
+            ::etl::print("received B");
         }
     };
 

--- a/libs/bsw/io/examples/VariantQueueExample.cpp
+++ b/libs/bsw/io/examples/VariantQueueExample.cpp
@@ -68,9 +68,9 @@ void read_no_payload()
     // EXAMPLE_START read_no_payload
     struct Visit
     {
-        void operator()(A const& /* a */) { printf("received A"); }
+        void operator()(A const& /* a */) { (void)fputs("received A", stdout); }
 
-        void operator()(B const& /* b */) { printf("received B"); }
+        void operator()(B const& /* b */) { (void)fputs("received B", stdout); }
     };
 
     MyQueue queue;
@@ -92,12 +92,12 @@ void read_with_payload()
     {
         void operator()(A const& /* a */, ::etl::span<uint8_t const> /* payload */)
         {
-            printf("received A");
+            (void)fputs("received A", stdout);
         }
 
         void operator()(B const& /* b */, ::etl::span<uint8_t const> /* payload */)
         {
-            printf("received B");
+            (void)fputs("received B", stdout);
         }
     };
 

--- a/libs/bsw/lifecycle/src/lifecycle/LifecycleManager.cpp
+++ b/libs/bsw/lifecycle/src/lifecycle/LifecycleManager.cpp
@@ -1,5 +1,7 @@
 // Copyright 2024 Accenture.
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
+
 #include "lifecycle/LifecycleManager.h"
 
 #include "lifecycle/LifecycleLogger.h"
@@ -218,3 +220,5 @@ void LifecycleManager::ComponentTransitionExecutor::execute()
 }
 
 } // namespace lifecycle
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/lifecycle/src/lifecycle/LifecycleManager.cpp
+++ b/libs/bsw/lifecycle/src/lifecycle/LifecycleManager.cpp
@@ -1,7 +1,5 @@
 // Copyright 2024 Accenture.
 
-// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
-
 #include "lifecycle/LifecycleManager.h"
 
 #include "lifecycle/LifecycleLogger.h"
@@ -89,6 +87,7 @@ void LifecycleManager::transitionDone(ILifecycleComponent& component)
             componentInfo._isTransitionPending = false;
             componentInfo._transitionTimes[static_cast<uint8_t>(executor._transition)]
                 = _getTimestamp() - _transitionStartTimestamp;
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
             Logger::debug(
                 LIFECYCLE,
                 "%s %s done",
@@ -127,6 +126,7 @@ void LifecycleManager::execute()
     }
     _isTransitionPending      = true;
     _transitionStartTimestamp = _getTimestamp();
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
     Logger::info(LIFECYCLE, "%s level %d", getTransitionString(_transition), _transitionLevel);
     for (uint8_t componentIndex = _levelIndices[static_cast<size_t>(_transitionLevel) - 1U];
          componentIndex < _levelIndices[static_cast<size_t>(_transitionLevel)];
@@ -144,6 +144,7 @@ void LifecycleManager::execute()
         {
             transitionContext = _transitionContext;
         }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
         Logger::info(LIFECYCLE, "%s %s", getTransitionString(_transition), componentInfo._name);
         ::async::execute(transitionContext, transitionExecutor);
     }
@@ -168,6 +169,7 @@ bool LifecycleManager::checkLevelTransitionDone()
         }
     }
     _isTransitionPending = false;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
     Logger::debug(
         LIFECYCLE, "%s level %d done", getTransitionString(_transition), _transitionLevel);
     _componentTransitionExecutors.clear();
@@ -220,5 +222,3 @@ void LifecycleManager::ComponentTransitionExecutor::execute()
 }
 
 } // namespace lifecycle
-
-// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/logger/test/src/logger/BufferedLoggerOutputTest.cpp
+++ b/libs/bsw/logger/test/src/logger/BufferedLoggerOutputTest.cpp
@@ -25,6 +25,8 @@ namespace
 using namespace logger;
 using namespace ::util;
 
+// Exercises the buffered logger output's variadic formatting path.
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
 uint32_t _totalLockCount;
 
 struct TestLock
@@ -154,5 +156,7 @@ TEST_F(BufferedLoggerOutputTest, testConstructorWithPredicate)
     cut.outputEntry(*this, entryRef);
     ASSERT_TRUE(checkAndResetEntry("1 2348 1 0 ver<?>"));
 }
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)
 
 } // namespace

--- a/libs/bsw/logger/test/src/logger/ConsoleEntryOutputTest.cpp
+++ b/libs/bsw/logger/test/src/logger/ConsoleEntryOutputTest.cpp
@@ -17,6 +17,8 @@ using namespace ::logger;
 
 namespace
 {
+// Exercises the console entry formatter's printf-style writer path.
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
 struct ConsoleEntryOutputTest
 : ::testing::Test
 , IEntryFormatter<uint32_t, uint32_t>
@@ -74,5 +76,7 @@ TEST_F(ConsoleEntryOutputTest, testAll)
         "15 15343 16 Level_Name Format string 83743 String\r\n",
         std::string(stdIo.out.begin(), stdIo.out.end()));
 }
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)
 
 } // namespace

--- a/libs/bsw/logger/test/src/logger/EntrySerializerTest.cpp
+++ b/libs/bsw/logger/test/src/logger/EntrySerializerTest.cpp
@@ -11,6 +11,8 @@ using namespace ::logger;
 
 using namespace ::util::logger;
 
+// Exercises the serializer's variadic log entry interface.
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
 struct EntrySerializerTest
 : ::testing::Test
 , private IEntrySerializerCallback<uint32_t>
@@ -207,3 +209,5 @@ TEST_F(EntrySerializerTest, testPrintfDatatypes)
     ASSERT_EQ("124:2:3:", serializeAndDeserialize(300, 124, 2, 3, "%n", 0));
     ASSERT_EQ("124:2:3:    0017", serializeAndDeserialize(300, 124, 2, 3, "%*.*d", 8, 4, 17));
 }
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/logger/test/src/logger/SharedStreamEntryOutputTest.cpp
+++ b/libs/bsw/logger/test/src/logger/SharedStreamEntryOutputTest.cpp
@@ -19,6 +19,8 @@ using namespace ::logger;
 
 namespace
 {
+// Exercises the shared stream entry formatter's printf-style writer path.
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
 class SharedOutputStreamMock : public ISharedOutputStream
 {
 public:
@@ -95,5 +97,7 @@ TEST_F(SharedStreamEntryOutputTest, testAll)
         "15 15343 16 Level_Name Format string 83743 String",
         std::string(streamMock.getStream().getString()));
 }
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)
 
 } // namespace

--- a/libs/bsw/loggerIntegration/src/logger/LoggerTime.cpp
+++ b/libs/bsw/loggerIntegration/src/logger/LoggerTime.cpp
@@ -4,9 +4,7 @@
 
 #include <etl/chrono.h>
 #include <etl/span.h>
-#include <util/format/StringWriter.h>
 
-#include <cstdio>
 #include <ctime>
 
 namespace
@@ -31,8 +29,6 @@ int64_t LoggerTime::getTimestamp() const
 void LoggerTime::formatTimestamp(
     ::util::stream::IOutputStream& stream, int64_t const& timestamp) const
 {
-    ::util::format::StringWriter writer(stream);
-
     ::std::time_t seconds   = static_cast<::std::time_t>(timestamp / 1000);
     uint32_t const mSeconds = timestamp % 1000;
 
@@ -54,13 +50,16 @@ void LoggerTime::formatTimestamp(
 
     if (timestampLength > 0)
     {
-        int n = snprintf(
-            timestampBuffer + timestampLength,
-            static_cast<uint32_t>(timestampBufferSize),
-            ".%03u",
-            static_cast<unsigned int>(mSeconds));
         stream.write(::etl::span<uint8_t const>(
-            reinterpret_cast<uint8_t const*>(timestampBuffer), timestampLength + n));
+            static_cast<uint8_t const*>(static_cast<void const*>(timestampBuffer)),
+            timestampLength));
+        // Append milliseconds (always 3 digits, zero-padded)
+        uint8_t const msStr[]
+            = {static_cast<uint8_t>('.'),
+               static_cast<uint8_t>('0' + (mSeconds / 100U) % 10U),
+               static_cast<uint8_t>('0' + (mSeconds / 10U) % 10U),
+               static_cast<uint8_t>('0' + mSeconds % 10U)};
+        stream.write(::etl::span<uint8_t const>(msStr, sizeof(msStr)));
     }
 }
 

--- a/libs/bsw/loggerIntegration/src/logger/LoggerTime.cpp
+++ b/libs/bsw/loggerIntegration/src/logger/LoggerTime.cpp
@@ -3,12 +3,43 @@
 #include "logger/LoggerTime.h"
 
 #include <etl/chrono.h>
+#include <etl/format.h>
 #include <etl/span.h>
 
 #include <ctime>
 
 namespace
 {
+class OutputStreamIterator
+{
+public:
+    explicit OutputStreamIterator(::util::stream::IOutputStream& stream) : _stream(&stream) {}
+
+    class Proxy
+    {
+    public:
+        explicit Proxy(::util::stream::IOutputStream& stream) : _stream(&stream) {}
+
+        Proxy& operator=(char const value)
+        {
+            _stream->write(static_cast<uint8_t>(value));
+            return *this;
+        }
+
+    private:
+        ::util::stream::IOutputStream* _stream;
+    };
+
+    Proxy operator*() { return Proxy(*_stream); }
+
+    OutputStreamIterator& operator++() { return *this; }
+
+    OutputStreamIterator operator++(int) { return *this; }
+
+private:
+    ::util::stream::IOutputStream* _stream;
+};
+
 int64_t const NO_INIT_BOUNDARY
     = ::etl::chrono::duration_cast<::etl::chrono::milliseconds>(::etl::chrono::hours(1)).count();
 
@@ -53,13 +84,7 @@ void LoggerTime::formatTimestamp(
         stream.write(::etl::span<uint8_t const>(
             static_cast<uint8_t const*>(static_cast<void const*>(timestampBuffer)),
             timestampLength));
-        // Append milliseconds (always 3 digits, zero-padded)
-        uint8_t const msStr[]
-            = {static_cast<uint8_t>('.'),
-               static_cast<uint8_t>('0' + (mSeconds / 100U) % 10U),
-               static_cast<uint8_t>('0' + (mSeconds / 10U) % 10U),
-               static_cast<uint8_t>('0' + mSeconds % 10U)};
-        stream.write(::etl::span<uint8_t const>(msStr, sizeof(msStr)));
+        (void)::etl::format_to(OutputStreamIterator(stream), ".{:03}", mSeconds);
     }
 }
 

--- a/libs/bsw/loggerIntegration/src/logger/LoggerTime.cpp
+++ b/libs/bsw/loggerIntegration/src/logger/LoggerTime.cpp
@@ -34,7 +34,7 @@ public:
 
     OutputStreamIterator& operator++() { return *this; }
 
-    OutputStreamIterator operator++(int) { return *this; }
+    OutputStreamIterator const operator++(int) { return *this; }
 
 private:
     ::util::stream::IOutputStream* _stream;

--- a/libs/bsw/lwipSocket/src/lwipSocket/netif/LwipNetworkInterface.cpp
+++ b/libs/bsw/lwipSocket/src/lwipSocket/netif/LwipNetworkInterface.cpp
@@ -1,5 +1,7 @@
 // Copyright 2025 Accenture.
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
+
 #include "lwipSocket/netif/LwipNetworkInterface.h"
 
 #include "lwipSocket/utils/LwipHelper.h"
@@ -203,3 +205,5 @@ void onLinkStatusChanged(bool const isLinkUp, netif& ni)
 }
 
 } // namespace lwipnetif
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/lwipSocket/src/lwipSocket/netif/LwipNetworkInterface.cpp
+++ b/libs/bsw/lwipSocket/src/lwipSocket/netif/LwipNetworkInterface.cpp
@@ -1,7 +1,5 @@
 // Copyright 2025 Accenture.
 
-// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
-
 #include "lwipSocket/netif/LwipNetworkInterface.h"
 
 #include "lwipSocket/utils/LwipHelper.h"
@@ -83,6 +81,7 @@ bool initNetifWithStaticIp6Address(
         lwipNetif.flags = 0U;
         if (!(isInitialized && (!_isStarted)))
         {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
             ::util::logger::Logger::error(
                 ::util::logger::TCP, "set static IP address called in wrong state");
         }
@@ -125,6 +124,7 @@ void start(netif& ni, ::ip::Ip4Config const& config)
     if (config.useDhcp)
     {
 #if LWIP_DHCP == 1
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
         ::util::logger::Logger::info(::util::logger::TCP, "dhcp_start");
         (void)dhcp_start(&ni
 
@@ -132,6 +132,7 @@ void start(netif& ni, ::ip::Ip4Config const& config)
         );
 #endif
 #if (LWIP_AUTOIP == 1) && (LWIP_DHCP_AUTOIP_COOP == 0)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
         logger::Logger::info(logger::TCP, "autoip_start");
         autoip_start(&_netif);
 #endif
@@ -140,6 +141,7 @@ void start(netif& ni, ::ip::Ip4Config const& config)
 #if LWIP_IPV6_DHCP6 == 1
     if (!_hasStaticIp6Address)
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
         logger::Logger::info(logger::TCP, "dhcp6_start");
         dhcp6_start(&_netif, &lwiputils::LwipDhcpVendorOptionProvider::dhcp6OptionsReceived);
     }
@@ -192,6 +194,7 @@ void createIp6Address()
 
 void onLinkStatusChanged(bool const isLinkUp, netif& ni)
 {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
     ::util::logger::Logger::info(
         ::util::logger::ETHERNET, "linkStatusChanged(%s)", (isLinkUp ? "UP" : "DOWN"));
     if (isLinkUp)
@@ -205,5 +208,3 @@ void onLinkStatusChanged(bool const isLinkUp, netif& ni)
 }
 
 } // namespace lwipnetif
-
-// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/lwipSocket/src/lwipSocket/tcp/LwipServerSocket.cpp
+++ b/libs/bsw/lwipSocket/src/lwipSocket/tcp/LwipServerSocket.cpp
@@ -1,7 +1,5 @@
 // Copyright 2025 Accenture.
 
-// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
-
 #include "lwipSocket/tcp/LwipServerSocket.h"
 
 #include "lwipSocket/tcp/LwipSocket.h"
@@ -40,11 +38,13 @@ bool LwipServerSocket::accept()
         return false;
     }
 
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
     if (fpPCB == nullptr)
     {
         fpPCB = tcp_new_ip_type(IPADDR_TYPE_ANY);
         if (fpPCB == nullptr)
         {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
             logger::Logger::error(logger::TCP, "LwipServerSocket::bind(): tcp_new() failed");
             return false;
         }
@@ -68,6 +68,7 @@ bool LwipServerSocket::accept()
     tcp_arg(fpPCB, this);
     tcp_accept(fpPCB, &tcpAcceptListener);
     logger::Logger::info(logger::TCP, "Socket prepared at port %d", _port);
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
     return true;
 }
 
@@ -101,12 +102,14 @@ bool LwipServerSocket::bind(IPAddress const& localIpAddress, uint16_t port)
         status = tcp_bind(fpPCB, IP4_ADDR_ANY, _port);
     }
 
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
     if (status != ERR_OK)
     {
         logger::Logger::error(logger::TCP, "LwipServerSocket::bind(): tcp_bind() failed");
         // Do not call tcp_close here - bind can be retried in accept function
         return false;
     }
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
     return true;
 }
 
@@ -114,6 +117,7 @@ void LwipServerSocket::close()
 {
     if (fpPCB != nullptr)
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
         logger::Logger::info(logger::TCP, "Socket at port %d closed", _port);
         (void)tcp_close(fpPCB);
         fpPCB = nullptr;
@@ -124,6 +128,7 @@ bool LwipServerSocket::isClosed() const { return (fpPCB == nullptr); }
 
 err_t LwipServerSocket::tcpAcceptListener(void* const arg, tcp_pcb* const pcb, err_t const result)
 {
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
     if (result != ERR_OK)
     {
         logger::Logger::error(
@@ -168,9 +173,8 @@ err_t LwipServerSocket::tcpAcceptListener(void* const arg, tcp_pcb* const pcb, e
     tcp_poll(pcb, &LwipSocket::tcpPollListener, 1);
 
     pServerSocket->_socketProvidingConnectionListener->connectionAccepted(*pSocket);
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
     return ERR_OK;
 }
 
 } /*namespace tcp*/
-
-// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/lwipSocket/src/lwipSocket/tcp/LwipServerSocket.cpp
+++ b/libs/bsw/lwipSocket/src/lwipSocket/tcp/LwipServerSocket.cpp
@@ -84,6 +84,7 @@ bool LwipServerSocket::bind(IPAddress const& localIpAddress, uint16_t port)
         fpPCB = tcp_new_ip_type(IPADDR_TYPE_ANY);
         if (fpPCB == nullptr)
         {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
             logger::Logger::error(logger::TCP, "LwipServerSocket::bind(): tcp_new() failed");
             return false;
         }

--- a/libs/bsw/lwipSocket/src/lwipSocket/tcp/LwipServerSocket.cpp
+++ b/libs/bsw/lwipSocket/src/lwipSocket/tcp/LwipServerSocket.cpp
@@ -1,5 +1,7 @@
 // Copyright 2025 Accenture.
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
+
 #include "lwipSocket/tcp/LwipServerSocket.h"
 
 #include "lwipSocket/tcp/LwipSocket.h"
@@ -170,3 +172,5 @@ err_t LwipServerSocket::tcpAcceptListener(void* const arg, tcp_pcb* const pcb, e
 }
 
 } /*namespace tcp*/
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/lwipSocket/src/lwipSocket/tcp/LwipSocket.cpp
+++ b/libs/bsw/lwipSocket/src/lwipSocket/tcp/LwipSocket.cpp
@@ -1,7 +1,5 @@
 // Copyright 2025 Accenture.
 
-// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
-
 #include "lwipSocket/tcp/LwipSocket.h"
 
 #include "lwipSocket/utils/LwipHelper.h"
@@ -54,6 +52,7 @@ LwipSocket::LwipSocket()
 
 void LwipSocket::setForceCopy(bool const forceCopy) { fForceCopy = forceCopy; }
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
 AbstractSocket::ErrorCode LwipSocket::send(::etl::span<uint8_t const> const& data)
 {
     lwiputils::TASK_ASSERT_HOOK();
@@ -250,6 +249,8 @@ err_t LwipSocket::receiveCallback(tcp_pcb const* const pcb, pbuf* const p, err_t
     return checkResult(result);
 }
 
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)
+
 err_t LwipSocket::tcpConnectedListener(void* const arg, tcp_pcb* const pcb, err_t const result)
 {
     if (arg == nullptr)
@@ -263,6 +264,7 @@ err_t LwipSocket::tcpConnectedListener(void* const arg, tcp_pcb* const pcb, err_
     return pSocket->connectCallback(pcb, result);
 }
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
 err_t LwipSocket::connectCallback(tcp_pcb const* const /*pcb*/, err_t const result)
 {
     logger::Logger::debug(logger::TCP, "LwipSocket::tcpConnectedListener(%d)", result);
@@ -342,6 +344,8 @@ LwipSocket::connect(IPAddress const& ipAddr, uint16_t const port, ConnectedDeleg
     return AbstractSocket::ErrorCode::SOCKET_ERR_OK;
 }
 
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)
+
 size_t LwipSocket::available()
 {
     if (!isEstablished())
@@ -386,6 +390,7 @@ void LwipSocket::open(tcp_pcb* const handle)
     }
     else
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
         logger::Logger::error(logger::TCP, "LwipSocket::open() called in illegal state != CLOSED");
     }
 }
@@ -552,6 +557,7 @@ err_t LwipSocket::tcpPollListener(void* const arg, tcp_pcb* const pcb)
     return ERR_OK;
 }
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
 void LwipSocket::tcpErrorListener(void* const arg, err_t const result)
 {
     if (arg == nullptr)
@@ -608,6 +614,8 @@ void LwipSocket::errorCallback(err_t const result)
     }
     discardData();
 }
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)
 
 void LwipSocket::setNagle(bool const enable)
 {
@@ -750,5 +758,3 @@ void LwipSocket::setKeepAlive()
 #endif
 
 } // namespace tcp
-
-// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/lwipSocket/src/lwipSocket/tcp/LwipSocket.cpp
+++ b/libs/bsw/lwipSocket/src/lwipSocket/tcp/LwipSocket.cpp
@@ -1,5 +1,7 @@
 // Copyright 2025 Accenture.
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
+
 #include "lwipSocket/tcp/LwipSocket.h"
 
 #include "lwipSocket/utils/LwipHelper.h"
@@ -748,3 +750,5 @@ void LwipSocket::setKeepAlive()
 #endif
 
 } // namespace tcp
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/lwipSocket/src/lwipSocket/tcp/LwipSocket.cpp
+++ b/libs/bsw/lwipSocket/src/lwipSocket/tcp/LwipSocket.cpp
@@ -255,6 +255,7 @@ err_t LwipSocket::tcpConnectedListener(void* const arg, tcp_pcb* const pcb, err_
 {
     if (arg == nullptr)
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
         logger::Logger::critical(
             logger::TCP, "LwipSocket::tcpReceiveListener(): arg must not be NULL!");
         return ERR_ARG;

--- a/libs/bsw/lwipSocket/src/lwipSocket/udp/LwipDatagramSocket.cpp
+++ b/libs/bsw/lwipSocket/src/lwipSocket/udp/LwipDatagramSocket.cpp
@@ -69,6 +69,7 @@ bool LwipDatagramSocket::isClosed() const { return (!(isBound() && isConnected()
 AbstractDatagramSocket::ErrorCode
 LwipDatagramSocket::bind(ip::IPAddress const* pIpAddress, uint16_t port)
 {
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
     lwiputils::TASK_ASSERT_HOOK();
 
     if (_dataListener == nullptr)
@@ -108,11 +109,13 @@ LwipDatagramSocket::bind(ip::IPAddress const* pIpAddress, uint16_t port)
     }
     udp_recv(fpRxPcb, &udpReceiveListener, static_cast<void*>(this));
     logger::Logger::info(logger::UDP, "DatagramSocket bound to UDP port %d", getLocalPort());
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
     return AbstractDatagramSocket::ErrorCode::UDP_SOCKET_OK;
 }
 
 AbstractDatagramSocket::ErrorCode LwipDatagramSocket::join(ip::IPAddress const& groupAddr)
 {
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
     lwiputils::TASK_ASSERT_HOOK();
 
     if (ip::isIp4Address(groupAddr))
@@ -185,6 +188,7 @@ AbstractDatagramSocket::ErrorCode LwipDatagramSocket::join(ip::IPAddress const& 
 #endif // LWIP_IPV6
     }
 
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
     return AbstractDatagramSocket::ErrorCode::UDP_SOCKET_OK;
 }
 
@@ -211,8 +215,10 @@ void LwipDatagramSocket::udpReceiveListener(
 {
     if (arg == nullptr)
     {
+        // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
         logger::Logger::error(
             logger::UDP, "LwipDatagramSocket::udpReceiveListener(): arg is NULL!");
+        // NOLINTEND(cppcoreguidelines-pro-type-vararg)
         return;
     }
 
@@ -285,6 +291,7 @@ size_t LwipDatagramSocket::read(uint8_t* buffer, size_t n)
 AbstractDatagramSocket::ErrorCode LwipDatagramSocket::connect(
     ip::IPAddress const& address, uint16_t port, ip::IPAddress* pLocalAddress)
 {
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
     lwiputils::TASK_ASSERT_HOOK();
 
     if (fpTxPcb != nullptr)
@@ -355,11 +362,13 @@ AbstractDatagramSocket::ErrorCode LwipDatagramSocket::connect(
         "DatagramSocket connecting to %s:%d",
         ip::to_str(address, ipAddrBuffer).data(),
         port);
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
     return AbstractDatagramSocket::ErrorCode::UDP_SOCKET_OK;
 }
 
 void LwipDatagramSocket::disconnect()
 {
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
     lwiputils::TASK_ASSERT_HOOK();
 
     if (fpTxPcb != nullptr)
@@ -376,6 +385,7 @@ void LwipDatagramSocket::disconnect()
         udp_remove(fpTxPcb);
         fpTxPcb = nullptr;
     }
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
 }
 
 err_t LwipDatagramSocket::udpWrite(udp_pcb* const pcb, void const* const data, size_t const size)
@@ -394,6 +404,7 @@ err_t LwipDatagramSocket::udpWrite(udp_pcb* const pcb, void const* const data, s
 
 AbstractDatagramSocket::ErrorCode LwipDatagramSocket::send(::etl::span<uint8_t const> const& data)
 {
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
     lwiputils::TASK_ASSERT_HOOK();
 
     if (fpTxPcb != nullptr)
@@ -407,11 +418,13 @@ AbstractDatagramSocket::ErrorCode LwipDatagramSocket::send(::etl::span<uint8_t c
         }
         return AbstractDatagramSocket::ErrorCode::UDP_SOCKET_OK;
     }
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
     return AbstractDatagramSocket::ErrorCode::UDP_SOCKET_NOT_OK;
 }
 
 LwipDatagramSocket::ErrorCode LwipDatagramSocket::send(DatagramPacket const& packet)
 {
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
     lwiputils::TASK_ASSERT_HOOK();
 
     netif* pNetif         = nullptr;
@@ -463,11 +476,13 @@ LwipDatagramSocket::ErrorCode LwipDatagramSocket::send(DatagramPacket const& pac
         }
     }
 
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
     return AbstractDatagramSocket::ErrorCode::UDP_SOCKET_OK;
 }
 
 void LwipDatagramSocket::close()
 {
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
     lwiputils::TASK_ASSERT_HOOK();
 
     if (fpRxPcb != nullptr)
@@ -481,6 +496,7 @@ void LwipDatagramSocket::close()
         udp_remove(*it);
     }
     fMulticastPcbs.clear();
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
 }
 
 uint16_t LwipDatagramSocket::getLocalPort() const

--- a/libs/bsw/runtime/src/runtime/StatisticsWriter.cpp
+++ b/libs/bsw/runtime/src/runtime/StatisticsWriter.cpp
@@ -1,7 +1,5 @@
 // Copyright 2024 Accenture.
 
-// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
-
 #include "runtime/StatisticsWriter.h"
 
 #include "bsp/timer/SystemTimer.h"
@@ -38,6 +36,7 @@ void StatisticsWriter::writeEol()
     _isLineStart = true;
 }
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): StringWriter::printf is variadic by design.
 void StatisticsWriter::writeText(
     char const* const title, uint32_t const minWidth, char const* const text)
 {
@@ -149,6 +148,6 @@ bool StatisticsWriter::handleDefaultMode(
     return true;
 }
 
-} // namespace runtime
-
 // NOLINTEND(cppcoreguidelines-pro-type-vararg)
+
+} // namespace runtime

--- a/libs/bsw/runtime/src/runtime/StatisticsWriter.cpp
+++ b/libs/bsw/runtime/src/runtime/StatisticsWriter.cpp
@@ -1,5 +1,7 @@
 // Copyright 2024 Accenture.
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
+
 #include "runtime/StatisticsWriter.h"
 
 #include "bsp/timer/SystemTimer.h"
@@ -148,3 +150,5 @@ bool StatisticsWriter::handleDefaultMode(
 }
 
 } // namespace runtime
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/transport/src/AbstractTransportLayer.cpp
+++ b/libs/bsw/transport/src/AbstractTransportLayer.cpp
@@ -1,5 +1,7 @@
 // Copyright 2024 Accenture.
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
+
 #include "transport/AbstractTransportLayer.h"
 
 #include "common/busid/BusId.h"
@@ -96,3 +98,5 @@ void AbstractTransportLayer::TransportMessageProvidingListenerHelper::dump()
 }
 
 } // namespace transport
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/transport/src/TransportMessage.cpp
+++ b/libs/bsw/transport/src/TransportMessage.cpp
@@ -1,5 +1,7 @@
 // Copyright 2024 Accenture.
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
+
 #include "transport/TransportMessage.h"
 
 #include "transport/TransportLogger.h"
@@ -136,3 +138,5 @@ bool TransportMessage::operator==(TransportMessage const& rhs) const
 }
 
 } // namespace transport
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/transport/src/TransportMessage.cpp
+++ b/libs/bsw/transport/src/TransportMessage.cpp
@@ -1,7 +1,5 @@
 // Copyright 2024 Accenture.
 
-// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
-
 #include "transport/TransportMessage.h"
 
 #include "transport/TransportLogger.h"
@@ -31,6 +29,7 @@ TransportMessage::TransportMessage(uint8_t* const buffer, uint32_t const bufferL
 , _validBytes(0U)
 {}
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
 void TransportMessage::init(uint8_t* const buffer, uint32_t const bufferLength)
 {
     if ((buffer == nullptr) && (bufferLength > 0U))
@@ -78,6 +77,8 @@ void TransportMessage::setPayloadLength(uint16_t const length)
     }
     _payloadLength = length;
 }
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)
 
 TransportMessage::ErrorCode
 TransportMessage::append(uint8_t const* const data, uint16_t const length)
@@ -138,5 +139,3 @@ bool TransportMessage::operator==(TransportMessage const& rhs) const
 }
 
 } // namespace transport
-
-// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/transportRouterSimple/src/transport/routing/TransportRouterSimple.cpp
+++ b/libs/bsw/transportRouterSimple/src/transport/routing/TransportRouterSimple.cpp
@@ -1,5 +1,7 @@
 // Copyright 2024 Accenture.
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
+
 #include "transport/routing/TransportRouterSimple.h"
 
 #include "busid/BusId.h"
@@ -194,3 +196,5 @@ void TransportRouterSimple::forwardMessageToTransportLayer(
 }
 
 } // namespace transport
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/libs/bsw/uds/test/src/uds/IntegrationTest.cpp
+++ b/libs/bsw/uds/test/src/uds/IntegrationTest.cpp
@@ -57,6 +57,8 @@ MATCHER_P(SameAddress, n, "")
  * Implementation of MyReadDataByIdentifier
  *
  */
+// Test helper traces intentionally use the current variadic logger API.
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
 class MyReadDataByIdentifier : public uds::AbstractDiagJob
 {
 public:
@@ -95,6 +97,8 @@ public:
 private:
     static uint8_t const IMPLEMENTED_REQUEST[3];
 };
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)
 
 uint8_t const MyReadDataByIdentifier::IMPLEMENTED_REQUEST[3] = {0x22, 0x01, 0x01};
 

--- a/libs/bsw/util/include/util/logger/Logger.h
+++ b/libs/bsw/util/include/util/logger/Logger.h
@@ -183,6 +183,8 @@ inline bool Logger::isEnabled(uint8_t const componentIndex, Level const level)
                                           : false;
 }
 
+// Logger API is intentionally variadic; type-safe alternatives are tracked as a future issue.
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
 inline void Logger::info(uint8_t const componentIndex, char const* const str, ...)
 {
     LOGGER_DOLOG(LEVEL_INFO)
@@ -221,6 +223,8 @@ Logger::log(uint8_t const componentIndex, Level const level, char const* const s
         doLog(componentIndex, level, str, ap);
     }
 }
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)
 
 } // namespace logger
 } // namespace util

--- a/libs/bsw/util/test/src/util/logger/LoggerTest.cpp
+++ b/libs/bsw/util/test/src/util/logger/LoggerTest.cpp
@@ -11,6 +11,8 @@ using namespace ::util::format;
 
 namespace
 {
+// Exercises the legacy logger API, which is variadic by design.
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
 // NOLINTNEXTLINE(cert-dcl50-cpp): va_list usage only for printing functionalities.
 void callLog(uint8_t index, Level level, char const* formatString, ...)
 {
@@ -182,3 +184,5 @@ TEST_F(LoggerTest, testUninitializedUsage)
     callLog(6, LEVEL_DEBUG, "abc", 1, 2, 3);
     ASSERT_EQ(LEVEL_NONE, Logger::getLevel(0));
 }
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/platforms/posix/bsp/bspEepromDriver/src/eeprom/EepromDriver.cpp
+++ b/platforms/posix/bsp/bspEepromDriver/src/eeprom/EepromDriver.cpp
@@ -20,7 +20,8 @@ EepromDriver::EepromDriver() : eepromFd(-1)
     bool fileExisted = false;
 
     // Try opening existing file first
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): POSIX open uses an optional mode argument.
+    // POSIX open uses an optional mode argument.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     eepromFd = open(eepromFilePath.c_str(), O_RDWR);
 
     if (eepromFd != -1)
@@ -32,12 +33,7 @@ EepromDriver::EepromDriver() : eepromFd(-1)
         // If opening fails, try creating it
         // POSIX open uses an optional mode argument.
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-        eepromFd = open(eepromFilePath.c_str(), O_RDWR | O_CREAT, 0666);
-
-        if (eepromFd != -1)
-        {
-            chmod(eepromFilePath.c_str(), 0666);
-        }
+        eepromFd = open(eepromFilePath.c_str(), O_RDWR | O_CREAT, 0600);
     }
 
     // Initialize only for newly created files
@@ -104,9 +100,7 @@ EepromDriver::write(uint32_t const address, uint8_t const* const buffer, uint32_
 
     if (!success)
     {
-        // POSIX EEPROM driver reports errors via printf.
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-        printf("Failed to write to EEPROM file\r\n");
+        (void)std::fputs("Failed to write to EEPROM file\r\n", stderr);
         return ::bsp::BSP_ERROR;
     }
     return ::bsp::BSP_OK;
@@ -123,9 +117,7 @@ EepromDriver::read(uint32_t const address, uint8_t* const buffer, uint32_t const
 
     if (!success)
     {
-        // POSIX EEPROM driver reports errors via printf.
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-        printf("Failed to read from EEPROM file\r\n");
+        (void)std::fputs("Failed to read from EEPROM file\r\n", stderr);
         return ::bsp::BSP_ERROR;
     }
     return ::bsp::BSP_OK;

--- a/platforms/posix/bsp/bspEepromDriver/src/eeprom/EepromDriver.cpp
+++ b/platforms/posix/bsp/bspEepromDriver/src/eeprom/EepromDriver.cpp
@@ -6,6 +6,8 @@
 
 #include <sys/stat.h>
 
+#include <cstdio>
+
 #include <cstring>
 #include <fcntl.h>
 #include <unistd.h>
@@ -18,6 +20,7 @@ EepromDriver::EepromDriver() : eepromFd(-1)
     bool fileExisted = false;
 
     // Try opening existing file first
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): POSIX open uses an optional mode argument.
     eepromFd = open(eepromFilePath.c_str(), O_RDWR);
 
     if (eepromFd != -1)
@@ -27,6 +30,8 @@ EepromDriver::EepromDriver() : eepromFd(-1)
     else
     {
         // If opening fails, try creating it
+        // POSIX open uses an optional mode argument.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
         eepromFd = open(eepromFilePath.c_str(), O_RDWR | O_CREAT, 0666);
 
         if (eepromFd != -1)
@@ -99,6 +104,8 @@ EepromDriver::write(uint32_t const address, uint8_t const* const buffer, uint32_
 
     if (!success)
     {
+        // POSIX EEPROM driver reports errors via printf.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
         printf("Failed to write to EEPROM file\r\n");
         return ::bsp::BSP_ERROR;
     }
@@ -116,6 +123,8 @@ EepromDriver::read(uint32_t const address, uint8_t* const buffer, uint32_t const
 
     if (!success)
     {
+        // POSIX EEPROM driver reports errors via printf.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
         printf("Failed to read from EEPROM file\r\n");
         return ::bsp::BSP_ERROR;
     }

--- a/platforms/posix/bsp/bspUart/src/bsp/Uart.cpp
+++ b/platforms/posix/bsp/bspUart/src/bsp/Uart.cpp
@@ -1,5 +1,3 @@
-
-// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
 #include <bsp/Uart.h>
 #include <bsp/uart/UartConfig.h>
 
@@ -92,5 +90,3 @@ bsp::Uart& Uart::getInstance(Id id)
 bool Uart::isInitialized() const { return _initialized; }
 
 bool Uart::waitForTxReady() { return true; }
-
-// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/platforms/posix/bsp/bspUart/src/bsp/Uart.cpp
+++ b/platforms/posix/bsp/bspUart/src/bsp/Uart.cpp
@@ -1,3 +1,5 @@
+
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
 #include <bsp/Uart.h>
 #include <bsp/uart/UartConfig.h>
 
@@ -90,3 +92,5 @@ bsp::Uart& Uart::getInstance(Id id)
 bool Uart::isInitialized() const { return _initialized; }
 
 bool Uart::waitForTxReady() { return true; }
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/platforms/posix/bsp/socketCanTransceiver/src/can/SocketCanTransceiver.cpp
+++ b/platforms/posix/bsp/socketCanTransceiver/src/can/SocketCanTransceiver.cpp
@@ -1,5 +1,7 @@
 // Copyright 2024 Accenture.
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
+
 #include "can/SocketCanTransceiver.h"
 
 #include <can/CanLogger.h>
@@ -294,3 +296,5 @@ void SocketCanTransceiver::guardedRun(int maxSentPerRun, int maxReceivedPerRun)
 }
 
 } // namespace can
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/platforms/posix/bsp/socketCanTransceiver/src/can/SocketCanTransceiver.cpp
+++ b/platforms/posix/bsp/socketCanTransceiver/src/can/SocketCanTransceiver.cpp
@@ -1,7 +1,5 @@
 // Copyright 2024 Accenture.
 
-// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
-
 #include "can/SocketCanTransceiver.h"
 
 #include <can/CanLogger.h>
@@ -166,6 +164,7 @@ void SocketCanTransceiver::run(int maxSentPerRun, int maxReceivedPerRun)
 
 void SocketCanTransceiver::guardedOpen()
 {
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
     char const* const name = _config.name;
     int error              = 0;
     int const fd           = socket(PF_CAN, SOCK_RAW, CAN_RAW);
@@ -222,6 +221,7 @@ void SocketCanTransceiver::guardedOpen()
     }
 
     _fileDescriptor = fd;
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
 }
 
 void SocketCanTransceiver::guardedClose()
@@ -279,6 +279,7 @@ void SocketCanTransceiver::guardedRun(int maxSentPerRun, int maxReceivedPerRun)
         if (length == CAN_MTU)
         {
             can_frame const& socketCanFrame = *reinterpret_cast<can_frame const*>(buffer);
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
             Logger::debug(
                 CAN,
                 "[SocketCanTransceiver] received CAN frame, id=0x%X, length=%d",
@@ -296,5 +297,3 @@ void SocketCanTransceiver::guardedRun(int maxSentPerRun, int maxReceivedPerRun)
 }
 
 } // namespace can
-
-// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/platforms/posix/bsp/tapEthernetDriver/src/TapEthernetDriver.cpp
+++ b/platforms/posix/bsp/tapEthernetDriver/src/TapEthernetDriver.cpp
@@ -1,5 +1,7 @@
 // Copyright 2025 Accenture.
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg): Logger/StringWriter API is variadic by design.
+
 #include "TapEthernetDriver.h"
 
 #include "lwip/arch.h"
@@ -142,3 +144,5 @@ bool TapEthernetDriver::writeFrame(pbuf* const buf) const
 }
 
 } // namespace ethernet
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)

--- a/platforms/s32k1xx/bsp/canflex2Transceiver/src/can/transceiver/canflex2/CanFlex2Transceiver.cpp
+++ b/platforms/s32k1xx/bsp/canflex2Transceiver/src/can/transceiver/canflex2/CanFlex2Transceiver.cpp
@@ -86,6 +86,8 @@ CanFlex2Transceiver::write(::can::CANFrame const& frame, ::can::ICANFrameSentLis
 {
     if (State::MUTED == _state)
     {
+        // Logger API is variadic by design.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
         logger::Logger::warn(
             logger::CAN,
             "Write Id 0x%x to muted %s",


### PR DESCRIPTION
## Purpose of this PR
- [ ] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [x] Other (Please specify)

**Description**
This PR enables `cppcoreguidelines-pro-type-vararg` in `.clang-tidy` and applies the required production-code fixes and targeted suppressions for the current codebase.

The change removes a number of direct `printf`-style uses in examples and drivers, tightens a POSIX EEPROM file-permission path, and keeps the remaining intentional vararg-based interfaces explicitly documented until they can be redesigned.

**Related Issues**
Related: #431

**Breaking Changes**
- [ ] Yes
- [x] No

If there are breaking changes, please explain what they are and how they may impact existing functionality.

**Test Plan**
- `python3 .ci/clang-tidy.py --build_directory build/tests/posix/Release --output_file /tmp/ct-p1-pro-type-vararg.yaml --exclude '3rdparty|/test/|/mock/' --ignore-checks 'clang-diagnostic-error'`
- Result: 0 findings for the enabled check in the available POSIX Release build.
- `cmake --build build/tests/posix/Release --target asyncImplExample:Release loggerIntegration:Release loggerTest:Release ioExamples:Release --parallel`
- `build/tests/posix/Release/libs/bsw/asyncImpl/examples/Release/asyncImplExample`
- `build/tests/posix/Release/libs/bsw/logger/test/Release/loggerTest`
- `cmake --build build/posix-freertos --target app.referenceApp --parallel`
- Focused follow-up checks after the ETL formatting changes:
  - `clang-tidy-17 -checks=-*,cppcoreguidelines-pro-type-vararg -p build/tests/posix/Release libs/bsw/asyncImpl/examples/src/example.cpp`
  - `clang-tidy-17 -checks=-*,cppcoreguidelines-pro-type-vararg -p build/tests/posix/Release libs/bsw/loggerIntegration/src/logger/LoggerTime.cpp`
  - `clang-tidy-17 -checks=-*,cppcoreguidelines-pro-type-vararg -p build/tests/posix/Release libs/bsw/io/examples/VariantQueueExample.cpp`
- Validation gap: the S32K build directory is not available locally in this workspace.

**Regression Tests**
Have tests been added/updated? [ ] Yes [x] No
