### PR TITLE
Clang-tidy: suppress cppcoreguidelines-pro-type-vararg in platform files

### DIFF
--- a/platforms/posix/bsp/bspUart/src/bsp/Uart.cpp
+++ b/platforms/posix/bsp/bspUart/src/bsp/Uart.cpp
@@ -60,6 +60,7 @@ void Uart::init()
 
         // Set the file descriptor to non-blocking
         oldflags = fcntl(STDIN_FILENO, F_GETFL, 0);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): POSIX fcntl arg type depends on cmd.
         fcntl(STDIN_FILENO, F_SETFL, oldflags | O_NONBLOCK);
         _initialized = true;
     }

--- a/platforms/posix/bsp/bspUart/src/bsp/Uart.cpp
+++ b/platforms/posix/bsp/bspUart/src/bsp/Uart.cpp
@@ -59,10 +59,13 @@ void Uart::init()
         (void)tcsetattr(_std_out_fd, TCSANOW, &tmp);
 
         // Set the file descriptor to non-blocking
-        oldflags = fcntl(STDIN_FILENO, F_GETFL, 0);
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): POSIX fcntl arg type depends on cmd.
-        fcntl(STDIN_FILENO, F_SETFL, oldflags | O_NONBLOCK);
-        _initialized = true;
+        oldflags = fcntl(_std_in_fd, F_GETFL, 0);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): POSIX fcntl arg type depends on cmd.
+        if ((oldflags != -1) && (fcntl(_std_in_fd, F_SETFL, oldflags | O_NONBLOCK) != -1))
+        {
+            _initialized = true;
+        }
     }
 }
 

--- a/platforms/s32k1xx/bsp/bspAdc/src/tester/AnalogTester.cpp
+++ b/platforms/s32k1xx/bsp/bspAdc/src/tester/AnalogTester.cpp
@@ -21,6 +21,8 @@ DEFINE_COMMAND_GROUP_GET_INFO_END;
 
 void AnalogTester::executeCommand(CommandContext& context, uint8_t const idx)
 {
+    // SharedStringWriter::printf is variadic by design.
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
     switch (idx)
     {
         case 1: // "all"
@@ -110,6 +112,7 @@ void AnalogTester::executeCommand(CommandContext& context, uint8_t const idx)
             break;
         }
     }
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
 }
 
 } // namespace bios

--- a/platforms/s32k1xx/bsp/bspEthernet/src/ethernet/EnetDriver.cpp
+++ b/platforms/s32k1xx/bsp/bspEthernet/src/ethernet/EnetDriver.cpp
@@ -152,6 +152,8 @@ uint8_t initDevice(
 
 uint8_t EnetDriver::init()
 {
+    // Logger API is variadic by design.
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
     _rxBuffers.init();
     _txBuffers.init();
 
@@ -169,6 +171,7 @@ uint8_t EnetDriver::init()
     }
 
     return result;
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
 }
 
 void EnetDriver::enableVlanTagging()

--- a/platforms/s32k1xx/bsp/bspEthernet/src/ethernet/RxBuffers.cpp
+++ b/platforms/s32k1xx/bsp/bspEthernet/src/ethernet/RxBuffers.cpp
@@ -84,6 +84,8 @@ void RxBuffers::init()
 
 void RxBuffers::interrupt()
 {
+    // Logger API is variadic by design.
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
     struct pbuf* buf;
     netif* pNetif;
 
@@ -116,10 +118,13 @@ void RxBuffers::interrupt()
             }
         }
     } while (buf != nullptr);
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
 }
 
 static bool isErrornousBuffer(ENET_ERXD const& descriptor)
 {
+    // Logger API is variadic by design.
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
     if ((descriptor.status1 & ENET_ERXD_STATUS1_TR(1)) != 0U)
     { // frame truncated, ignore other error-flags
         Logger::log(ETHERNET, _WARN, "Frame truncated");
@@ -152,6 +157,7 @@ static bool isErrornousBuffer(ENET_ERXD const& descriptor)
     }
 
     return false;
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
 }
 
 pbuf* RxBuffers::getCurrentBuffer()

--- a/platforms/s32k1xx/bsp/bspEthernet/src/ethernet/TxBuffers.cpp
+++ b/platforms/s32k1xx/bsp/bspEthernet/src/ethernet/TxBuffers.cpp
@@ -99,6 +99,8 @@ bool TxBuffers::writeBuffer(
     ::etl::span<uint8_t const> const data,
     bool const lastBufferInFrame)
 {
+    // Logger API is variadic by design.
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
     // sanity checks
     ETL_ASSERT(
         txDescriptorIndex < _descriptors.size(),
@@ -126,10 +128,13 @@ bool TxBuffers::writeBuffer(
     }
 
     return true;
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
 }
 
 bool TxBuffers::writeFrame(uint16_t const vlanId, const struct pbuf* const buf)
 {
+    // Logger API is variadic by design.
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
     struct pbuf* const p = const_cast<struct pbuf*>(buf);
 
     auto const txBufferDescriptorCount = pbuf_clen(p);
@@ -251,6 +256,7 @@ bool TxBuffers::writeFrame(uint16_t const vlanId, const struct pbuf* const buf)
         Logger::log(ETHERNET, _ERROR, "ENET tx fifo is full");
     }
     return false;
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
 }
 
 bool TxBuffers::getNextDescriptorIndex(uint8_t const n, ::etl::span<uint8_t> const indexes)

--- a/platforms/s32k1xx/bsp/bspTja1101/src/phy/Tja1101Tester.cpp
+++ b/platforms/s32k1xx/bsp/bspTja1101/src/phy/Tja1101Tester.cpp
@@ -20,6 +20,8 @@ Tja1101Tester::Tja1101Tester(Tja1101& ethernetPhyTja1101) : _ethernetPhyTja1101(
 
 void Tja1101Tester::executeCommand(::util::command::CommandContext& context, uint8_t const idx)
 {
+    // SharedStringWriter::printf is variadic by design.
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
     ::util::format::SharedStringWriter writer(context);
     switch (idx)
     {
@@ -66,6 +68,7 @@ void Tja1101Tester::executeCommand(::util::command::CommandContext& context, uin
             break;
         }
     }
+    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
 }
 
 } // namespace enetphy


### PR DESCRIPTION
## Purpose of this PR
- [ ] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [x] Other (Please specify)

**Description**
This PR suppresses `cppcoreguidelines-pro-type-vararg` violations in platform files where the variadic use is intentional and cannot be avoided:

- `platforms/posix/bsp/bspUart/src/bsp/Uart.cpp` — POSIX `fcntl` is inherently variadic; its third argument's type depends on the command passed.  Both the `F_GETFL` and `F_SETFL` calls are now suppressed.  The patch also switches from `STDIN_FILENO` to `_std_in_fd` for consistency and guards `_initialized` behind return-value checks on both calls.
- `platforms/s32k1xx/bsp/bspEthernet/src/ethernet/EnetDriver.cpp` — logger API is variadic by design.
- `platforms/s32k1xx/bsp/bspEthernet/src/ethernet/TxBuffers.cpp` — same.
- `platforms/s32k1xx/bsp/bspEthernet/src/ethernet/RxBuffers.cpp` — same.
- `platforms/s32k1xx/bsp/bspAdc/src/tester/AnalogTester.cpp` — `SharedStringWriter::printf` is variadic by design.
- `platforms/s32k1xx/bsp/bspTja1101/src/phy/Tja1101Tester.cpp` — same.

Functions with multiple violations use `NOLINTBEGIN/NOLINTEND` at function scope; single occurrences use `NOLINTNEXTLINE`.

**Related Issues**
N/A