### PR TITLE
Clang-tidy: enable cppcoreguidelines-pro-type-reinterpret-cast

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,7 @@ Checks: >-
     bugprone-*,
     -bugprone-easily-swappable-parameters,
     cppcoreguidelines-pro-type-vararg,
+    cppcoreguidelines-pro-type-reinterpret-cast,
     llvm-*,-llvm-header-guard,-llvm-include-order,
     google-readability-casting
 ExtraArgs: ['-Wno-unknown-warning-option']

--- a/executables/referenceApp/application/include/systems/DemoSystem.h
+++ b/executables/referenceApp/application/include/systems/DemoSystem.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include <async/Async.h>
 #include <async/IRunnable.h>
 #include <lifecycle/AsyncLifecycleComponent.h>
@@ -106,6 +108,10 @@ private:
         uint8_t charParam1;
         uint16_t reserved;
     };
+
+    static_assert(
+        offsetof(StorageData, charParam0) == sizeof(uint32_t),
+        "StorageData layout must keep charParam0 immediately after intParam");
 
     // END storage data
 

--- a/executables/referenceApp/application/src/systems/DemoSystem.cpp
+++ b/executables/referenceApp/application/src/systems/DemoSystem.cpp
@@ -80,10 +80,8 @@ DemoSystem::DemoSystem(
 #ifdef PLATFORM_SUPPORT_STORAGE
 , _storage(storage)
 // BEGIN storage buffers
-, _storageReadBuf(
-      ::etl::span<uint8_t>(reinterpret_cast<uint8_t*>(&_storageData), sizeof(_storageData)))
-, _storageWriteBuf(
-      ::etl::span<uint8_t const>(reinterpret_cast<uint8_t const*>(&_storageData.charParam0), 1))
+, _storageReadBuf(::etl::span<StorageData, 1>(&_storageData, 1).reinterpret_as<uint8_t>())
+, _storageWriteBuf(::etl::span<uint8_t const>(&_storageData.charParam0, 1))
 // END storage buffers
 , _jobDoneCallback(
       ::storage::StorageJob::JobDoneCallback::create<DemoSystem, &DemoSystem::storageJobDone>(

--- a/executables/referenceApp/application/src/systems/EthernetSystem.cpp
+++ b/executables/referenceApp/application/src/systems/EthernetSystem.cpp
@@ -17,8 +17,8 @@ int32_t vlanForNetif(void const* const vlwipNi)
 {
     ETL_ASSERT(vlwipNi != nullptr, ETL_ERROR_GENERIC("netif must not be null"));
 
-    auto const lwipNi         = reinterpret_cast<netif const*>(vlwipNi);
-    auto const ethernetSystem = reinterpret_cast<::systems::EthernetSystem*>(lwipNi->state);
+    auto const lwipNi         = static_cast<netif const*>(vlwipNi);
+    auto const ethernetSystem = static_cast<::systems::EthernetSystem*>(lwipNi->state);
 
     ETL_ASSERT(
         lwipNi >= ethernetSystem->netifs.netifs.begin()
@@ -38,7 +38,7 @@ int32_t vlanForNetif(void const* const vlwipNi)
 
 static err_t linkoutput(netif* const aNetif, struct pbuf* const buf)
 {
-    auto const ethernetSystem = reinterpret_cast<::systems::EthernetSystem*>(aNetif->state);
+    auto const ethernetSystem = static_cast<::systems::EthernetSystem*>(aNetif->state);
     if ((aNetif->flags & NETIF_FLAG_LINK_UP) == 0)
     {
         return ERR_VAL;
@@ -64,7 +64,7 @@ static err_t joinMulticastGroupIpV4(
     }
     if (action == NETIF_ADD_MAC_FILTER)
     {
-        auto const ethernetSystem = reinterpret_cast<::systems::EthernetSystem*>(aNetif->state);
+        auto const ethernetSystem = static_cast<::systems::EthernetSystem*>(aNetif->state);
         ::etl::array<uint8_t, 6> groupAddress
             = {LL_IP4_MULTICAST_ADDR_0,
                LL_IP4_MULTICAST_ADDR_1,

--- a/libs/bsp/bspCharInputOutput/src/charInputOutput/charIoSerial.cpp
+++ b/libs/bsp/bspCharInputOutput/src/charInputOutput/charIoSerial.cpp
@@ -74,7 +74,8 @@ int SerialLogger_getc()
 void SerialLogger_Idle()
 {
     etl::span<uint8_t const> const data(
-        reinterpret_cast<uint8_t const*>(LoggerBuffer.data()), SerialLogger_bufferInd);
+        static_cast<uint8_t const*>(static_cast<void const*>(LoggerBuffer.data())),
+        SerialLogger_bufferInd);
     getUart().write(data);
     SerialLogger_bufferInd = 0;
 }

--- a/libs/bsw/lwipSocket/src/lwipSocket/netif/LwipNetworkInterface.cpp
+++ b/libs/bsw/lwipSocket/src/lwipSocket/netif/LwipNetworkInterface.cpp
@@ -45,15 +45,21 @@ bool initNetifIp4(
         ::etl::copy(
             ip::packed(networkInterfaceConfig.ipAddress()),
             ::etl::span<uint8_t>(
-                reinterpret_cast<uint8_t*>(&ipAddress.addr), sizeof(ipAddress.addr)));
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): lwIP ip4_addr struct
+                reinterpret_cast<uint8_t*>(&ipAddress.addr),
+                sizeof(ipAddress.addr)));
         ::etl::copy(
             ip::packed(networkInterfaceConfig.networkMask()),
             ::etl::span<uint8_t>(
-                reinterpret_cast<uint8_t*>(&networkMask.addr), sizeof(networkMask.addr)));
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): lwIP ip4_addr struct
+                reinterpret_cast<uint8_t*>(&networkMask.addr),
+                sizeof(networkMask.addr)));
         ::etl::copy(
             ip::packed(networkInterfaceConfig.defaultGateway()),
             ::etl::span<uint8_t>(
-                reinterpret_cast<uint8_t*>(&defaultGateway.addr), sizeof(defaultGateway.addr)));
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): lwIP ip4_addr struct
+                reinterpret_cast<uint8_t*>(&defaultGateway.addr),
+                sizeof(defaultGateway.addr)));
     }
 
     auto const isInitialized

--- a/platforms/posix/bsp/socketCanTransceiver/src/can/SocketCanTransceiver.cpp
+++ b/platforms/posix/bsp/socketCanTransceiver/src/can/SocketCanTransceiver.cpp
@@ -212,6 +212,7 @@ void SocketCanTransceiver::guardedOpen()
     ::std::memset(&addr, 0, sizeof(addr));
     addr.can_family  = AF_CAN;
     addr.can_ifindex = ifr.ifr_ifindex;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): POSIX bind() requires sockaddr*
     error            = bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
     if (error < 0)
     {
@@ -255,8 +256,7 @@ void SocketCanTransceiver::guardedRun(int maxSentPerRun, int maxReceivedPerRun)
         socketCanFrame.can_dlc = length;
         ::std::memcpy(socketCanFrame.data, canFrame.getPayload(), length);
         ::std::memset(socketCanFrame.data + length, 0, sizeof(socketCanFrame.data) - length);
-        ssize_t const bytesWritten
-            = ::write(_fileDescriptor, reinterpret_cast<char*>(&socketCanFrame), CAN_MTU);
+        ssize_t const bytesWritten = ::write(_fileDescriptor, &socketCanFrame, CAN_MTU);
         if (bytesWritten != CAN_MTU)
         {
             break;
@@ -271,13 +271,14 @@ void SocketCanTransceiver::guardedRun(int maxSentPerRun, int maxReceivedPerRun)
     for (int count = 0; count < maxReceivedPerRun; ++count)
     {
         alignas(can_frame) uint8_t buffer[CANFD_MTU];
-        ssize_t const length = read(_fileDescriptor, reinterpret_cast<char*>(buffer), CANFD_MTU);
+        ssize_t const length = read(_fileDescriptor, buffer, CANFD_MTU);
         if (length < 0)
         {
             break;
         }
         if (length == CAN_MTU)
         {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
             can_frame const& socketCanFrame = *reinterpret_cast<can_frame const*>(buffer);
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): Logger API is variadic by design.
             Logger::debug(

--- a/platforms/posix/bsp/tapEthernetDriver/src/TapEthernetDriver.cpp
+++ b/platforms/posix/bsp/tapEthernetDriver/src/TapEthernetDriver.cpp
@@ -122,7 +122,9 @@ void TapEthernetDriver::readFrame()
     {
         // We can "upcast" here since the initial allocation was made as RxCustimPbuf
         // The pbuf is embedded as the first memeber so the address stays the same.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): lwIP pbuf container-of
         auto* driverPbuf = reinterpret_cast<::lwiputils::RxCustomPbuf*>(p);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): freeing original uint8_t[]
         delete[] reinterpret_cast<uint8_t*>(driverPbuf->slot);
         delete driverPbuf;
     };


### PR DESCRIPTION
## Purpose of this PR
- [ ] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [x] Other (Please specify)

**Description**
This PR enables `cppcoreguidelines-pro-type-reinterpret-cast` in `.clang-tidy` and applies the required production-code cast fixes and targeted suppressions for the current codebase.

The changes replace several low-level pointer conversions with safer alternatives while preserving existing behavior. The branch also keeps `LoggerTime.cpp` compatible with the ETL-based formatting update so it remains mergeable if the vararg cleanup lands first.

**Related Issues**
N/A

**Breaking Changes**
- [ ] Yes
- [x] No

If there are breaking changes, please explain what they are and how they may impact existing functionality.

**Test Plan**
- `python3 .ci/clang-tidy.py --build_directory build/tests/posix/Release --output_file /tmp/ct-p1-pro-type-reinterpret-cast.yaml --exclude '3rdparty|/test/|/mock/' --ignore-checks 'clang-diagnostic-error'`
- Result: 0 findings for the enabled check in the available POSIX Release build.
- Follow-up validation for the `LoggerTime.cpp` compatibility update:
  - `cmake --build build/tests/posix/Release --target loggerIntegration:Release loggerTest:Release --parallel`
  - `build/tests/posix/Release/libs/bsw/logger/test/Release/loggerTest`
  - `clang-tidy-17 -checks=-*,cppcoreguidelines-pro-type-reinterpret-cast -p build/tests/posix/Release libs/bsw/loggerIntegration/src/logger/LoggerTime.cpp`
- Validation gap: the S32K build directory is not available locally in this workspace.

**Regression Tests**
Have tests been added/updated? [ ] Yes [x] No
