### PR TITLE
Add /target/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ bazel-bin
 bazel-openbsw
 bazel-out
 bazel-testlogs
+/target/


### PR DESCRIPTION
Add /target/ to .gitignore

For any rust crate that is part of the workspace the `target/` directory
at the workspace root is used. Ignore this in .gitignore.
