### PR TITLE
Add UDS Service ReadDTCInformation (0x19)

### DIFF
--- a/executables/referenceApp/application/include/systems/UdsSystem.h
+++ b/executables/referenceApp/application/include/systems/UdsSystem.h
@@ -24,6 +24,7 @@
 #include <uds/jobs/WriteIdentifierToMemory.h>
 #include <uds/services/communicationcontrol/CommunicationControl.h>
 #include <uds/services/readdata/ReadDataByIdentifier.h>
+#include <uds/services/readdtcinformation/ReadDTCInformation.h>
 #include <uds/services/routinecontrol/RequestRoutineResults.h>
 #include <uds/services/routinecontrol/RoutineControl.h>
 #include <uds/services/routinecontrol/StartRoutine.h>
@@ -102,6 +103,7 @@ private:
     ReadIdentifierPot _read22Cf02;
     WriteIdentifierToMemory _write2eCf03;
     TesterPresent _testerPresent;
+    ReadDTCInformation _readDTCInformation;
 
     ::async::ContextType _context;
     ::async::TimeoutType _timeout;

--- a/executables/referenceApp/application/src/systems/UdsSystem.cpp
+++ b/executables/referenceApp/application/src/systems/UdsSystem.cpp
@@ -133,6 +133,7 @@ void UdsSystem::addDiagJobs()
     (void)_jobRoot.addAbstractDiagJob(_testerPresent);
     (void)_jobRoot.addAbstractDiagJob(_diagnosticSessionControl);
     (void)_jobRoot.addAbstractDiagJob(_communicationControl);
+    (void)_jobRoot.addAbstractDiagJob(_readDTCInformation);
 }
 
 void UdsSystem::removeDiagJobs()
@@ -156,6 +157,7 @@ void UdsSystem::removeDiagJobs()
     _jobRoot.removeAbstractDiagJob(_testerPresent);
     _jobRoot.removeAbstractDiagJob(_diagnosticSessionControl);
     _jobRoot.removeAbstractDiagJob(_communicationControl);
+    _jobRoot.removeAbstractDiagJob(_readDTCInformation);
 }
 
 void UdsSystem::execute() {}

--- a/libs/bsw/uds/CMakeLists.txt
+++ b/libs/bsw/uds/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
     src/uds/resume/ResumableResetDriver.cpp
     src/uds/services/controldtcsetting/ControlDTCSetting.cpp
     src/uds/services/communicationcontrol/CommunicationControl.cpp
+    src/uds/services/readdtcinformation/ReadDTCInformation.cpp
     src/uds/services/ecureset/ECUReset.cpp
     src/uds/services/ecureset/EnableRapidPowerShutdown.cpp
     src/uds/services/ecureset/HardReset.cpp

--- a/libs/bsw/uds/include/uds/services/readdtcinformation/ReadDTCInformation.h
+++ b/libs/bsw/uds/include/uds/services/readdtcinformation/ReadDTCInformation.h
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (c) 2026 BMW AG
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#pragma once
+
+#include "uds/base/Service.h"
+
+namespace uds
+{
+class IncomingDiagConnection;
+
+/**
+ * UDS service ReadDTCInformation (0x19).
+ *
+ */
+class ReadDTCInformation : public Service
+{
+public:
+    enum SubFunction
+    {
+        REPORT_DTC_BY_STATUS_MASK                     = 0x02,
+        REPORT_DTC_SNAPSHOT_RECORD_BY_DTC_NUMBER      = 0x04,
+        REPORT_DTC_EXTENDED_DATA_RECORD_BY_DTC_NUMBER = 0x06,
+        REPORT_SUPPORTED_DTCS                         = 0x0A
+    };
+
+    explicit ReadDTCInformation();
+
+private:
+    DiagReturnCode::Type verify(uint8_t const request[], uint16_t requestLength) override;
+
+    DiagReturnCode::Type process(
+        IncomingDiagConnection& connection,
+        uint8_t const request[],
+        uint16_t requestLength) override;
+};
+
+} // namespace uds

--- a/libs/bsw/uds/src/uds/services/readdtcinformation/ReadDTCInformation.cpp
+++ b/libs/bsw/uds/src/uds/services/readdtcinformation/ReadDTCInformation.cpp
@@ -1,0 +1,69 @@
+/********************************************************************************
+ * Copyright (c) 2026 BMW AG
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "uds/services/readdtcinformation/ReadDTCInformation.h"
+
+#include "uds/connection/IncomingDiagConnection.h"
+#include "uds/session/DiagSession.h"
+
+namespace uds
+{
+ReadDTCInformation::ReadDTCInformation()
+: Service(ServiceId::READ_DTC_INFORMATION, DiagSession::ALL_SESSIONS())
+{
+    setDefaultDiagReturnCode(DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED);
+}
+
+DiagReturnCode::Type
+ReadDTCInformation::verify(uint8_t const* const request, uint16_t const requestLength)
+{
+    return Service::verify(request, requestLength);
+}
+
+DiagReturnCode::Type ReadDTCInformation::process(
+    IncomingDiagConnection& connection, uint8_t const* const request, uint16_t const requestLength)
+{
+    uint8_t const subFunction = request[0];
+    switch (subFunction)
+    {
+        case REPORT_DTC_BY_STATUS_MASK:
+        {
+            if (requestLength < 2U)
+            {
+                return DiagReturnCode::ISO_INVALID_FORMAT;
+            }
+            uint8_t const dtcData[] = {
+                0xFFU, // DTCStatusAvailabilityMask
+                0x12U,
+                0x34U,
+                0x56U,
+                0x09U // DTC 0x123456, status 0x09
+            };
+            PositiveResponse& response = connection.releaseRequestGetResponse();
+            (void)response.appendUint8(subFunction);
+            (void)response.appendData(dtcData, sizeof(dtcData));
+            (void)connection.sendPositiveResponseInternal(response.getLength(), *this);
+            return DiagReturnCode::OK;
+        }
+        // NOLINTNEXTLINE(bugprone-branch-clone): Remove suppression when cases are implemented.
+        case REPORT_DTC_SNAPSHOT_RECORD_BY_DTC_NUMBER:
+        case REPORT_DTC_EXTENDED_DATA_RECORD_BY_DTC_NUMBER:
+        case REPORT_SUPPORTED_DTCS:
+        {
+            return DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED;
+        }
+        default:
+        {
+            return DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED;
+        }
+    }
+}
+
+} // namespace uds

--- a/libs/bsw/uds/test/CMakeLists.txt
+++ b/libs/bsw/uds/test/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
     src/uds/jobs/WritedentifierToMemoryJobTest.cpp
     src/uds/resume/ResumableResetDriverTest.cpp
     src/uds/services/controldtcsetting/ControlDTCSettingTest.cpp
+    src/uds/services/readdtcinformation/ReadDTCInformationTest.cpp
     src/uds/services/readdata/MultipleReadDataByIdentifierTest.cpp
     src/uds/services/readdata/ReadDataByIdentifierTest.cpp
     src/uds/services/routinecontrol/RequestRoutineResultsTest.cpp

--- a/libs/bsw/uds/test/src/uds/services/readdtcinformation/ReadDTCInformationTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/readdtcinformation/ReadDTCInformationTest.cpp
@@ -1,0 +1,185 @@
+/********************************************************************************
+ * Copyright (c) 2026 BMW AG
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "uds/services/readdtcinformation/ReadDTCInformation.h"
+
+#include "uds/connection/IncomingDiagConnectionMock.h"
+#include "uds/session/ApplicationDefaultSession.h"
+#include "uds/session/DiagSessionManagerMock.h"
+
+#include <transport/TransportMessageWithBuffer.h>
+
+#include <gmock/gmock.h>
+
+namespace
+{
+using namespace ::uds;
+using namespace ::testing;
+using namespace ::transport::test;
+
+class ReadDTCInformationTest : public ::testing::Test
+{
+public:
+    ReadDTCInformationTest()
+    : fReadDTCInformation(), fIncomingDiagConnection(::async::CONTEXT_INVALID), fSessionManager()
+    {}
+
+    virtual void SetUp() { fReadDTCInformation.setDefaultDiagSessionManager(fSessionManager); }
+
+protected:
+    ReadDTCInformation fReadDTCInformation;
+    StrictMock<IncomingDiagConnectionMock> fIncomingDiagConnection;
+    StrictMock<DiagSessionManagerMock> fSessionManager;
+};
+
+TEST_F(ReadDTCInformationTest, execute_with_subfunction_0x02_and_valid_status_mask_should_return_OK)
+{
+    uint8_t request[] = {
+        0x19U, // ReadDTCInformation SID
+        0x02U, // reportDTCByStatusMask
+        0xFFU  // DTCStatusMask
+    };
+
+    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+
+    fIncomingDiagConnection.requestMessage = pRequest.get();
+
+    EXPECT_CALL(fSessionManager, getActiveSession())
+        .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
+
+    EXPECT_CALL(fSessionManager, acceptedJob(_, _, _, _))
+        .WillRepeatedly(Return(uds::DiagReturnCode::OK));
+
+    EXPECT_EQ(
+        DiagReturnCode::OK,
+        fReadDTCInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+}
+
+TEST_F(
+    ReadDTCInformationTest,
+    execute_with_subfunction_0x02_without_status_mask_should_return_ISO_INVALID_FORMAT)
+{
+    uint8_t request[] = {
+        0x19U, // ReadDTCInformation SID
+        0x02U  // reportDTCByStatusMask (no DTCStatusMask)
+    };
+
+    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+
+    fIncomingDiagConnection.requestMessage = pRequest.get();
+
+    EXPECT_CALL(fSessionManager, getActiveSession())
+        .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
+
+    EXPECT_CALL(fSessionManager, acceptedJob(_, _, _, _))
+        .WillRepeatedly(Return(uds::DiagReturnCode::OK));
+
+    EXPECT_EQ(
+        DiagReturnCode::ISO_INVALID_FORMAT,
+        fReadDTCInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+}
+
+TEST_F(
+    ReadDTCInformationTest,
+    execute_with_subfunction_0x04_should_return_ISO_SUBFUNCTION_NOT_SUPPORTED)
+{
+    uint8_t request[]
+        = {0x19U, // ReadDTCInformation SID
+           0x04U, // reportDTCSnapshotRecordByDTCNumber
+           0xFFU};
+
+    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+
+    fIncomingDiagConnection.requestMessage = pRequest.get();
+
+    EXPECT_CALL(fSessionManager, getActiveSession())
+        .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
+
+    EXPECT_CALL(fSessionManager, acceptedJob(_, _, _, _))
+        .WillRepeatedly(Return(uds::DiagReturnCode::OK));
+
+    EXPECT_EQ(
+        DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED,
+        fReadDTCInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+}
+
+TEST_F(
+    ReadDTCInformationTest,
+    execute_with_subfunction_0x06_should_return_ISO_SUBFUNCTION_NOT_SUPPORTED)
+{
+    uint8_t request[]
+        = {0x19U, // ReadDTCInformation SID
+           0x06U, // reportDTCExtendedDataRecordByDTCNumber
+           0xFFU};
+
+    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+
+    fIncomingDiagConnection.requestMessage = pRequest.get();
+
+    EXPECT_CALL(fSessionManager, getActiveSession())
+        .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
+
+    EXPECT_CALL(fSessionManager, acceptedJob(_, _, _, _))
+        .WillRepeatedly(Return(uds::DiagReturnCode::OK));
+
+    EXPECT_EQ(
+        DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED,
+        fReadDTCInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+}
+
+TEST_F(
+    ReadDTCInformationTest,
+    execute_with_subfunction_0x0A_should_return_ISO_SUBFUNCTION_NOT_SUPPORTED)
+{
+    uint8_t request[]
+        = {0x19U, // ReadDTCInformation SID
+           0x0AU, // reportSupportedDTCs
+           0xFFU};
+
+    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+
+    fIncomingDiagConnection.requestMessage = pRequest.get();
+
+    EXPECT_CALL(fSessionManager, getActiveSession())
+        .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
+
+    EXPECT_CALL(fSessionManager, acceptedJob(_, _, _, _))
+        .WillRepeatedly(Return(uds::DiagReturnCode::OK));
+
+    EXPECT_EQ(
+        DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED,
+        fReadDTCInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+}
+
+TEST_F(
+    ReadDTCInformationTest,
+    execute_with_unsupported_subfunction_should_return_ISO_SUBFUNCTION_NOT_SUPPORTED)
+{
+    uint8_t request[]
+        = {0x19U, // ReadDTCInformation SID
+           0x00U, // unsupported subfunction
+           0xFFU};
+
+    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+
+    fIncomingDiagConnection.requestMessage = pRequest.get();
+
+    EXPECT_CALL(fSessionManager, getActiveSession())
+        .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
+
+    EXPECT_CALL(fSessionManager, acceptedJob(_, _, _, _))
+        .WillRepeatedly(Return(uds::DiagReturnCode::OK));
+
+    EXPECT_EQ(
+        DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED,
+        fReadDTCInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+}
+
+} // anonymous namespace


### PR DESCRIPTION
Add UDS service 0x19 (ReadDTCInformation) with example sub-function handling (The actual implementation of the sub-functions differs across projects, so they need to be handled separately by each project’s DEM team.):
- 0x02 reportDTCByStatusMask: returns demo DTC 0x123456 with status 0x09
- 0x04, 0x06, 0x0A: recognized but return NRC 0x12 (subfunctionNotSupported)
- Unit tests covering all sub-function cases
- Registered in referenceApp UdsSystem