### PR TITLE
Add ClearDiagnosticInformation service (0x14)

### DIFF
--- a/executables/referenceApp/application/include/systems/UdsSystem.h
+++ b/executables/referenceApp/application/include/systems/UdsSystem.h
@@ -22,6 +22,7 @@
 #include <uds/async/AsyncDiagJob.h>
 #include <uds/jobs/ReadIdentifierFromMemory.h>
 #include <uds/jobs/WriteIdentifierToMemory.h>
+#include <uds/services/cleardiagnosticinformation/ClearDiagnosticInformation.h>
 #include <uds/services/communicationcontrol/CommunicationControl.h>
 #include <uds/services/readdata/ReadDataByIdentifier.h>
 #include <uds/services/readdtcinformation/ReadDTCInformation.h>
@@ -86,6 +87,7 @@ private:
 
     DiagJobRoot _jobRoot;
     DiagnosticSessionControl _diagnosticSessionControl;
+    ClearDiagnosticInformation _clearDiagnosticInformation;
     CommunicationControl _communicationControl;
     DiagnosisConfiguration _udsConfiguration;
     ::etl::pool<IncomingDiagConnection, 5> _connectionPool;

--- a/executables/referenceApp/application/src/systems/UdsSystem.cpp
+++ b/executables/referenceApp/application/src/systems/UdsSystem.cpp
@@ -114,6 +114,9 @@ ReadDataByIdentifier& UdsSystem::getReadDataByIdentifier() { return _readDataByI
 
 void UdsSystem::addDiagJobs()
 {
+    // 14 - ClearDiagnosticInformation
+    (void)_jobRoot.addAbstractDiagJob(_clearDiagnosticInformation);
+
     // 22 - ReadDataByIdentifier
     (void)_jobRoot.addAbstractDiagJob(_readDataByIdentifier);
     (void)_jobRoot.addAbstractDiagJob(_read22Cf01);
@@ -138,6 +141,9 @@ void UdsSystem::addDiagJobs()
 
 void UdsSystem::removeDiagJobs()
 {
+    // 14 - ClearDiagnosticInformation
+    _jobRoot.removeAbstractDiagJob(_clearDiagnosticInformation);
+
     // 22 - ReadDataByIdentifier
     _jobRoot.removeAbstractDiagJob(_readDataByIdentifier);
     _jobRoot.removeAbstractDiagJob(_read22Cf01);

--- a/libs/bsw/uds/CMakeLists.txt
+++ b/libs/bsw/uds/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
     src/uds/jobs/RoutineControlJob.cpp
     src/uds/jobs/WriteIdentifierToMemory.cpp
     src/uds/resume/ResumableResetDriver.cpp
+    src/uds/services/cleardiagnosticinformation/ClearDiagnosticInformation.cpp
     src/uds/services/controldtcsetting/ControlDTCSetting.cpp
     src/uds/services/communicationcontrol/CommunicationControl.cpp
     src/uds/services/readdtcinformation/ReadDTCInformation.cpp

--- a/libs/bsw/uds/include/uds/services/cleardiagnosticinformation/ClearDiagnosticInformation.h
+++ b/libs/bsw/uds/include/uds/services/cleardiagnosticinformation/ClearDiagnosticInformation.h
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (c) 2026 BMW AG
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#pragma once
+
+#include "uds/base/Service.h"
+
+namespace uds
+{
+/**
+ * UDS service ClearDiagnosticInformation (0x14).
+ *
+ * This service enables a tester to request clearing of diagnostic trouble
+ * codes (DTCs). The actual clearing is project-specific and must be provided
+ * by the integrator separately. This class provides only a demo implementation
+ * which handles the groupOfDTC parameter:
+ * - groupOfDTC 0xFFFFFF (all DTCs) returns a positive response
+ * - any other group returns NRC 0x31 (requestOutOfRange)
+ */
+class ClearDiagnosticInformation : public Service
+{
+public:
+    explicit ClearDiagnosticInformation();
+
+private:
+    static uint8_t const EXPECTED_REQUEST_LENGTH = 3U;
+    static uint8_t const RESPONSE_LENGTH         = 0U;
+    static uint32_t const GROUP_ALL_DTCS         = 0xFFFFFFU;
+
+    DiagReturnCode::Type process(
+        IncomingDiagConnection& connection,
+        uint8_t const request[],
+        uint16_t requestLength) override;
+};
+
+} // namespace uds

--- a/libs/bsw/uds/src/uds/services/cleardiagnosticinformation/ClearDiagnosticInformation.cpp
+++ b/libs/bsw/uds/src/uds/services/cleardiagnosticinformation/ClearDiagnosticInformation.cpp
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (c) 2026 BMW AG
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "uds/services/cleardiagnosticinformation/ClearDiagnosticInformation.h"
+
+#include "uds/connection/IncomingDiagConnection.h"
+#include "uds/session/DiagSession.h"
+
+namespace uds
+{
+ClearDiagnosticInformation::ClearDiagnosticInformation()
+: Service(
+    ServiceId::CLEAR_DIAGNOSTIC_INFORMATION,
+    EXPECTED_REQUEST_LENGTH,
+    RESPONSE_LENGTH,
+    DiagSession::ALL_SESSIONS())
+{
+    setDefaultDiagReturnCode(DiagReturnCode::ISO_REQUEST_OUT_OF_RANGE);
+}
+
+DiagReturnCode::Type ClearDiagnosticInformation::process(
+    IncomingDiagConnection& connection,
+    uint8_t const* const request,
+    uint16_t const /* requestLength */)
+{
+    uint32_t const groupOfDTC = (static_cast<uint32_t>(request[0]) << 16)
+                                | (static_cast<uint32_t>(request[1]) << 8)
+                                | static_cast<uint32_t>(request[2]);
+
+    switch (groupOfDTC)
+    {
+        case GROUP_ALL_DTCS:
+        {
+            // Demo: clear all DTCs. Real DTC clearing is project-specific and will not be
+            // implemented in this reference file
+            PositiveResponse& response = connection.releaseRequestGetResponse();
+            (void)connection.sendPositiveResponseInternal(response.getLength(), *this);
+            return DiagReturnCode::OK;
+        }
+        // Additional groupOfDTC values (e.g. powertrain, chassis, body, network)
+        // are reserved for project-specific DEM implementation.
+        default:
+        {
+            return DiagReturnCode::ISO_REQUEST_OUT_OF_RANGE;
+        }
+    }
+}
+
+} // namespace uds

--- a/libs/bsw/uds/test/CMakeLists.txt
+++ b/libs/bsw/uds/test/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(
     src/uds/jobs/RoutineControlJobTest.cpp
     src/uds/jobs/WritedentifierToMemoryJobTest.cpp
     src/uds/resume/ResumableResetDriverTest.cpp
+    src/uds/services/cleardiagnosticinformation/ClearDiagnosticInformationTest.cpp
     src/uds/services/controldtcsetting/ControlDTCSettingTest.cpp
     src/uds/services/readdtcinformation/ReadDTCInformationTest.cpp
     src/uds/services/readdata/MultipleReadDataByIdentifierTest.cpp

--- a/libs/bsw/uds/test/src/uds/services/cleardiagnosticinformation/ClearDiagnosticInformationTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/cleardiagnosticinformation/ClearDiagnosticInformationTest.cpp
@@ -1,0 +1,146 @@
+/********************************************************************************
+ * Copyright (c) 2026 BMW AG
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "uds/services/cleardiagnosticinformation/ClearDiagnosticInformation.h"
+
+#include "uds/connection/IncomingDiagConnectionMock.h"
+#include "uds/session/ApplicationDefaultSession.h"
+#include "uds/session/DiagSessionManagerMock.h"
+
+#include <transport/TransportMessageWithBuffer.h>
+
+#include <gmock/gmock.h>
+
+namespace
+{
+using namespace ::uds;
+using namespace ::testing;
+using namespace ::transport::test;
+
+class ClearDiagnosticInformationTest : public ::testing::Test
+{
+public:
+    ClearDiagnosticInformationTest()
+    : fClearDiagnosticInformation()
+    , fIncomingDiagConnection(::async::CONTEXT_INVALID)
+    , fSessionManager()
+    {}
+
+    virtual void SetUp()
+    {
+        fClearDiagnosticInformation.setDefaultDiagSessionManager(fSessionManager);
+    }
+
+protected:
+    ClearDiagnosticInformation fClearDiagnosticInformation;
+    StrictMock<IncomingDiagConnectionMock> fIncomingDiagConnection;
+    StrictMock<DiagSessionManagerMock> fSessionManager;
+};
+
+TEST_F(ClearDiagnosticInformationTest, execute_with_group_all_dtcs_should_return_DiagReturnCode_OK)
+{
+    uint8_t request[] = {
+        0x14U, // ClearDiagnosticInformation SID
+        0xFFU, // groupOfDTC high byte
+        0xFFU, // groupOfDTC middle byte
+        0xFFU  // groupOfDTC low byte
+    };
+
+    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+
+    fIncomingDiagConnection.requestMessage = pRequest.get();
+
+    EXPECT_CALL(fSessionManager, getActiveSession())
+        .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
+
+    EXPECT_CALL(fSessionManager, acceptedJob(_, _, _, _))
+        .WillRepeatedly(Return(uds::DiagReturnCode::OK));
+
+    EXPECT_EQ(
+        DiagReturnCode::OK,
+        fClearDiagnosticInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+}
+
+TEST_F(
+    ClearDiagnosticInformationTest,
+    execute_with_unsupported_group_should_return_ISO_REQUEST_OUT_OF_RANGE)
+{
+    uint8_t request[] = {
+        0x14U, // ClearDiagnosticInformation SID
+        0x12U, // groupOfDTC high byte
+        0x34U, // groupOfDTC middle byte
+        0x56U  // groupOfDTC low byte
+    };
+
+    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+
+    fIncomingDiagConnection.requestMessage = pRequest.get();
+
+    EXPECT_CALL(fSessionManager, getActiveSession())
+        .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
+
+    EXPECT_CALL(fSessionManager, acceptedJob(_, _, _, _))
+        .WillRepeatedly(Return(uds::DiagReturnCode::OK));
+
+    EXPECT_EQ(
+        DiagReturnCode::ISO_REQUEST_OUT_OF_RANGE,
+        fClearDiagnosticInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+}
+
+TEST_F(
+    ClearDiagnosticInformationTest,
+    execute_with_powertrain_group_should_return_ISO_REQUEST_OUT_OF_RANGE)
+{
+    uint8_t request[] = {
+        0x14U, // ClearDiagnosticInformation SID
+        0x00U, // groupOfDTC high byte
+        0x00U, // groupOfDTC middle byte
+        0x00U  // groupOfDTC low byte
+    };
+
+    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+
+    fIncomingDiagConnection.requestMessage = pRequest.get();
+
+    EXPECT_CALL(fSessionManager, getActiveSession())
+        .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
+
+    EXPECT_CALL(fSessionManager, acceptedJob(_, _, _, _))
+        .WillRepeatedly(Return(uds::DiagReturnCode::OK));
+
+    EXPECT_EQ(
+        DiagReturnCode::ISO_REQUEST_OUT_OF_RANGE,
+        fClearDiagnosticInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+}
+
+TEST_F(ClearDiagnosticInformationTest, execute_with_invalid_length_should_return_ISO_INVALID_FORMAT)
+{
+    uint8_t request[] = {
+        0x14U, // ClearDiagnosticInformation SID
+        0xFFU, // groupOfDTC high byte
+        0xFFU  // groupOfDTC middle byte (low byte missing)
+    };
+
+    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+
+    fIncomingDiagConnection.requestMessage = pRequest.get();
+
+    EXPECT_CALL(fSessionManager, getActiveSession())
+        .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
+
+    EXPECT_CALL(fSessionManager, acceptedJob(_, _, _, _))
+        .WillRepeatedly(Return(uds::DiagReturnCode::OK));
+
+    EXPECT_EQ(
+        DiagReturnCode::ISO_INVALID_FORMAT,
+        fClearDiagnosticInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+}
+
+} // anonymous namespace


### PR DESCRIPTION
**Add UDS service ClearDiagnosticInformation (0x14)**

Add the UDS service 0x14 (ClearDiagnosticInformation) to enable
requesting clearing of DTCs. The actual clearing of DTCs is
project-specific and must be provided by the integrator separately.
This commit therefore adds only:

- a demo implementation of the service in the library which handles:
-- groupOfDTC 0xFFFFFF (all DTCs) returns a positive response
-- any other group returns NRC 0x31 (requestOutOfRange)
-- the fixed request length of 4 bytes is validated by the framework
- registration of the service in the reference application
- unit tests covering the supported groupOfDTC cases