### PR TITLE
Fix cppcoreguidelines-pro-type-reinterpret-cast violations in s32k1xx BSP

### DIFF
--- a/platforms/s32k1xx/bsp/bspEepromDriver/src/eeprom/EepromDriver.cpp
+++ b/platforms/s32k1xx/bsp/bspEepromDriver/src/eeprom/EepromDriver.cpp
@@ -179,6 +179,8 @@ EepromDriver::write(uint32_t const address, uint8_t const* const buffer, uint32_
         return bsp::BSP_ERROR;
     }
 
+    // MMIO base address arithmetic yields hardware-mapped pointer.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     auto* const target = reinterpret_cast<uint8_t*>(address + _configuration.fBaseAddress);
     for (uint32_t i = 0U; i < length; ++i)
     {
@@ -206,6 +208,8 @@ EepromDriver::read(uint32_t const address, uint8_t* const buffer, uint32_t const
         return bsp::BSP_ERROR;
     }
 
+    // MMIO base address arithmetic yields hardware-mapped pointer.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     auto* const source = reinterpret_cast<uint8_t*>(address + _configuration.fBaseAddress);
     for (uint32_t i = 0U; i < length; ++i)
     {

--- a/platforms/s32k1xx/bsp/bspEthernet/include/ethernet/RxBuffers.h
+++ b/platforms/s32k1xx/bsp/bspEthernet/include/ethernet/RxBuffers.h
@@ -35,6 +35,8 @@ public:
     void interrupt();
     pbuf* readFrame(netif*& pNetif);
 
+    // Pointer-to-integer for ENet DMA descriptor base address register.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     uint32_t descriptorAddress() const { return reinterpret_cast<uint32_t>(_descriptors.data()); }
 
     pbuf* getCurrentBuffer();

--- a/platforms/s32k1xx/bsp/bspEthernet/include/ethernet/TxBuffers.h
+++ b/platforms/s32k1xx/bsp/bspEthernet/include/ethernet/TxBuffers.h
@@ -62,6 +62,8 @@ public:
 
     void interrupt();
 
+    // Pointer-to-integer for ENet DMA descriptor base address register.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     uint32_t descriptorAddress() const { return reinterpret_cast<uint32_t>(_descriptors.data()); }
 
     bool _enableVlanTagging;

--- a/platforms/s32k1xx/bsp/bspEthernet/src/ethernet/RxBuffers.cpp
+++ b/platforms/s32k1xx/bsp/bspEthernet/src/ethernet/RxBuffers.cpp
@@ -18,8 +18,11 @@ uint8_t freeRxDescriptorIndex(
 {
     ETL_ASSERT(pbufAtIndex.size() != 0L, ETL_ERROR_GENERIC("buffer size must not be null"));
 
+    // RxCustomPbuf embeds pbuf_custom as its first member; address identity is guaranteed.
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
     auto* const pbuf1 = reinterpret_cast<::lwiputils::RxCustomPbuf*>(pbufAtIndex[nextBusy]);
     auto* const pbuf2 = reinterpret_cast<::lwiputils::RxCustomPbuf*>(pbufAtIndex[descriptorIndex]);
+    // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
 
     ::ETL_OR_STD::swap(pbufAtIndex[nextBusy], pbufAtIndex[descriptorIndex]);
     ::ETL_OR_STD::swap(pbuf1->slot, pbuf2->slot);
@@ -31,10 +34,11 @@ void freeCustomPbufHelper(pbuf* const p)
 {
     // We can "upcast" here since the initial allocation was made as RxCustimPbuf
     // The pbuf is embedded as the first memeber so the address stays the same.
+    // RxCustomPbuf embeds pbuf_custom as its first member; address identity is guaranteed.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     auto* const customPbuf = reinterpret_cast<::lwiputils::RxCustomPbuf*>(p);
-    auto* const driver     = reinterpret_cast<RxBuffers*>(customPbuf->driver);
-    auto const index
-        = reinterpret_cast<ENET_ERXD*>(customPbuf->slot) - driver->_descriptors.begin();
+    auto* const driver     = static_cast<RxBuffers*>(customPbuf->driver);
+    auto const index = static_cast<ENET_ERXD*>(customPbuf->slot) - driver->_descriptors.begin();
 
     {
         ::interrupts::SuspendResumeAllInterruptsScopedLock const scopedCriticalSection;
@@ -60,9 +64,11 @@ void RxBuffers::init()
         _descriptors[i].status1 = ENET_ERXD_STATUS1_EMPTY(1);
         _descriptors[i].status3 = _descriptors[i].status3 | ENET_ERXD_STATUS3_INT(1);
         _descriptors[i].length  = 0U;
+        // Pointer-to-integer for DMA alignment check.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto const dataAddress  = reinterpret_cast<uint32_t>(_descriptors[i].data);
         ETL_ASSERT(
-            (reinterpret_cast<uint32_t>(_descriptors[i].data) % 64) == 0U,
-            ETL_ERROR_GENERIC("descriptor data must 64 byte aligned"));
+            (dataAddress % 64) == 0U, ETL_ERROR_GENERIC("descriptor data must 64 byte aligned"));
 
         _descriptors[_descriptors.size() - 1].status1
             = _descriptors[_descriptors.size() - 1].status1 | ENET_ERXD_STATUS1_WRAP(1U);

--- a/platforms/s32k1xx/bsp/bspEthernet/src/ethernet/TxBuffers.cpp
+++ b/platforms/s32k1xx/bsp/bspEthernet/src/ethernet/TxBuffers.cpp
@@ -164,7 +164,7 @@ bool TxBuffers::writeFrame(uint16_t const vlanId, const struct pbuf* const buf)
 
             if (nextPbuf != 0L)
             {
-                payload  = reinterpret_cast<uint8_t*>(nextPbuf->payload);
+                payload  = static_cast<uint8_t*>(nextPbuf->payload);
                 length   = nextPbuf->len;
                 nextPbuf = nextPbuf->next;
             }


### PR DESCRIPTION
## Purpose of this PR
- [x] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Other (Please specify)

**Description**
Fixes the failing `clang-tidy (tests-s32k1xx-release)` CI job introduced after enabling `cppcoreguidelines-pro-type-reinterpret-cast` (PR #435). The check correctly surfaced violations in s32k1xx BSP files that were not visible to the posix build used during initial validation.

**Real fixes** (replacing `reinterpret_cast` with `static_cast` where the source type is `void*`):
- `RxBuffers.cpp`: `RxCustomPbuf::driver` and `::slot` are `void*` — use `static_cast`
- `TxBuffers.cpp`: lwip `pbuf::payload` is `void*` — use `static_cast`

**NOLINT suppressions** (casts that cannot be replaced):
- `EepromDriver.cpp`: integer base address + offset → `uint8_t*` for MMIO hardware access
- `RxBuffers.cpp`: `pbuf*` → `RxCustomPbuf*` lwip custom-pbuf upcast (struct embedding, first-member address identity guaranteed by lwip design)
- `RxBuffers.cpp`: pointer → `uint32_t` for DMA 64-byte alignment check
- `RxBuffers.h` / `TxBuffers.h`: descriptor data pointer → `uint32_t` for ENet DMA base address register

**Related Issues**
N/A