### PR TITLE
Fix posix stdin read error handling

### DIFF
--- a/platforms/posix/bsp/bspStdio/src/bsp/stdIo/stdIo.cpp
+++ b/platforms/posix/bsp/bspStdio/src/bsp/stdIo/stdIo.cpp
@@ -23,8 +23,8 @@ extern "C" int32_t getByteFromStdin()
     static Uart& uart = Uart::getInstance(Uart::Id::TERMINAL);
     uint8_t data_byte = 0;
     etl::span<uint8_t> data(&data_byte, 1U);
-    uart.read(data);
-    if (data.size() == 0)
+    size_t const bytes_read = uart.read(data);
+    if (bytes_read == 0)
     {
         return -1;
     }

--- a/platforms/posix/bsp/bspUart/src/bsp/Uart.cpp
+++ b/platforms/posix/bsp/bspUart/src/bsp/Uart.cpp
@@ -29,12 +29,15 @@ size_t Uart::write(::etl::span<uint8_t const> const data)
 
 size_t Uart::read(::etl::span<uint8_t> data)
 {
-    size_t bytes_read = 0;
     if (_initialized)
     {
-        bytes_read = ::read(_std_in_fd, data.data(), data.size());
+        ssize_t const result = ::read(_std_in_fd, data.data(), data.size());
+        if (result > 0)
+        {
+            return static_cast<size_t>(result);
+        }
     }
-    return bytes_read;
+    return 0U;
 }
 
 void Uart::init()


### PR DESCRIPTION
getByteFromStdin never returns -1 because it checks the size of the span passed by value instead of the return value of the uart read.
Use ssize_t for the ::read() result in Uart::read to avoid silent conversion of -1 to a large size_t.