### PR TITLE
User specific configuration of module uds

### DIFF
--- a/executables/referenceApp/udsConfiguration/include/uds/UdsConfig.h
+++ b/executables/referenceApp/udsConfiguration/include/uds/UdsConfig.h
@@ -1,4 +1,5 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #pragma once
 #include "platform/estdint.h"
@@ -17,5 +18,37 @@ public:
     static uint16_t const TRANSFER_DATA_TIME           = 60U;
     static uint32_t const TESTER_PRESENT_TIMEOUT_MS    = 5000U;
     static uint8_t const BUSY_MESSAGE_EXTRA_BYTES      = 7U;
+};
+
+class UdsConstants
+{
+public:
+    /**
+     * This is an extended timeout which is used when the programming
+     * session in bootloader is entered. This is due to the fact that
+     * a tester that is connected via ethernet may need more time
+     * to reconnect (e.g. slow DHCP server)
+     *
+     * 60s no longer needed, changed to required 10s
+     */
+    static uint32_t const TESTER_PRESENT_EXTENDED_TIMEOUT = 10000U; // ms
+
+    /* Session Timeouts P2* and P2*/
+    /* Default */
+    static uint16_t const DEFAULT_DIAG_RESPONSE_TIME        = 50U;  // ms
+    static uint16_t const DEFAULT_DIAG_RESPONSE_PENDING     = 500U; // 10ms
+    /* Programming session */
+    static uint16_t const PROGRAMMING_DIAG_RESPONSE_TIME    = 50U;   // ms
+    static uint16_t const PROGRAMMING_DIAG_RESPONSE_PENDING = 5000U; // 10ms
+
+    /* Reset times */
+    /* ECUReset: HardReset -> 10 01 */
+    static uint16_t const RESET_TIME_HARD = 1000U; // ms
+    /* ECUReset: SoftReset -> 10 03 */
+    static uint16_t const RESET_TIME_SOFT = 1000U; // ms
+    /* ECUReset: EnableRapidPowerShutdown -> 10 04 */
+    static uint8_t const SHUTDOWN_TIME    = 10U; // ms
+    /* DSC Reset */
+    static uint16_t const RESET_TIME_DSC  = 1000U; // ms
 };
 } /* namespace uds */

--- a/executables/referenceApp/udsConfiguration/include/uds/UdsConfig.h
+++ b/executables/referenceApp/udsConfiguration/include/uds/UdsConfig.h
@@ -1,21 +1,55 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #pragma once
 #include "platform/estdint.h"
 
 namespace uds
 {
-class UdsVmsConstants
+namespace UdsVmsConstants
 {
-public:
-    static uint16_t const MAX_BLOCK_LENGTH             = 4090U;
-    static uint16_t const ERASE_MEMORY_TIME            = 120U;
-    static uint16_t const CHECK_MEMORY_TIME            = 15U;
-    static uint16_t const BOOTLOADER_INSTALLATION_TIME = 40U;
-    static uint16_t const AUTHENTICATION_TIME          = 5U;
-    static uint16_t const RESET_TIME                   = 10U;
-    static uint16_t const TRANSFER_DATA_TIME           = 60U;
-    static uint32_t const TESTER_PRESENT_TIMEOUT_MS    = 5000U;
-    static uint8_t const BUSY_MESSAGE_EXTRA_BYTES      = 7U;
-};
+static constexpr uint16_t MAX_BLOCK_LENGTH             = 4090U;
+static constexpr uint16_t ERASE_MEMORY_TIME            = 120U;
+static constexpr uint16_t CHECK_MEMORY_TIME            = 15U;
+static constexpr uint16_t BOOTLOADER_INSTALLATION_TIME = 40U;
+static constexpr uint16_t AUTHENTICATION_TIME          = 5U;
+static constexpr uint16_t RESET_TIME                   = 10U;
+static constexpr uint16_t TRANSFER_DATA_TIME           = 60U;
+
+static constexpr uint32_t TESTER_PRESENT_TIMEOUT_MS = 5000U;
+
+static constexpr uint8_t BUSY_MESSAGE_EXTRA_BYTES = 7U;
+} /* namespace UdsVmsConstants */
+
+namespace UdsConstants
+{
+/**
+ * This is an extended timeout which is used when the programming
+ * session in bootloader is entered. This is due to the fact that
+ * a tester that is connected via ethernet may need more time
+ * to reconnect (e.g. slow DHCP server)
+ *
+ * 60s no longer needed, changed to required 10s
+ */
+static constexpr uint32_t TESTER_PRESENT_EXTENDED_TIMEOUT = 10000U; // ms
+
+/* Session Timeouts P2* and P2*/
+/* Default */
+static constexpr uint16_t DEFAULT_DIAG_RESPONSE_TIME        = 50U;  // ms
+static constexpr uint16_t DEFAULT_DIAG_RESPONSE_PENDING     = 500U; // 10ms
+/* Programming session */
+static constexpr uint16_t PROGRAMMING_DIAG_RESPONSE_TIME    = 50U;   // ms
+static constexpr uint16_t PROGRAMMING_DIAG_RESPONSE_PENDING = 5000U; // 10ms
+
+/* Reset times */
+/* ECUReset: HardReset -> 11 01 */
+static constexpr uint16_t RESET_TIME_HARD = 1000U; // ms
+/* ECUReset: SoftReset -> 11 03 */
+static constexpr uint16_t RESET_TIME_SOFT = 1000U; // ms
+/* ECUReset: EnableRapidPowerShutdown -> 11 04 */
+static constexpr uint8_t SHUTDOWN_TIME    = 10U; // ms
+/* DSC Reset */
+static constexpr uint16_t RESET_TIME_DSC  = 1000U; // ms
+} /* namespace UdsConstants */
+
 } /* namespace uds */

--- a/executables/unitTest/udsConfiguration/include/uds/UdsConfig.h
+++ b/executables/unitTest/udsConfiguration/include/uds/UdsConfig.h
@@ -24,4 +24,35 @@ public:
     static uint8_t const BUSY_MESSAGE_EXTRA_BYTES = 7U;
 };
 
+class UdsConstants
+{
+public:
+    /**
+     * This is an extended timeout which is used when the programming
+     * session in bootloader is entered. This is due to the fact that
+     * a tester that is connected via ethernet may need more time
+     * to reconnect (e.g. slow DHCP server)
+     *
+     * 60s no longer needed, changed to required 10s
+     */
+    static uint32_t const TESTER_PRESENT_EXTENDED_TIMEOUT = 10000U; // ms
+
+    /* Session Timeouts P2* and P2*/
+    /* Default */
+    static uint16_t const DEFAULT_DIAG_RESPONSE_TIME        = 50U;  // ms
+    static uint16_t const DEFAULT_DIAG_RESPONSE_PENDING     = 500U; // 10ms
+    /* Programming session */
+    static uint16_t const PROGRAMMING_DIAG_RESPONSE_TIME    = 50U;   // ms
+    static uint16_t const PROGRAMMING_DIAG_RESPONSE_PENDING = 5000U; // 10ms
+
+    /* Reset times */
+    /* ECUReset: HardReset -> 10 01 */
+    static uint16_t const RESET_TIME_HARD = 1000U; // ms
+    /* ECUReset: SoftReset -> 10 03 */
+    static uint16_t const RESET_TIME_SOFT = 1000U; // ms
+    /* ECUReset: EnableRapidPowerShutdown -> 10 04 */
+    static uint8_t const SHUTDOWN_TIME    = 10U; // ms
+    /* DSC Reset */
+    static uint16_t const RESET_TIME_DSC  = 1000U; // ms
+};
 } /* namespace uds */

--- a/executables/unitTest/udsConfiguration/include/uds/UdsConfig.h
+++ b/executables/unitTest/udsConfiguration/include/uds/UdsConfig.h
@@ -1,27 +1,55 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #pragma once
-
-#include <platform/estdint.h>
+#include "platform/estdint.h"
 
 namespace uds
 {
-class UdsVmsConstants
+namespace UdsVmsConstants
 {
-public:
-    static uint16_t const MAX_BLOCK_LENGTH = 4090U;
+static constexpr uint16_t MAX_BLOCK_LENGTH             = 4090U;
+static constexpr uint16_t ERASE_MEMORY_TIME            = 120U;
+static constexpr uint16_t CHECK_MEMORY_TIME            = 15U;
+static constexpr uint16_t BOOTLOADER_INSTALLATION_TIME = 40U;
+static constexpr uint16_t AUTHENTICATION_TIME          = 5U;
+static constexpr uint16_t RESET_TIME                   = 10U;
+static constexpr uint16_t TRANSFER_DATA_TIME           = 60U;
 
-    static uint16_t const ERASE_MEMORY_TIME            = 120U;
-    static uint16_t const CHECK_MEMORY_TIME            = 15U;
-    static uint16_t const BOOTLOADER_INSTALLATION_TIME = 40U;
-    static uint16_t const AUTHENTICATION_TIME          = 5U;
+static constexpr uint32_t TESTER_PRESENT_TIMEOUT_MS = 5000U;
 
-    static uint16_t const RESET_TIME = 10U;
+static constexpr uint8_t BUSY_MESSAGE_EXTRA_BYTES = 7U;
+} /* namespace UdsVmsConstants */
 
-    static uint16_t const TRANSFER_DATA_TIME        = 60U;
-    static uint32_t const TESTER_PRESENT_TIMEOUT_MS = 5000U;
+namespace UdsConstants
+{
+/**
+ * This is an extended timeout which is used when the programming
+ * session in bootloader is entered. This is due to the fact that
+ * a tester that is connected via ethernet may need more time
+ * to reconnect (e.g. slow DHCP server)
+ *
+ * 60s no longer needed, changed to required 10s
+ */
+static constexpr uint32_t TESTER_PRESENT_EXTENDED_TIMEOUT = 10000U; // ms
 
-    static uint8_t const BUSY_MESSAGE_EXTRA_BYTES = 7U;
-};
+/* Session Timeouts P2* and P2*/
+/* Default */
+static constexpr uint16_t DEFAULT_DIAG_RESPONSE_TIME        = 50U;  // ms
+static constexpr uint16_t DEFAULT_DIAG_RESPONSE_PENDING     = 500U; // 10ms
+/* Programming session */
+static constexpr uint16_t PROGRAMMING_DIAG_RESPONSE_TIME    = 50U;   // ms
+static constexpr uint16_t PROGRAMMING_DIAG_RESPONSE_PENDING = 5000U; // 10ms
+
+/* Reset times */
+/* ECUReset: HardReset -> 11 01 */
+static constexpr uint16_t RESET_TIME_HARD = 1000U; // ms
+/* ECUReset: SoftReset -> 11 03 */
+static constexpr uint16_t RESET_TIME_SOFT = 1000U; // ms
+/* ECUReset: EnableRapidPowerShutdown -> 11 04 */
+static constexpr uint8_t SHUTDOWN_TIME    = 10U; // ms
+/* DSC Reset */
+static constexpr uint16_t RESET_TIME_DSC  = 1000U; // ms
+} /* namespace UdsConstants */
 
 } /* namespace uds */

--- a/libs/bsw/uds/include/uds/DiagCodes.h
+++ b/libs/bsw/uds/include/uds/DiagCodes.h
@@ -1,4 +1,5 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #pragma once
 
@@ -9,11 +10,6 @@ namespace uds
 class DiagCodes
 {
 public:
-    static uint8_t const FINGERPRINT_SIZE_INDEX   = 0x03U;
-    static uint8_t const FLAG_LONG_FINGERPRINT_13 = 0x08U;
-    static uint8_t const SIZE_FINGERPRINT_LONG_13 = 0x0DU;
-    static uint8_t const SIZE_FINGERPRINT_SHORT_4 = 0x04U;
-
     static uint8_t const POSITIVE_RESPONSE                        = 0x00U;
     static uint8_t const POSITIVE_RESPONSE_WAIT_FOR_EEPROM_FINISH = 0x00U;
     static uint8_t const MIN_DIAG_MESSAGE_LENGTH                  = 3U;
@@ -27,18 +23,9 @@ public:
     static uint8_t const ID_ROUTINE_CONTROL_STOP_ROUTINE       = 0x02U;
     static uint8_t const ID_ROUTINE_CONTROL_GET_ROUTINE_RESULT = 0x03U;
 
-    static uint16_t const REQUEST_ROUTINE_ID_TESTERASSISTENT = 0x0F0BU;
-
     // Functional addressing
     static uint8_t const FUNCTIONAL_ID_ALL_KWP2000_ECUS  = 0xEFU;
     static uint8_t const FUNCTIONAL_ID_ALL_ISO14229_ECUS = 0xDFU;
-
-    static uint8_t const ERASE_MEMORY_ACTIVATION_CODE = 0x06U;
-
-    // StandardCoreVersion
-    static uint16_t const STANDARD_CORE_VERSION = 0x0BB8U;
-
-    // Max blocklength for data transfer
 
     static uint8_t const SERVICE_ID_LENGTH     = 1U;
     static uint8_t const SUBFUNCTION_ID_LENGTH = 1U;

--- a/libs/bsw/uds/include/uds/services/ecureset/EnableRapidPowerShutdown.h
+++ b/libs/bsw/uds/include/uds/services/ecureset/EnableRapidPowerShutdown.h
@@ -1,4 +1,5 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #pragma once
 
@@ -16,7 +17,6 @@ public:
 private:
     static uint8_t const sfImplementedRequest[2];
     static uint8_t const RESPONSE_LENGTH = 1U;
-    static uint8_t const ShutDownTime    = 10U; // power down time
 
     virtual DiagReturnCode::Type process(
         IncomingDiagConnection& connection, uint8_t const request[], uint16_t requestLength) final;

--- a/libs/bsw/uds/include/uds/services/ecureset/HardReset.h
+++ b/libs/bsw/uds/include/uds/services/ecureset/HardReset.h
@@ -1,4 +1,5 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #pragma once
 
@@ -18,8 +19,6 @@ public:
     void responseSent(IncomingDiagConnection& connection, ResponseSendResult result) override;
 
 private:
-    static uint16_t const RESET_TIME = 1000U; // ms
-
     DiagReturnCode::Type process(
         IncomingDiagConnection& connection,
         uint8_t const request[],

--- a/libs/bsw/uds/include/uds/services/ecureset/SoftReset.h
+++ b/libs/bsw/uds/include/uds/services/ecureset/SoftReset.h
@@ -1,4 +1,5 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #pragma once
 
@@ -18,7 +19,6 @@ public:
     void responseSent(IncomingDiagConnection& connection, ResponseSendResult result) override;
 
 private:
-    static uint16_t const RESET_TIME = 1000U; // ms
     static uint8_t const sfImplementedRequest[2];
 
     DiagReturnCode::Type process(

--- a/libs/bsw/uds/include/uds/services/sessioncontrol/DiagnosticSessionControl.h
+++ b/libs/bsw/uds/include/uds/services/sessioncontrol/DiagnosticSessionControl.h
@@ -1,4 +1,5 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #pragma once
 
@@ -110,20 +111,6 @@ protected:
     void addDiagSessionListener_local(IDiagSessionChangedListener&);
     void removeDiagSessionListener_local(IDiagSessionChangedListener&);
     void expired_local();
-
-    static uint16_t const RESET_TIME                      = 1000U; // ms
-    /**
-     * This is an extended timeout which is used when the programming
-     * session in bootloader is entered. This is due to the fact that
-     * a tester that is connected via ethernet may need more time
-     * to reconnect (e.g. slow DHCP server)
-     *
-     * 60s no longer needed, changed to required 10s
-     */
-    static uint32_t const TESTER_PRESENT_EXTENDED_TIMEOUT = 10000U; // ms
-    static uint16_t const DEFAULT_DIAG_RESPONSE_TIME      = 50U;    // ms
-    static uint16_t const DEFAULT_DIAG_RESPONSE_PENDING   = 500U;   // 10ms
-    static uint16_t const EXTENDED_DIAG_RESPONSE_PENDING  = 3000U;  // 10ms
 
     DiagReturnCode::Type process(
         IncomingDiagConnection& connection,

--- a/libs/bsw/uds/src/uds/services/ecureset/EnableRapidPowerShutdown.cpp
+++ b/libs/bsw/uds/src/uds/services/ecureset/EnableRapidPowerShutdown.cpp
@@ -1,7 +1,9 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #include "uds/services/ecureset/EnableRapidPowerShutdown.h"
 
+#include "uds/UdsConfig.h"
 #include "uds/connection/IncomingDiagConnection.h"
 #include "uds/session/ApplicationDefaultSession.h"
 #include "uds/session/ApplicationExtendedSession.h"
@@ -28,7 +30,7 @@ DiagReturnCode::Type EnableRapidPowerShutdown::process(
     uint16_t const /* requestLength */)
 {
     PositiveResponse& response = connection.releaseRequestGetResponse();
-    (void)response.appendUint8(ShutDownTime);
+    (void)response.appendUint8(UdsConstants::SHUTDOWN_TIME);
     (void)connection.sendPositiveResponseInternal(response.getLength(), *this);
     return DiagReturnCode::OK;
 }
@@ -37,7 +39,7 @@ void EnableRapidPowerShutdown::responseSent(
     IncomingDiagConnection& connection, ResponseSendResult /* result */)
 {
     connection.terminate();
-    uint8_t localShutdowntime = ShutDownTime;
+    uint8_t localShutdowntime = UdsConstants::SHUTDOWN_TIME;
     (void)fUdsLifecycleConnector.requestPowerdown(true, localShutdowntime);
 }
 } // namespace uds

--- a/libs/bsw/uds/src/uds/services/ecureset/HardReset.cpp
+++ b/libs/bsw/uds/src/uds/services/ecureset/HardReset.cpp
@@ -1,8 +1,10 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #include "uds/services/ecureset/HardReset.h"
 
 #include "uds/DiagDispatcher.h"
+#include "uds/UdsConfig.h"
 #include "uds/connection/IncomingDiagConnection.h"
 #include "uds/session/DiagSession.h"
 #include "uds/session/IDiagSessionManager.h"
@@ -40,7 +42,8 @@ void HardReset::responseSent(
     IncomingDiagConnection& connection, ResponseSendResult const /* result */)
 {
     connection.terminate();
-    if (!fUdsLifecycleConnector.requestShutdown(IUdsLifecycleConnector::HARD_RESET, RESET_TIME))
+    if (!fUdsLifecycleConnector.requestShutdown(
+            IUdsLifecycleConnector::HARD_RESET, UdsConstants::RESET_TIME_HARD))
     {
         fDiagDispatcher.fEnabled = true;
     }

--- a/libs/bsw/uds/src/uds/services/ecureset/SoftReset.cpp
+++ b/libs/bsw/uds/src/uds/services/ecureset/SoftReset.cpp
@@ -1,8 +1,10 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #include "uds/services/ecureset/SoftReset.h"
 
 #include "uds/DiagDispatcher.h"
+#include "uds/UdsConfig.h"
 #include "uds/connection/IncomingDiagConnection.h"
 #include "uds/session/ApplicationDefaultSession.h"
 #include "uds/session/ApplicationExtendedSession.h"
@@ -44,7 +46,8 @@ void SoftReset::responseSent(
     IncomingDiagConnection& connection, ResponseSendResult const /* result */)
 {
     connection.terminate();
-    if (!fUdsLifecycleConnector.requestShutdown(IUdsLifecycleConnector::SOFT_RESET, RESET_TIME))
+    if (!fUdsLifecycleConnector.requestShutdown(
+            IUdsLifecycleConnector::SOFT_RESET, UdsConstants::RESET_TIME_SOFT))
     {
         fDiagDispatcher.fEnabled = true;
     }

--- a/libs/bsw/uds/src/uds/services/sessioncontrol/DiagnosticSessionControl.cpp
+++ b/libs/bsw/uds/src/uds/services/sessioncontrol/DiagnosticSessionControl.cpp
@@ -1,4 +1,5 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #include "uds/services/sessioncontrol/DiagnosticSessionControl.h"
 
@@ -126,14 +127,14 @@ DiagReturnCode::Type DiagnosticSessionControl::process(
 
     if (requestedSession == DiagSession::PROGRAMMING)
     {
-        (void)response.appendUint16(DEFAULT_DIAG_RESPONSE_TIME);
-        (void)response.appendUint16(EXTENDED_DIAG_RESPONSE_PENDING);
+        (void)response.appendUint16(UdsConstants::PROGRAMMING_DIAG_RESPONSE_TIME);
+        (void)response.appendUint16(UdsConstants::PROGRAMMING_DIAG_RESPONSE_PENDING);
         Logger::debug(UDS, "EXTENDED TIMEOUTS");
     }
     else
     {
-        (void)response.appendUint16(DEFAULT_DIAG_RESPONSE_TIME);
-        (void)response.appendUint16(DEFAULT_DIAG_RESPONSE_PENDING);
+        (void)response.appendUint16(UdsConstants::DEFAULT_DIAG_RESPONSE_TIME);
+        (void)response.appendUint16(UdsConstants::DEFAULT_DIAG_RESPONSE_PENDING);
         Logger::debug(UDS, "DEFAULT SESSION TIMEOUTS");
     }
 
@@ -352,7 +353,7 @@ void DiagnosticSessionControl::sessionWritten(bool const successful)
     else
     {
         (void)fUdsLifecycleConnector.requestShutdown(
-            IUdsLifecycleConnector::HARD_RESET, RESET_TIME);
+            IUdsLifecycleConnector::HARD_RESET, UdsConstants::RESET_TIME_HARD);
     }
 }
 

--- a/libs/bsw/uds/src/uds/services/sessioncontrol/DiagnosticSessionControl.cpp
+++ b/libs/bsw/uds/src/uds/services/sessioncontrol/DiagnosticSessionControl.cpp
@@ -1,4 +1,5 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #include "uds/services/sessioncontrol/DiagnosticSessionControl.h"
 
@@ -126,14 +127,14 @@ DiagReturnCode::Type DiagnosticSessionControl::process(
 
     if (requestedSession == DiagSession::PROGRAMMING)
     {
-        (void)response.appendUint16(DEFAULT_DIAG_RESPONSE_TIME);
-        (void)response.appendUint16(EXTENDED_DIAG_RESPONSE_PENDING);
-        Logger::debug(UDS, "EXTENDED TIMEOUTS");
+        (void)response.appendUint16(UdsConstants::PROGRAMMING_DIAG_RESPONSE_TIME);
+        (void)response.appendUint16(UdsConstants::PROGRAMMING_DIAG_RESPONSE_PENDING);
+        Logger::debug(UDS, "PROGRAMMING TIMEOUTS");
     }
     else
     {
-        (void)response.appendUint16(DEFAULT_DIAG_RESPONSE_TIME);
-        (void)response.appendUint16(DEFAULT_DIAG_RESPONSE_PENDING);
+        (void)response.appendUint16(UdsConstants::DEFAULT_DIAG_RESPONSE_TIME);
+        (void)response.appendUint16(UdsConstants::DEFAULT_DIAG_RESPONSE_PENDING);
         Logger::debug(UDS, "DEFAULT SESSION TIMEOUTS");
     }
 
@@ -352,7 +353,7 @@ void DiagnosticSessionControl::sessionWritten(bool const successful)
     else
     {
         (void)fUdsLifecycleConnector.requestShutdown(
-            IUdsLifecycleConnector::HARD_RESET, RESET_TIME);
+            IUdsLifecycleConnector::HARD_RESET, UdsConstants::RESET_TIME_HARD);
     }
 }
 

--- a/libs/bsw/uds/test/mock/include/uds/UdsConfig.h
+++ b/libs/bsw/uds/test/mock/include/uds/UdsConfig.h
@@ -22,4 +22,36 @@ public:
 
     static uint16_t const BUSY_MESSAGE_EXTRA_BYTES = 7U;
 };
+
+class UdsConstants
+{
+public:
+    /**
+     * This is an extended timeout which is used when the programming
+     * session in bootloader is entered. This is due to the fact that
+     * a tester that is connected via ethernet may need more time
+     * to reconnect (e.g. slow DHCP server)
+     *
+     * 60s no longer needed, changed to required 10s
+     */
+    static uint32_t const TESTER_PRESENT_EXTENDED_TIMEOUT = 10000U; // ms
+
+    /* Session Timeouts P2* and P2*/
+    /* Default */
+    static uint16_t const DEFAULT_DIAG_RESPONSE_TIME        = 50U;  // ms
+    static uint16_t const DEFAULT_DIAG_RESPONSE_PENDING     = 500U; // 10ms
+    /* Programming session */
+    static uint16_t const PROGRAMMING_DIAG_RESPONSE_TIME    = 50U;   // ms
+    static uint16_t const PROGRAMMING_DIAG_RESPONSE_PENDING = 5000U; // 10ms
+
+    /* Reset times */
+    /* ECUReset: HardReset -> 10 01 */
+    static uint16_t const RESET_TIME_HARD = 1000U; // ms
+    /* ECUReset: SoftReset -> 10 03 */
+    static uint16_t const RESET_TIME_SOFT = 1000U; // ms
+    /* ECUReset: EnableRapidPowerShutdown -> 10 04 */
+    static uint8_t const SHUTDOWN_TIME    = 10U; // ms
+    /* DSC Reset */
+    static uint16_t const RESET_TIME_DSC  = 1000U; // ms
+};
 } // namespace uds

--- a/libs/bsw/uds/test/mock/include/uds/UdsConfig.h
+++ b/libs/bsw/uds/test/mock/include/uds/UdsConfig.h
@@ -1,25 +1,55 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #pragma once
-
 #include "platform/estdint.h"
 
 namespace uds
 {
-class UdsVmsConstants
+namespace UdsVmsConstants
 {
-public:
-    static uint16_t const MAX_BLOCK_LENGTH = 4090U;
+static constexpr uint16_t MAX_BLOCK_LENGTH             = 4090U;
+static constexpr uint16_t ERASE_MEMORY_TIME            = 120U;
+static constexpr uint16_t CHECK_MEMORY_TIME            = 15U;
+static constexpr uint16_t BOOTLOADER_INSTALLATION_TIME = 40U;
+static constexpr uint16_t AUTHENTICATION_TIME          = 5U;
+static constexpr uint16_t RESET_TIME                   = 10U;
+static constexpr uint16_t TRANSFER_DATA_TIME           = 60U;
 
-    static uint16_t const ERASE_MEMORY_TIME            = 120U;
-    static uint16_t const CHECK_MEMORY_TIME            = 15U;
-    static uint16_t const BOOTLOADER_INSTALLATION_TIME = 40U;
-    static uint16_t const AUTHENTICATION_TIME          = 5U;
-    static uint16_t const RESET_TIME                   = 10U;
-    static uint16_t const TRANSFER_DATA_TIME           = 10U;
+static constexpr uint32_t TESTER_PRESENT_TIMEOUT_MS = 5000U;
 
-    static uint32_t const TESTER_PRESENT_TIMEOUT_MS = 5000U;
+static constexpr uint8_t BUSY_MESSAGE_EXTRA_BYTES = 7U;
+} /* namespace UdsVmsConstants */
 
-    static uint16_t const BUSY_MESSAGE_EXTRA_BYTES = 7U;
-};
-} // namespace uds
+namespace UdsConstants
+{
+/**
+ * This is an extended timeout which is used when the programming
+ * session in bootloader is entered. This is due to the fact that
+ * a tester that is connected via ethernet may need more time
+ * to reconnect (e.g. slow DHCP server)
+ *
+ * 60s no longer needed, changed to required 10s
+ */
+static constexpr uint32_t TESTER_PRESENT_EXTENDED_TIMEOUT = 10000U; // ms
+
+/* Session Timeouts P2* and P2*/
+/* Default */
+static constexpr uint16_t DEFAULT_DIAG_RESPONSE_TIME        = 50U;  // ms
+static constexpr uint16_t DEFAULT_DIAG_RESPONSE_PENDING     = 500U; // 10ms
+/* Programming session */
+static constexpr uint16_t PROGRAMMING_DIAG_RESPONSE_TIME    = 50U;   // ms
+static constexpr uint16_t PROGRAMMING_DIAG_RESPONSE_PENDING = 5000U; // 10ms
+
+/* Reset times */
+/* ECUReset: HardReset -> 11 01 */
+static constexpr uint16_t RESET_TIME_HARD = 1000U; // ms
+/* ECUReset: SoftReset -> 11 03 */
+static constexpr uint16_t RESET_TIME_SOFT = 1000U; // ms
+/* ECUReset: EnableRapidPowerShutdown -> 11 04 */
+static constexpr uint8_t SHUTDOWN_TIME    = 10U; // ms
+/* DSC Reset */
+static constexpr uint16_t RESET_TIME_DSC  = 1000U; // ms
+} /* namespace UdsConstants */
+
+} /* namespace uds */

--- a/libs/bsw/uds/test/src/uds/services/sessioncontrol/DiagnosticSessionControlTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/sessioncontrol/DiagnosticSessionControlTest.cpp
@@ -1,4 +1,5 @@
 // Copyright 2024 Accenture.
+// Copyright 2026 BMW AG
 
 #include "uds/services/sessioncontrol/DiagnosticSessionControl.h"
 
@@ -72,8 +73,6 @@ public:
 
     /* do not implement that */
     bool persistAndRestoreSession() override { return false; }
-
-    using DiagnosticSessionControl::RESET_TIME;
 };
 
 struct DiagnosticSessionControlTest : ::testing::Test
@@ -632,7 +631,7 @@ TEST_F(
 {
     EXPECT_CALL(
         fUdsLifecycleConnector,
-        requestShutdown(IUdsLifecycleConnector::HARD_RESET, fDiagnosticSessionControl.RESET_TIME))
+        requestShutdown(IUdsLifecycleConnector::HARD_RESET, UdsConstants::RESET_TIME_HARD))
         .WillOnce(Return(true));
     fDiagnosticSessionControl.sessionWritten(true);
 }


### PR DESCRIPTION
Static configuration in module uds that is project specific should be moved to a configuration file that is placed outside the static code in directory bsw. Preferred file is UdsConfig.h.