### PR TITLE
Fix copyright config: add missing extensions and use current year

### DIFF
--- a/.treefmt.toml
+++ b/.treefmt.toml
@@ -78,4 +78,7 @@ includes = [
   "*.py", "*.sh",
   "*.toml", "*.yml", "*.yaml", "*.ini",
   "*.rst", "*.md", "*.puml",
+  "*.bzl", "*.bazel", "BUILD", "BUILD.bazel", "MODULE.bazel", "WORKSPACE", "WORKSPACE.bazel",
+  "*.rs",
+  "*.trlc", "*.rsl",
 ]

--- a/tools/cr_checker/cr_checker.py
+++ b/tools/cr_checker/cr_checker.py
@@ -749,7 +749,7 @@ def process_files(
                     item, encoding, effective_offset
                 )
                 if not ext_year:
-                    ext_year = "2024"
+                    ext_year = str(datetime.now().year)
                 if not ext_author:
                     ext_author = get_author_from_config(config)
                 actual_remove = remove_offset if remove_offset else old_header_len

--- a/tools/cr_checker/exclusions.txt
+++ b/tools/cr_checker/exclusions.txt
@@ -1,5 +1,7 @@
 cmake/modules/CodeCoverage.cmake
 tools/cr_checker/templates.ini
-.github/ISSUE_TEMPLATE/
+NOTICE.md
+.github/ISSUE_TEMPLATE/bug_report.md
+.github/ISSUE_TEMPLATE/feature_request.md
 3rdparty/
 build/


### PR DESCRIPTION
**Title:** 
Fix copyright checker: add missing file extensions and use current year

**Description:**
Follow-up bugfix for #464 (Add Copyright headers to all source and documentation files).

**Issues fixed:**
- .treefmt.toml was missing Bazel (*.bzl, BUILD, BUILD.bazel, MODULE.bazel, WORKSPACE, WORKSPACE.bazel, *.bazel), Rust (*.rs), and requirements (*.trlc, *.rsl) extensions in the [formatter.copyright] section. This caused treefmt to skip these files, so copyright headers were not checked or added. (Reported in #475)
- Default year was hardcoded to 2024 when adding headers to new files. Now uses the current year automatically.
- Fixed non-functional directory exclusion (.github/ISSUE_TEMPLATE/) by replacing it with explicit file exclusions.
