### PR TITLE
Migrate FreeRTOS [1/2]: core, ports and BSP/MCU

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,7 +2,7 @@ build:s32k148_gcc --platforms=//bazel/platform:s32k148
 # Default to gcc
 build:s32k148 --config=s32k148_gcc
 
-# TODO: Temporary config only needed for artifact analysis 
+# TODO: Temporary config only needed for artifact analysis
 # Make Bazel's build match CMake s32k148-freertos-gcc default config
 build:s32k148_relwithdebinfo --config=s32k148
 build:s32k148_relwithdebinfo --copt=-g3

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright (c) 2024 Accenture
+# Copyright (c) 2026 Accenture
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License Version 2.0 which is available at

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright (c) 2024 Accenture
+# Copyright (c) 2026 Accenture
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License Version 2.0 which is available at

--- a/bazel/config/rtos/BUILD.bazel
+++ b/bazel/config/rtos/BUILD.bazel
@@ -9,35 +9,33 @@
 # *******************************************************************************
 
 """
-Build configuration flag for selecting between application build variants.
-This allows targets to define variable dependencies/headers/sources based on the
-active build variant (reference_app or unit_test).
+RTOS related configuration parameters
 
-- Set via --//bazel/config/executable_config=<value>
-- Defaults to "reference_app"
-- Overridden to "unit_test" for bazel test commands in .bazelrc
+The rtos string flag controls which RTOS implementation is compiled into the build
+- Set it via --//bazel/config/rtos=<value>
+- Defaults to "freertos"
 """
 
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 string_flag(
-    name = "executable_config",
-    build_setting_default = "reference_app",
+    name = "rtos",
+    build_setting_default = "freertos",
     values = [
-        "reference_app",
-        "unit_test",
+        "freertos",
+        "threadx",
     ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
-    name = "reference_app",
-    flag_values = {":executable_config": "reference_app"},
+    name = "support_freertos",
+    flag_values = {":rtos": "freertos"},
     visibility = ["//visibility:public"],
 )
 
 config_setting(
-    name = "unit_test",
-    flag_values = {":executable_config": "unit_test"},
+    name = "support_threadx",
+    flag_values = {":rtos": "threadx"},
     visibility = ["//visibility:public"],
 )

--- a/bazel/platform/BUILD.bazel
+++ b/bazel/platform/BUILD.bazel
@@ -13,6 +13,6 @@ platform(
     constraint_values = [
         "@platforms//cpu:armv7e-m",
         "@platforms//os:none",
-        "//bazel/platform/constraints:s32k148",
+        "//bazel/platform/constraints/soc:s32k148",
     ],
 )

--- a/bazel/platform/constraints/BUILD.bazel
+++ b/bazel/platform/constraints/BUILD.bazel
@@ -8,11 +8,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-platform(
+constraint_setting(
+    name = "target_platform_constraint",
+    visibility = ["//visibility:public"],
+)
+
+constraint_value(
     name = "s32k148",
-    constraint_values = [
-        "@platforms//cpu:armv7e-m",
-        "@platforms//os:none",
-        "//bazel/platform/constraints:s32k148",
-    ],
+    constraint_setting = ":target_platform_constraint",
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "is_s32k148",
+    constraint_values = [":s32k148"],
+    visibility = ["//visibility:public"],
 )

--- a/bazel/platform/constraints/soc/BUILD.bazel
+++ b/bazel/platform/constraints/soc/BUILD.bazel
@@ -9,13 +9,13 @@
 # *******************************************************************************
 
 constraint_setting(
-    name = "target_platform_constraint",
+    name = "soc",
     visibility = ["//visibility:public"],
 )
 
 constraint_value(
     name = "s32k148",
-    constraint_setting = ":target_platform_constraint",
+    constraint_setting = ":soc",
     visibility = ["//visibility:public"],
 )
 

--- a/bazel/toolchain/BUILD.bazel
+++ b/bazel/toolchain/BUILD.bazel
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright (c) 2024 Accenture
+# Copyright (c) 2026 Accenture
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License Version 2.0 which is available at

--- a/bazel/toolchain/arm_none_eabi/gcc/arm_none_eabi_gcc_cc_toolchain_config.bzl
+++ b/bazel/toolchain/arm_none_eabi/gcc/arm_none_eabi_gcc_cc_toolchain_config.bzl
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright (c) 2024 Accenture
+# Copyright (c) 2026 Accenture
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License Version 2.0 which is available at

--- a/bazel_migration/README.md
+++ b/bazel_migration/README.md
@@ -1,6 +1,6 @@
 <!--
  *******************************************************************************
-  Copyright (c) 2024 Accenture
+  Copyright (c) 2026 Accenture
 
   This program and the accompanying materials are made available under the
   terms of the Apache License Version 2.0 which is available at
@@ -19,32 +19,41 @@
 - Toolchain reproducibility is provided by the Docker container (pins `arm-none-eabi-gcc` at a fixed version under `/opt/arm-gnu-toolchain`). This does not represent full hermeticity and would break cache correctness in remote cache scenarios.
 - Build output for one example library (`libs/bsw/util`) verified against CMake output.
 - Conditional dependency selection via `label_flag` (`etl_profile`) for build variants (`reference_app` / `unit_test`)
-- No further libraries or executables have been migrated yet.
+- See the file tree below for current migration status.
 
 Open:
 - Bazel readme and integration guide
 - Bazel CI tests
 - Clang toolchain
 - Consider if toolchain should be made fully hermetic
-- Migration of all libs and executables
-- Migration of unit test configs
+- Migration of remaining libs and executables
+- Migration of unit tests and test related configs
 - Toolchain / build artifact verification
 
 ```
 OpenBSW Bazel migration
-├── bazel/ ✅ (toolchain arm-none-eabi-gcc for s32k148)
+├── bazel/ ✅ (toolchain + s32k148 platform/constraints + rtos config)
 ├── cmake/ ⬛
 ├── doc/ ⬛
 ├── docker/ ⬛
 ├── executables/
 │   ├── referenceApp/ 🔲
-│   │   └── configuration ✅
+│   │   ├── asyncCoreConfiguration ✅
+│   │   ├── configuration ✅
+│   │   └── platforms/
+│   │       ├── posix/ ✅ (freeRtosCoreConfiguration, osHooks)
+│   │       └── s32k148evb/ ✅ (freeRtosCoreConfiguration, osHooks)
 │   └── unitTest/ 🔲
 │       └── configuration ✅
 ├── libs/
 │   ├── 3rdparty/
-│   │   └── etl ✅
+│   │   ├── cmsis ✅
+│   │   ├── etl ✅
+│   │   └── freeRtos ✅
+│   ├── bsp/
+│   │   └── bspInterrupts ✅
 │   ├── bsw/
+│   │   ├── asyncFreeRtos 🔲 (freertos_configuration only)
 │   │   ├── asyncImpl ✅
 │   │   ├── io ✅
 │   │   ├── logger ✅
@@ -57,8 +66,8 @@ OpenBSW Bazel migration
 │   │   ├── util ✅
 │   └── (remaining) 🔲
 ├── platforms/
-│   ├── posix/ 🔲
-│   └── s32k1xx/ 🔲
+│   ├── posix/ ✅ (freeRtosPosix, bspInterruptsImpl)
+│   └── s32k1xx/ ✅ (freertos_cm4_sysTick, bspMcu, bspInterruptsImpl)
 ├── test/ Scope of Bazel support TBD
 └── tools/ Scope of Bazel support TBD
 

--- a/executables/referenceApp/asyncCoreConfiguration/BUILD.bazel
+++ b/executables/referenceApp/asyncCoreConfiguration/BUILD.bazel
@@ -8,11 +8,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-platform(
-    name = "s32k148",
-    constraint_values = [
-        "@platforms//cpu:armv7e-m",
-        "@platforms//os:none",
-        "//bazel/platform/constraints:s32k148",
-    ],
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "async_core_configuration",
+    hdrs = ["include/async/Config.h"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
 )

--- a/executables/referenceApp/etl_profile/BUILD.bazel
+++ b/executables/referenceApp/etl_profile/BUILD.bazel
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright (c) 2024 Accenture
+# Copyright (c) 2026 Accenture
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License Version 2.0 which is available at

--- a/executables/referenceApp/platforms/posix/freeRtosCoreConfiguration/BUILD.bazel
+++ b/executables/referenceApp/platforms/posix/freeRtosCoreConfiguration/BUILD.bazel
@@ -8,11 +8,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-platform(
-    name = "s32k148",
-    constraint_values = [
-        "@platforms//cpu:armv7e-m",
-        "@platforms//os:none",
-        "//bazel/platform/constraints:s32k148",
-    ],
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "freertos_core_configuration",
+    hdrs = ["include/os/FreeRtosPlatformConfig.h"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
 )

--- a/executables/referenceApp/platforms/posix/main/BUILD.bazel
+++ b/executables/referenceApp/platforms/posix/main/BUILD.bazel
@@ -8,11 +8,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-platform(
-    name = "s32k148",
-    constraint_values = [
-        "@platforms//cpu:armv7e-m",
-        "@platforms//os:none",
-        "//bazel/platform/constraints:s32k148",
-    ],
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "freertos_os_hooks",
+    srcs = ["src/osHooks/freertos/osHooks.cpp"],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//libs/3rdparty/freeRtos:__pkg__"],
+    deps = ["//libs/3rdparty/freeRtos:free_rtos_headers"],
 )

--- a/executables/referenceApp/platforms/posix/main/BUILD.bazel
+++ b/executables/referenceApp/platforms/posix/main/BUILD.bazel
@@ -15,5 +15,5 @@ cc_library(
     srcs = ["src/osHooks/freertos/osHooks.cpp"],
     target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//libs/3rdparty/freeRtos:__pkg__"],
-    deps = ["//libs/3rdparty/freeRtos:free_rtos_headers"],
+    deps = ["//libs/3rdparty/freeRtos:freertos_headers"],
 )

--- a/executables/referenceApp/platforms/s32k148evb/freeRtosCoreConfiguration/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/freeRtosCoreConfiguration/BUILD.bazel
@@ -8,11 +8,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-platform(
-    name = "s32k148",
-    constraint_values = [
-        "@platforms//cpu:armv7e-m",
-        "@platforms//os:none",
-        "//bazel/platform/constraints:s32k148",
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "freertos_core_configuration",
+    hdrs = ["include/os/FreeRtosPlatformConfig.h"],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/bsw/bsp",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
     ],
 )

--- a/executables/referenceApp/platforms/s32k148evb/freeRtosCoreConfiguration/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/freeRtosCoreConfiguration/BUILD.bazel
@@ -14,7 +14,7 @@ cc_library(
     name = "freertos_core_configuration",
     hdrs = ["include/os/FreeRtosPlatformConfig.h"],
     strip_include_prefix = "include",
-    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
     visibility = ["//visibility:public"],
     deps = [
         "//libs/bsw/bsp",

--- a/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
@@ -8,11 +8,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-platform(
-    name = "s32k148",
-    constraint_values = [
-        "@platforms//cpu:armv7e-m",
-        "@platforms//os:none",
-        "//bazel/platform/constraints:s32k148",
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "freertos_os_hooks",
+    srcs = ["src/osHooks/freertos/osHooks.cpp"],
+    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+    visibility = ["//libs/3rdparty/freeRtos:__pkg__"],
+    deps = [
+        "//libs/3rdparty/freeRtos:free_rtos_headers",
+        "//libs/bsw/common",
     ],
 )

--- a/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
@@ -13,10 +13,10 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 cc_library(
     name = "freertos_os_hooks",
     srcs = ["src/osHooks/freertos/osHooks.cpp"],
-    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
     visibility = ["//libs/3rdparty/freeRtos:__pkg__"],
     deps = [
-        "//libs/3rdparty/freeRtos:free_rtos_headers",
+        "//libs/3rdparty/freeRtos:freertos_headers",
         "//libs/bsw/common",
     ],
 )

--- a/executables/unitTest/etl_profile/BUILD.bazel
+++ b/executables/unitTest/etl_profile/BUILD.bazel
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright (c) 2024 Accenture
+# Copyright (c) 2026 Accenture
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License Version 2.0 which is available at

--- a/libs/3rdparty/cmsis/.riminfo
+++ b/libs/3rdparty/cmsis/.riminfo
@@ -1,4 +1,4 @@
-3ded7009a2d53c0760fb5e79d6f89a98d35cf100
+bcc3a4c5da990c0950ecaa0631b4301a1b2e249e
 
 RIM Info file. You're welcome to read but don't write it.
 Instead, use RIM commands to do the things you want to do.
@@ -7,7 +7,7 @@ BEWARE: Any manual modification will invalidate the file!
 remote_url     : https://github.com/ARM-software/CMSIS_6.git
 revision_sha1  : b0bbb0423b278ca632cfe1474eb227961d835fd2
 target_revision: b0bbb0423b278ca632cfe1474eb227961d835fd2
-ignores        : a-profile,a-profile/*,cmsis_armclang.h,core_ca.h,core_cm0.h,core_cm0plus.h,core_cm1.h,core_cm23.h,core_cm3.h,core_cm33.h,core_cm35p.h,core_cm52.h,core_cm55.h,core_cm7.h,core_cm85.h,core_sc000.h,core_sc300.h,core_starmc1.h,m-profile/armv7m_cachel1.h,m-profile/armv81m_pac.h,m-profile/armv8m_mpu.h,m-profile/armv8m_pmu.h,m-profile/cmsis_armclang_m.h,m-profile/cmsis_iccarm_m.h,m-profile/cmsis_tiarmclang_m.h,r-profile,r-profile/*,tz_context.h,core_cm4.h,LICENSE,module.spec
+ignores        : a-profile,a-profile/*,cmsis_armclang.h,core_ca.h,core_cm0.h,core_cm0plus.h,core_cm1.h,core_cm23.h,core_cm3.h,core_cm33.h,core_cm35p.h,core_cm52.h,core_cm55.h,core_cm7.h,core_cm85.h,core_sc000.h,core_sc300.h,core_starmc1.h,m-profile/armv7m_cachel1.h,m-profile/armv81m_pac.h,m-profile/armv8m_mpu.h,m-profile/armv8m_pmu.h,m-profile/cmsis_armclang_m.h,m-profile/cmsis_iccarm_m.h,m-profile/cmsis_tiarmclang_m.h,r-profile,r-profile/*,tz_context.h,core_cm4.h,LICENSE,module.spec,BUILD.bazel
 checksum       : a87f40792ba0244a9e2214917b5bce0897cd08ad
 subdir         : CMSIS/Core/Include
 

--- a/libs/3rdparty/cmsis/BUILD.bazel
+++ b/libs/3rdparty/cmsis/BUILD.bazel
@@ -26,6 +26,6 @@ cc_library(
         "m-profile/cmsis_gcc_m.h",
     ],
     strip_include_prefix = ".",
-    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
     visibility = ["//visibility:public"],
 )

--- a/libs/3rdparty/cmsis/BUILD.bazel
+++ b/libs/3rdparty/cmsis/BUILD.bazel
@@ -10,9 +10,22 @@
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
+# CMSIS headers
+# Mirrors CMake `bspMcu` PUBLIC include dirs: `libs/3rdparty/cmsis` and
+# `libs/3rdparty/cmsis/m-profile`.
 cc_library(
-    name = "platform",
-    hdrs = glob(["include/**/*.h"]),
-    strip_include_prefix = "include",
+    name = "cmsis",
+    hdrs = [
+        "cmsis_clang.h",
+        "cmsis_compiler.h",
+        "cmsis_gcc.h",
+        "cmsis_version.h",
+        "core_cm4.h",
+        "m-profile/armv7m_mpu.h",
+        "m-profile/cmsis_clang_m.h",
+        "m-profile/cmsis_gcc_m.h",
+    ],
+    strip_include_prefix = ".",
+    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
     visibility = ["//visibility:public"],
 )

--- a/libs/3rdparty/etl/BUILD.bazel
+++ b/libs/3rdparty/etl/BUILD.bazel
@@ -30,6 +30,7 @@ label_flag(
 cc_library(
     name = "etl",
     hdrs = glob(["include/**/*.h"]),
+    # Use "includes" field here to match CMake SYSTEM include specifier.
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [

--- a/libs/3rdparty/freeRtos/BUILD.bazel
+++ b/libs/3rdparty/freeRtos/BUILD.bazel
@@ -14,8 +14,8 @@ alias(
     name = "freertos_port_default",
     actual = select(
         {
-            "//bazel/platform/constraints:s32k148": "//platforms/s32k1xx/3rdparty/freertos_cm4_sysTick:freertos_cm4_sys_tick_port",
-            "@platforms//os:linux": "//platforms/posix/3rdparty/freeRtosPosix:freertos_posix_port",
+            "//bazel/platform/constraints/soc:s32k148": "//platforms/s32k1xx/3rdparty/freertos_cm4_sysTick:freertos_cm4_sys_tick_port_headers",
+            "@platforms//os:linux": "//platforms/posix/3rdparty/freeRtosPosix:freertos_posix_port_headers",
         },
         no_match_error = "No FreeRTOS port for this platform. Override --//libs/3rdparty/freeRtos:freertos_port with your own port target.",
     ),
@@ -34,7 +34,7 @@ alias(
     name = "freertos_port_impl_default",
     actual = select(
         {
-            "//bazel/platform/constraints:s32k148": "//platforms/s32k1xx/3rdparty/freertos_cm4_sysTick:freertos_cm4_sys_tick",
+            "//bazel/platform/constraints/soc:s32k148": "//platforms/s32k1xx/3rdparty/freertos_cm4_sysTick:freertos_cm4_sys_tick",
             "@platforms//os:linux": "//platforms/posix/3rdparty/freeRtosPosix:freertos_posix",
         },
         no_match_error = "No FreeRTOS port implementation for this platform. Override --//libs/3rdparty/freeRtos:freertos_port_impl with your own port target.",
@@ -51,27 +51,27 @@ label_flag(
 )
 
 alias(
-    name = "free_rtos_os_hooks_default",
+    name = "freertos_os_hooks_default",
     actual = select(
         {
-            "//bazel/platform/constraints:s32k148": "//executables/referenceApp/platforms/s32k148evb/main:freertos_os_hooks",
+            "//bazel/platform/constraints/soc:s32k148": "//executables/referenceApp/platforms/s32k148evb/main:freertos_os_hooks",
             "@platforms//os:linux": "//executables/referenceApp/platforms/posix/main:freertos_os_hooks",
         },
-        no_match_error = "No FreeRTOS OS hooks for this platform. Override --//libs/3rdparty/freeRtos:free_rtos_os_hooks with your own hooks target.",
+        no_match_error = "No FreeRTOS OS hooks for this platform. Override --//libs/3rdparty/freeRtos:freertos_os_hooks with your own hooks target.",
     ),
 )
 
 # FreeRTOS OS hooks
 #   Default:  select based on the target platform (S32K148, POSIX)
-#   Override: --//libs/3rdparty/freeRtos:free_rtos_os_hooks=//path/to:your_os_hooks
+#   Override: --//libs/3rdparty/freeRtos:freertos_os_hooks=//path/to:your_os_hooks
 label_flag(
-    name = "free_rtos_os_hooks",
-    build_setting_default = ":free_rtos_os_hooks_default",
+    name = "freertos_os_hooks",
+    build_setting_default = ":freertos_os_hooks_default",
     visibility = ["//visibility:public"],
 )
 
 cc_library(
-    name = "free_rtos_headers",
+    name = "freertos_headers",
     hdrs = glob(["include/**/*.h"]),
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
@@ -82,9 +82,9 @@ cc_library(
 )
 
 # Circular dependency present on the CMake side: free_rtos -> freeRtosPortImpl -> freeRtos
-# Split off free_rtos_headers and freertos_port_impl to break the circular dependency for Bazel
+# Split off freertos_headers and freertos_port_impl to break the circular dependency for Bazel
 cc_library(
-    name = "free_rtos",
+    name = "freertos",
     srcs = [
         "src/croutine.c",
         "src/event_groups.c",
@@ -97,11 +97,11 @@ cc_library(
     copts = ["-Wno-unused-variable"],
     visibility = ["//visibility:public"],
     implementation_deps = [
-        ":free_rtos_os_hooks",
+        ":freertos_os_hooks",
         ":freertos_port_impl",
     ],
     deps = [
-        ":free_rtos_headers",
+        ":freertos_headers",
         "//libs/bsw/platform",
     ],
 )

--- a/libs/3rdparty/freeRtos/BUILD.bazel
+++ b/libs/3rdparty/freeRtos/BUILD.bazel
@@ -1,0 +1,105 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+alias(
+    name = "freertos_port_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints:s32k148": "//platforms/s32k1xx/3rdparty/freertos_cm4_sysTick:freertos_cm4_sys_tick_port",
+            "@platforms//os:linux": "//platforms/posix/3rdparty/freeRtosPosix:freertos_posix_port",
+        },
+        no_match_error = "No FreeRTOS port for this platform. Override --//libs/3rdparty/freeRtos:freertos_port with your own port target.",
+    ),
+)
+
+# FreeRTOS port (portmacro.h).
+#   Default:  select based on the target platform (S32K148, POSIX)
+#   Override: --//libs/3rdparty/freeRtos:freertos_port=//path/to:your_port
+label_flag(
+    name = "freertos_port",
+    build_setting_default = ":freertos_port_default",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "freertos_port_impl_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints:s32k148": "//platforms/s32k1xx/3rdparty/freertos_cm4_sysTick:freertos_cm4_sys_tick",
+            "@platforms//os:linux": "//platforms/posix/3rdparty/freeRtosPosix:freertos_posix",
+        },
+        no_match_error = "No FreeRTOS port implementation for this platform. Override --//libs/3rdparty/freeRtos:freertos_port_impl with your own port target.",
+    ),
+)
+
+# FreeRTOS port implementation
+#   Default:  select based on the target platform (S32K148, POSIX)
+#   Override: --//libs/3rdparty/freeRtos:freertos_port_impl=//path/to:your_port_impl
+label_flag(
+    name = "freertos_port_impl",
+    build_setting_default = ":freertos_port_impl_default",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "free_rtos_os_hooks_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints:s32k148": "//executables/referenceApp/platforms/s32k148evb/main:freertos_os_hooks",
+            "@platforms//os:linux": "//executables/referenceApp/platforms/posix/main:freertos_os_hooks",
+        },
+        no_match_error = "No FreeRTOS OS hooks for this platform. Override --//libs/3rdparty/freeRtos:free_rtos_os_hooks with your own hooks target.",
+    ),
+)
+
+# FreeRTOS OS hooks
+#   Default:  select based on the target platform (S32K148, POSIX)
+#   Override: --//libs/3rdparty/freeRtos:free_rtos_os_hooks=//path/to:your_os_hooks
+label_flag(
+    name = "free_rtos_os_hooks",
+    build_setting_default = ":free_rtos_os_hooks_default",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "free_rtos_headers",
+    hdrs = glob(["include/**/*.h"]),
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":freertos_port",
+        "//libs/bsw/asyncFreeRtos:freertos_configuration",
+    ],
+)
+
+# Circular dependency present on the CMake side: free_rtos -> freeRtosPortImpl -> freeRtos
+# Split off free_rtos_headers and freertos_port_impl to break the circular dependency for Bazel
+cc_library(
+    name = "free_rtos",
+    srcs = [
+        "src/croutine.c",
+        "src/event_groups.c",
+        "src/list.c",
+        "src/queue.c",
+        "src/stream_buffer.c",
+        "src/tasks.c",
+        "src/timers.c",
+    ],
+    copts = ["-Wno-unused-variable"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":free_rtos_headers",
+        ":free_rtos_os_hooks",
+        ":freertos_port_impl",
+        "//libs/bsw/platform",
+    ],
+)

--- a/libs/3rdparty/freeRtos/BUILD.bazel
+++ b/libs/3rdparty/freeRtos/BUILD.bazel
@@ -96,10 +96,12 @@ cc_library(
     ],
     copts = ["-Wno-unused-variable"],
     visibility = ["//visibility:public"],
-    deps = [
-        ":free_rtos_headers",
+    implementation_deps = [
         ":free_rtos_os_hooks",
         ":freertos_port_impl",
+    ],
+    deps = [
+        ":free_rtos_headers",
         "//libs/bsw/platform",
     ],
 )

--- a/libs/3rdparty/freeRtos/BUILD.bazel
+++ b/libs/3rdparty/freeRtos/BUILD.bazel
@@ -95,11 +95,11 @@ cc_library(
         "src/timers.c",
     ],
     copts = ["-Wno-unused-variable"],
-    visibility = ["//visibility:public"],
     implementation_deps = [
         ":freertos_os_hooks",
         ":freertos_port_impl",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":freertos_headers",
         "//libs/bsw/platform",

--- a/libs/bsp/bspInterrupts/BUILD.bazel
+++ b/libs/bsp/bspInterrupts/BUILD.bazel
@@ -14,7 +14,7 @@ alias(
     name = "bsp_interrupts_impl_default",
     actual = select(
         {
-            "//bazel/platform/constraints:s32k148": "//platforms/s32k1xx/bsp/bspInterruptsImpl:bsp_interrupts_impl",
+            "//bazel/platform/constraints/soc:s32k148": "//platforms/s32k1xx/bsp/bspInterruptsImpl:bsp_interrupts_impl",
             "@platforms//os:linux": "//platforms/posix/bsp/bspInterruptsImpl:bsp_interrupts_impl",
         },
         no_match_error = "No interrupt-lock implementation for this platform. Override --//libs/bsp/bspInterrupts:bsp_interrupts_impl with your own implementation target.",

--- a/libs/bsp/bspInterrupts/BUILD.bazel
+++ b/libs/bsp/bspInterrupts/BUILD.bazel
@@ -1,0 +1,44 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+alias(
+    name = "bsp_interrupts_impl_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints:s32k148": "//platforms/s32k1xx/bsp/bspInterruptsImpl:bsp_interrupts_impl",
+            "@platforms//os:linux": "//platforms/posix/bsp/bspInterruptsImpl:bsp_interrupts_impl",
+        },
+        no_match_error = "No interrupt-lock implementation for this platform. Override --//libs/bsp/bspInterrupts:bsp_interrupts_impl with your own implementation target.",
+    ),
+)
+
+# Interrupt-lock implementation
+#   Default:  select based on the target platform (S32K148, POSIX)
+#   Override: --//libs/bsp/bspInterrupts:bsp_interrupts_impl=//path/to:your_impl
+label_flag(
+    name = "bsp_interrupts_impl",
+    build_setting_default = ":bsp_interrupts_impl_default",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "bsp_interrupts",
+    hdrs = [
+        "include/interrupts/SuspendResumeAllInterruptsLock.h",
+        "include/interrupts/SuspendResumeAllInterruptsScopedLock.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bsp_interrupts_impl",
+    ],
+)

--- a/libs/bsw/asyncFreeRtos/BUILD.bazel
+++ b/libs/bsw/asyncFreeRtos/BUILD.bazel
@@ -14,7 +14,7 @@ alias(
     name = "freertos_core_configuration_default",
     actual = select(
         {
-            "//bazel/platform/constraints:s32k148": "//executables/referenceApp/platforms/s32k148evb/freeRtosCoreConfiguration:freertos_core_configuration",
+            "//bazel/platform/constraints/soc:s32k148": "//executables/referenceApp/platforms/s32k148evb/freeRtosCoreConfiguration:freertos_core_configuration",
             "@platforms//os:linux": "//executables/referenceApp/platforms/posix/freeRtosCoreConfiguration:freertos_core_configuration",
         },
         no_match_error = "No FreeRTOS core configuration for this platform. Override --//libs/bsw/asyncFreeRtos:freertos_core_configuration with your own configuration target.",

--- a/libs/bsw/asyncFreeRtos/BUILD.bazel
+++ b/libs/bsw/asyncFreeRtos/BUILD.bazel
@@ -31,6 +31,32 @@ label_flag(
 )
 
 cc_library(
+    name = "async_core_configuration_unittest_stub",
+    hdrs = ["test/mock/include/async/Config.h"],
+    strip_include_prefix = "test/mock/include",
+)
+
+alias(
+    name = "async_core_configuration_default",
+    actual = select(
+        {
+            "//bazel/config/executable_config:reference_app": "//executables/referenceApp/asyncCoreConfiguration:async_core_configuration",
+            "//bazel/config/executable_config:unit_test": ":async_core_configuration_unittest_stub",
+        },
+        no_match_error = "No async core configuration. Override --//libs/bsw/asyncFreeRtos:async_core_configuration with your own target.",
+    ),
+)
+
+# Async core configuration (async/Config.h - task counts, stack sizes).
+#   Default:  select based on //bazel/config/executable_config
+#   Override: --//libs/bsw/asyncFreeRtos:async_core_configuration=//path/to:your_config
+label_flag(
+    name = "async_core_configuration",
+    build_setting_default = ":async_core_configuration_default",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "freertos_configuration",
     hdrs = [
         "freeRtosConfiguration/FreeRTOSConfig.h",
@@ -40,8 +66,8 @@ cc_library(
     strip_include_prefix = "freeRtosConfiguration",
     visibility = ["//visibility:public"],
     deps = [
+        ":async_core_configuration",
         ":freertos_core_configuration",
-        "//executables/referenceApp/asyncCoreConfiguration:async_core_configuration",
         "//libs/bsw/platform",
     ],
 )

--- a/libs/bsw/asyncFreeRtos/BUILD.bazel
+++ b/libs/bsw/asyncFreeRtos/BUILD.bazel
@@ -1,0 +1,47 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+alias(
+    name = "freertos_core_configuration_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints:s32k148": "//executables/referenceApp/platforms/s32k148evb/freeRtosCoreConfiguration:freertos_core_configuration",
+            "@platforms//os:linux": "//executables/referenceApp/platforms/posix/freeRtosCoreConfiguration:freertos_core_configuration",
+        },
+        no_match_error = "No FreeRTOS core configuration for this platform. Override --//libs/bsw/asyncFreeRtos:freertos_core_configuration with your own configuration target.",
+    ),
+)
+
+# FreeRTOS core configuration (FreeRtosPlatformConfig.h and platform wiring).
+#   Default:  select based on the target platform (S32K148, POSIX)
+#   Override: --//libs/bsw/asyncFreeRtos:freertos_core_configuration=//path/to:your_config
+label_flag(
+    name = "freertos_core_configuration",
+    build_setting_default = ":freertos_core_configuration_default",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "freertos_configuration",
+    hdrs = [
+        "freeRtosConfiguration/FreeRTOSConfig.h",
+        "freeRtosConfiguration/async/Hook.h",
+        "freeRtosConfiguration/freertos_tasks_c_additions.h",
+    ],
+    strip_include_prefix = "freeRtosConfiguration",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":freertos_core_configuration",
+        "//executables/referenceApp/asyncCoreConfiguration:async_core_configuration",
+        "//libs/bsw/platform",
+    ],
+)

--- a/libs/bsw/common/BUILD.bazel
+++ b/libs/bsw/common/BUILD.bazel
@@ -40,6 +40,7 @@ cc_library(
     ],
 )
 
+
 cc_library(
     name = "common",
     visibility = ["//visibility:public"],

--- a/libs/bsw/common/BUILD.bazel
+++ b/libs/bsw/common/BUILD.bazel
@@ -40,7 +40,6 @@ cc_library(
     ],
 )
 
-
 cc_library(
     name = "common",
     visibility = ["//visibility:public"],

--- a/libs/bsw/middleware/BUILD.bazel
+++ b/libs/bsw/middleware/BUILD.bazel
@@ -13,19 +13,31 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 cc_library(
     name = "middleware_lock_types_test_stub",
     hdrs = ["test/include/middleware/concurrency/lock_types.h"],
+    # CMake test/CMakeLists.txt adds test/include PUBLIC, non-SYSTEM -> strip_include_prefix (-I).
     strip_include_prefix = "test/include",
 )
 
+# Default wiring in case it is not overriden via label_flag: middleware_lock_types
+#   unit_test     -> host no-op stub (CMake puts test/include on middleware's include path)
+#   reference_app -> platform integration supplies lock_types.h; stub stands in until one exists
 alias(
-    name = "middleware_lock_types",
+    name = "middleware_lock_types_default",
     actual = select(
         {
-            # TODO: Use test lock_types.h stub since it is the only existing implementation.
-            "//bazel/config/executable_config:reference_app": ":middleware_lock_types_test_stub",
             "//bazel/config/executable_config:unit_test": ":middleware_lock_types_test_stub",
+            "//bazel/config/executable_config:reference_app": ":middleware_lock_types_test_stub",
         },
-        no_match_error = "Please set executable_config to either 'reference_app' or 'unit_test'",
+        no_match_error = "Set executable_config to 'reference_app' or 'unit_test', or override --//libs/bsw/middleware:middleware_lock_types",
     ),
+)
+
+# lock_types.h provider. Platform integration supplies the concrete types at build time.
+#   Default:  per executable_config selection above (currently the host stub)
+#   Override: --//libs/bsw/middleware:middleware_lock_types=//<your>:lock_types
+label_flag(
+    name = "middleware_lock_types",
+    build_setting_default = ":middleware_lock_types_default",
+    visibility = ["//visibility:public"],
 )
 
 cc_library(

--- a/platforms/posix/3rdparty/freeRtosPosix/BUILD.bazel
+++ b/platforms/posix/3rdparty/freeRtosPosix/BUILD.bazel
@@ -1,15 +1,15 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(
-    name = "freertos_posix_port",
+    name = "freertos_posix_port_headers",
     hdrs = ["include/portmacro.h"],
     strip_include_prefix = "include",
     target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
 )
 
-# Uses free_rtos_headers (not free_rtos) to avoid the circular dependency:
-#   free_rtos -> freertos_port_impl -> free_rtos_headers
+# Uses freertos_headers (not free_rtos) to avoid the circular dependency:
+#   free_rtos -> freertos_port_impl -> freertos_headers
 cc_library(
     name = "freertos_posix",
     srcs = [
@@ -22,8 +22,8 @@ cc_library(
     target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
     deps = [
-        ":freertos_posix_port",
-        "//libs/3rdparty/freeRtos:free_rtos_headers",
+        ":freertos_posix_port_headers",
+        "//libs/3rdparty/freeRtos:freertos_headers",
         "//libs/bsp/bspInterrupts:bsp_interrupts",
         "//libs/bsw/platform",
     ],

--- a/platforms/posix/3rdparty/freeRtosPosix/BUILD.bazel
+++ b/platforms/posix/3rdparty/freeRtosPosix/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "freertos_posix_port",
+    hdrs = ["include/portmacro.h"],
+    strip_include_prefix = "include",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+)
+
+# Uses free_rtos_headers (not free_rtos) to avoid the circular dependency:
+#   free_rtos -> freertos_port_impl -> free_rtos_headers
+cc_library(
+    name = "freertos_posix",
+    srcs = [
+        "src/port.c",
+        "src/utils/wait_for_event.c",
+        "src/utils/wait_for_event.h",
+    ],
+    linkopts = ["-lpthread"],
+    local_defines = ["_POSIX_C_SOURCE=200112L"],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":freertos_posix_port",
+        "//libs/3rdparty/freeRtos:free_rtos_headers",
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//libs/bsw/platform",
+    ],
+)

--- a/platforms/posix/bsp/bspInterruptsImpl/BUILD.bazel
+++ b/platforms/posix/bsp/bspInterruptsImpl/BUILD.bazel
@@ -10,14 +10,18 @@
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
+# Posix FreeRTOS interrupt suspension implementation.
+# Depends on free_rtos_headers (not free_rtos) to break the circular dep:
+#   free_rtos -> freertos_port_impl (freertos_posix) -> bsp_interrupts
+#             -> bsp_interrupts_impl -> free_rtos_headers
 cc_library(
-    name = "util",
-    srcs = glob(["src/util/**/*.cpp"]),
-    hdrs = glob(["include/**/*.h"]),
-    strip_include_prefix = "include",
+    name = "bsp_interrupts_impl",
+    srcs = ["freertos/src/interrupts/suspendResumeAllInterrupts.cpp"],
+    hdrs = ["freertos/include/interrupts/suspendResumeAllInterrupts.h"],
+    strip_include_prefix = "freertos/include",
     visibility = ["//visibility:public"],
     deps = [
-        "//libs/3rdparty/etl",
+        "//libs/3rdparty/freeRtos:free_rtos_headers",
         "//libs/bsw/platform",
     ],
 )

--- a/platforms/posix/bsp/bspInterruptsImpl/BUILD.bazel
+++ b/platforms/posix/bsp/bspInterruptsImpl/BUILD.bazel
@@ -11,9 +11,9 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 # Posix FreeRTOS interrupt suspension implementation.
-# Depends on free_rtos_headers (not free_rtos) to break the circular dep:
+# Depends on freertos_headers (not free_rtos) to break the circular dep:
 #   free_rtos -> freertos_port_impl (freertos_posix) -> bsp_interrupts
-#             -> bsp_interrupts_impl -> free_rtos_headers
+#             -> bsp_interrupts_impl -> freertos_headers
 cc_library(
     name = "bsp_interrupts_impl",
     srcs = ["freertos/src/interrupts/suspendResumeAllInterrupts.cpp"],
@@ -21,7 +21,7 @@ cc_library(
     strip_include_prefix = "freertos/include",
     visibility = ["//visibility:public"],
     deps = [
-        "//libs/3rdparty/freeRtos:free_rtos_headers",
+        "//libs/3rdparty/freeRtos:freertos_headers",
         "//libs/bsw/platform",
     ],
 )

--- a/platforms/s32k1xx/3rdparty/freertos_cm4_sysTick/BUILD.bazel
+++ b/platforms/s32k1xx/3rdparty/freertos_cm4_sysTick/BUILD.bazel
@@ -1,26 +1,26 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(
-    name = "freertos_cm4_sys_tick_port",
+    name = "freertos_cm4_sys_tick_port_headers",
     hdrs = ["include/portmacro.h"],
     strip_include_prefix = "include",
-    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
     visibility = ["//visibility:public"],
 )
 
 # Circular dependency present on the CMake side: freeRtos -> freeRtosCm4SysTick -> freeRtos
-# Split off free_rtos_headers to break the circular dependency for Bazel
+# Split off freertos_headers to break the circular dependency for Bazel
 cc_library(
     name = "freertos_cm4_sys_tick",
     srcs = ["src/port.c"],
     copts = ["-Wno-unused-but-set-variable"],
-    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
     visibility = ["//visibility:public"],
     implementation_deps = [
         "//libs/bsp/bspInterrupts:bsp_interrupts",
     ],
     deps = [
-        ":freertos_cm4_sys_tick_port",
-        "//libs/3rdparty/freeRtos:free_rtos_headers",
+        ":freertos_cm4_sys_tick_port_headers",
+        "//libs/3rdparty/freeRtos:freertos_headers",
     ],
 )

--- a/platforms/s32k1xx/3rdparty/freertos_cm4_sysTick/BUILD.bazel
+++ b/platforms/s32k1xx/3rdparty/freertos_cm4_sysTick/BUILD.bazel
@@ -14,11 +14,11 @@ cc_library(
     name = "freertos_cm4_sys_tick",
     srcs = ["src/port.c"],
     copts = ["-Wno-unused-but-set-variable"],
-    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
-    visibility = ["//visibility:public"],
     implementation_deps = [
         "//libs/bsp/bspInterrupts:bsp_interrupts",
     ],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
     deps = [
         ":freertos_cm4_sys_tick_port_headers",
         "//libs/3rdparty/freeRtos:freertos_headers",

--- a/platforms/s32k1xx/3rdparty/freertos_cm4_sysTick/BUILD.bazel
+++ b/platforms/s32k1xx/3rdparty/freertos_cm4_sysTick/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "freertos_cm4_sys_tick_port",
+    hdrs = ["include/portmacro.h"],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+    visibility = ["//visibility:public"],
+)
+
+# Circular dependency present on the CMake side: freeRtos -> freeRtosCm4SysTick -> freeRtos
+# Split off free_rtos_headers to break the circular dependency for Bazel
+cc_library(
+    name = "freertos_cm4_sys_tick",
+    srcs = ["src/port.c"],
+    copts = ["-Wno-unused-but-set-variable"],
+    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":freertos_cm4_sys_tick_port",
+        "//libs/3rdparty/freeRtos:free_rtos_headers",
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+    ],
+)

--- a/platforms/s32k1xx/3rdparty/freertos_cm4_sysTick/BUILD.bazel
+++ b/platforms/s32k1xx/3rdparty/freertos_cm4_sysTick/BUILD.bazel
@@ -16,9 +16,11 @@ cc_library(
     copts = ["-Wno-unused-but-set-variable"],
     target_compatible_with = ["//bazel/platform/constraints:s32k148"],
     visibility = ["//visibility:public"],
+    implementation_deps = [
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+    ],
     deps = [
         ":freertos_cm4_sys_tick_port",
         "//libs/3rdparty/freeRtos:free_rtos_headers",
-        "//libs/bsp/bspInterrupts:bsp_interrupts",
     ],
 )

--- a/platforms/s32k1xx/bsp/bspInterruptsImpl/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspInterruptsImpl/BUILD.bazel
@@ -41,13 +41,13 @@ cc_library(
         "include/interrupt_manager.h",
         "include/interrupts/disableEnableAllInterrupts.h",
     ],
-    strip_include_prefix = "include",
-    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
-    visibility = ["//visibility:public"],
     implementation_deps = [
         "//libs/bsw/platform",
         "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
     ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
     deps = [
         ":bsp_interrupts_impl_rtos_hdrs",
     ],

--- a/platforms/s32k1xx/bsp/bspInterruptsImpl/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspInterruptsImpl/BUILD.bazel
@@ -20,7 +20,7 @@ cc_library(
     name = "bsp_interrupts_impl_freertos_hdrs",
     hdrs = ["freertos/include/interrupts/suspendResumeAllInterrupts.h"],
     strip_include_prefix = "freertos/include",
-    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
 )
 
 alias(
@@ -42,7 +42,7 @@ cc_library(
         "include/interrupts/disableEnableAllInterrupts.h",
     ],
     strip_include_prefix = "include",
-    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
     visibility = ["//visibility:public"],
     implementation_deps = [
         "//libs/bsw/platform",

--- a/platforms/s32k1xx/bsp/bspInterruptsImpl/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspInterruptsImpl/BUILD.bazel
@@ -1,0 +1,52 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# This module exposes two public header roots with different prefixes:
+# "include/" (the common interrupt API) and "freertos/include/" (the
+# RTOS-specific header). A cc_library can strip only one include prefix,
+# so the RTOS header root lives in its own small library and is re-exported
+# through bsp_interrupts_impl below. Consumers still include it as
+# "interrupts/suspendResumeAllInterrupts.h".
+cc_library(
+    name = "bsp_interrupts_impl_freertos_hdrs",
+    hdrs = ["freertos/include/interrupts/suspendResumeAllInterrupts.h"],
+    strip_include_prefix = "freertos/include",
+    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+)
+
+alias(
+    name = "bsp_interrupts_impl_rtos_hdrs",
+    actual = select(
+        {
+            "//bazel/config/rtos:support_freertos": ":bsp_interrupts_impl_freertos_hdrs",
+            # TODO: add a "//bazel/config/rtos:support_threadx" branch once ThreadX is migrated.
+        },
+        no_match_error = "s32k1xx bsp_interrupts_impl supports only --//bazel/config/rtos=freertos; ThreadX is not yet migrated.",
+    ),
+)
+
+cc_library(
+    name = "bsp_interrupts_impl",
+    srcs = ["src/interrupt_manager.c"],
+    hdrs = [
+        "include/interrupt_manager.h",
+        "include/interrupts/disableEnableAllInterrupts.h",
+    ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bsp_interrupts_impl_rtos_hdrs",
+        "//libs/bsw/platform",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+    ],
+)

--- a/platforms/s32k1xx/bsp/bspInterruptsImpl/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspInterruptsImpl/BUILD.bazel
@@ -44,9 +44,11 @@ cc_library(
     strip_include_prefix = "include",
     target_compatible_with = ["//bazel/platform/constraints:s32k148"],
     visibility = ["//visibility:public"],
-    deps = [
-        ":bsp_interrupts_impl_rtos_hdrs",
+    implementation_deps = [
         "//libs/bsw/platform",
         "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+    ],
+    deps = [
+        ":bsp_interrupts_impl_rtos_hdrs",
     ],
 )

--- a/platforms/s32k1xx/bsp/bspMcu/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspMcu/BUILD.bazel
@@ -15,7 +15,7 @@ cc_library(
     srcs = ["src/reset/softwareSystemReset.cpp"],
     hdrs = glob(["include/**/*.h"]),
     strip_include_prefix = "include",
-    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
     visibility = ["//visibility:public"],
     deps = [
         "//libs/3rdparty/cmsis",

--- a/platforms/s32k1xx/bsp/bspMcu/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspMcu/BUILD.bazel
@@ -8,11 +8,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-platform(
-    name = "s32k148",
-    constraint_values = [
-        "@platforms//cpu:armv7e-m",
-        "@platforms//os:none",
-        "//bazel/platform/constraints:s32k148",
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_mcu",
+    srcs = ["src/reset/softwareSystemReset.cpp"],
+    hdrs = glob(["include/**/*.h"]),
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/cmsis",
+        "//libs/bsw/platform",
     ],
 )


### PR DESCRIPTION
## Migrate FreeRTOS [1/2] core, ports and BSP/MCU

First half of the FreeRTOS migration: core, platform ports, BSP/MCU layers and per-platform reference configuration. The async/runtime binding layer follows in a second PR

### Migrated library targets:
- //libs/3rdparty/freeRtos:free_rtos (freeRtos)
- //libs/3rdparty/freeRtos:free_rtos_headers (freeRtos): header-only split that breaks the CMake dependency cycle
- //platforms/posix/3rdparty/freeRtosPosix:freertos_posix_port (freeRtosPosixPort)
- //platforms/posix/3rdparty/freeRtosPosix:freertos_posix (freeRtosPosix)
- //platforms/s32k1xx/3rdparty/freertos_cm4_sysTick:freertos_cm4_sys_tick_port (freeRtosCm4SysTickPort)
- //platforms/s32k1xx/3rdparty/freertos_cm4_sysTick:freertos_cm4_sys_tick (freeRtosCm4SysTick)
- //libs/bsp/bspInterrupts:bsp_interrupts (bspInterrupts)
- //platforms/posix/bsp/bspInterruptsImpl:bsp_interrupts_impl (bspInterruptsImpl)
- //platforms/s32k1xx/bsp/bspInterruptsImpl:bsp_interrupts_impl (bspInterruptsImpl)
- //platforms/s32k1xx/bsp/bspMcu:bsp_mcu (bspMcu)
- //libs/3rdparty/cmsis:cmsis (no CMake target): CMSIS-Core headers, previously part of bspMcu's include dirs
- //libs/bsw/asyncFreeRtos:freertos_configuration (freeRtosConfiguration)
- //executables/referenceApp/asyncCoreConfiguration:async_core_configuration (asyncCoreConfiguration)
- //executables/referenceApp/platforms/posix/freeRtosCoreConfiguration:freertos_core_configuration (freeRtosCoreConfiguration)
- //executables/referenceApp/platforms/s32k148evb/freeRtosCoreConfiguration:freertos_core_configuration (freeRtosCoreConfiguration)
- //executables/referenceApp/platforms/posix/main:freertos_os_hooks (osHooks)
- //executables/referenceApp/platforms/s32k148evb/main:freertos_os_hooks (osHooks)

### Configuration parameters:
- //bazel/config/rtos:rtos (BUILD_TARGET_RTOS): string_flag [freertos, threadx], default freertos;
  first consumed by s32k1xx bspInterruptsImpl to select its RTOS-specific interrupt
  headers (FreeRTOS only; ThreadX branch deferred via no_match_error)
- //bazel/platform/constraints:s32k148 (+ //bazel/platform:s32k148): board constraint; host resolves via @platforms//os:linux
- overrideable label_flags (override per board/app):
    //libs/3rdparty/freeRtos:freertos_port (freeRtosPort)
    //libs/3rdparty/freeRtos:freertos_port_impl (freeRtosPortImpl)
    //libs/3rdparty/freeRtos:free_rtos_os_hooks (osHooks)
    //libs/bsp/bspInterrupts:bsp_interrupts_impl (bspInterruptsImpl)
    //libs/bsw/asyncFreeRtos:freertos_core_configuration (freeRtosCoreConfiguration)
    //libs/bsw/middleware:middleware_lock_types (lock_types.h provider; converted from a closed select to a label_flag)
    //libs/bsw/common:common_impl (app configuration injection; converted from a closed select to a label_flag)

### Additional changes:
- Add copyright headers to Bazel related files
- Add BUILD.bazel to ignored rim files for cmsis