### PR TITLE
Use minimal cache mode for docker image

### DIFF
--- a/.github/actions/setup-docker-env/action.yml
+++ b/.github/actions/setup-docker-env/action.yml
@@ -25,7 +25,7 @@ runs:
         tags: openbsw-development:local
         outputs: type=docker
         cache-from: type=gha
-        cache-to: type=gha,mode=max,ignore-error=true
+        cache-to: type=gha,mode=min,ignore-error=true
 
     - name: Create Bazel cache directories
       shell: bash


### PR DESCRIPTION
Currently, the GitHub actions cache is not big enough to hold all data for our image build. Maybe changing the mode from max to min will solve the issue by reducing the needed storage space. In contrast to max, this only stores the layers that finally go into the image and skip intermediate ones. As long as we do not get more storage space for the GHA cache, this might be a compromise.