### PR TITLE
Fix logger to work for extended canId

### DIFF
--- a/platforms/posix/bsp/socketCanTransceiver/src/can/SocketCanTransceiver.cpp
+++ b/platforms/posix/bsp/socketCanTransceiver/src/can/SocketCanTransceiver.cpp
@@ -284,7 +284,7 @@ void SocketCanTransceiver::guardedRun(int maxSentPerRun, int maxReceivedPerRun)
             Logger::debug(
                 CAN,
                 "[SocketCanTransceiver] received CAN frame, id=0x%X, length=%d",
-                static_cast<int>(socketCanFrame.can_id),
+                static_cast<int>(::can::CanId::rawId(socketCanFrame.can_id)),
                 static_cast<int>(socketCanFrame.can_dlc));
             CANFrame canFrame;
             canFrame.setId(socketCanFrame.can_id);


### PR DESCRIPTION
Fix logger to work for extended canId
