### PR TITLE
Add rustfmt to treefmt config

### DIFF
--- a/.treefmt.toml
+++ b/.treefmt.toml
@@ -43,3 +43,7 @@ includes = [ "*.c", "*.cc", "*.cpp", "*.h", "*.hh", "*.hpp" ]
 command = "cmake-format"
 options = [ "-i" ]
 includes = [ "**/CMakeLists.txt", "*.cmake", "CMakeLists.txt" ]
+
+[formatter.rust]
+command = "tools/rustfmt-wrapper"
+includes = [ "*.rs" ]

--- a/tools/rustfmt-wrapper
+++ b/tools/rustfmt-wrapper
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from shutil import which
+import subprocess
+import sys
+
+
+def main():
+    if which("rustfmt") is None:
+        # rustfmt not installed, silently skip formatting
+        sys.exit(0)
+
+    completed = subprocess.run(["rustfmt"] + sys.argv[1:])
+    sys.exit(completed.returncode)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add rustfmt to treefmt config

This adds a wrapper script for rustfmt so treefmt skips rustfmt silently
when the rustfmt executable is not found (similarly to passing
`--allow-missing-formatter` to treefmt).
