### PR TITLE
Migrate transport, transportRouterSimple and uds to Bazel

### DIFF
--- a/executables/referenceApp/transportConfiguration/BUILD.bazel
+++ b/executables/referenceApp/transportConfiguration/BUILD.bazel
@@ -1,0 +1,23 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "transport_configuration",
+    srcs = ["src/transport/TransportConfiguration.cpp"],
+    hdrs = ["include/transport/TransportConfiguration.h"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/etl",
+        "//libs/bsw/transport",
+    ],
+)

--- a/executables/referenceApp/udsConfiguration/BUILD.bazel
+++ b/executables/referenceApp/udsConfiguration/BUILD.bazel
@@ -1,0 +1,35 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "uds_configuration",
+    hdrs = [
+        "include/uds/DummySessionPersistence.h",
+        "include/uds/UdsConfig.h",
+        "include/uds/UdsLifecycleConnector.h",
+        "include/uds/session/DiagSession.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/bsw/common:common_headers",
+        "//libs/bsw/uds:uds_headers",
+    ],
+)
+
+cc_library(
+    name = "uds_configuration_impl",
+    srcs = ["src/uds/session/DiagSession.cpp"],
+    implementation_deps = ["//libs/bsw/uds"],
+    visibility = ["//visibility:public"],
+    deps = [":uds_configuration"],
+)

--- a/libs/bsw/transport/BUILD.bazel
+++ b/libs/bsw/transport/BUILD.bazel
@@ -1,0 +1,41 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "transport",
+    srcs = [
+        "src/AbstractTransportLayer.cpp",
+        "src/LogicalAddress.cpp",
+        "src/TransportLogger.cpp",
+        "src/TransportMessage.cpp",
+    ],
+    hdrs = [
+        "include/transport/AbstractTransportLayer.h",
+        "include/transport/BufferedTransportMessage.h",
+        "include/transport/ITransportMessageListener.h",
+        "include/transport/ITransportMessageProcessedListener.h",
+        "include/transport/ITransportMessageProvider.h",
+        "include/transport/ITransportMessageProvidingListener.h",
+        "include/transport/LogicalAddress.h",
+        "include/transport/TransportLogger.h",
+        "include/transport/TransportMessage.h",
+        "include/transport/TransportMessageSendJob.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/etl",
+        "//libs/bsw/async",
+        "//libs/bsw/common",
+        "//libs/bsw/util",
+    ],
+)

--- a/libs/bsw/transportRouterSimple/BUILD.bazel
+++ b/libs/bsw/transportRouterSimple/BUILD.bazel
@@ -1,0 +1,32 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "transport_router_simple",
+    srcs = [
+        "src/transport/TpRouterLogger.cpp",
+        "src/transport/routing/TransportRouterSimple.cpp",
+    ],
+    hdrs = [
+        "include/transport/TpRouterLogger.h",
+        "include/transport/routing/TransportRouterSimple.h",
+    ],
+    implementation_deps = [
+        "//libs/bsw/common:configuration",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//executables/referenceApp/transportConfiguration:transport_configuration",
+        "//libs/bsw/transport",
+    ],
+)

--- a/libs/bsw/uds/BUILD.bazel
+++ b/libs/bsw/uds/BUILD.bazel
@@ -1,0 +1,40 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# Circular dependency present on the CMake side: uds -> udsConfiguration -> uds
+# Split off uds_headers to break the circular dependency for Bazel
+cc_library(
+    name = "uds_headers",
+    hdrs = glob(["include/**/*.h"]),
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/etl",
+        "//libs/bsw/async:async_headers",
+        "//libs/bsw/transport",
+        "//libs/bsw/util",
+    ],
+)
+
+cc_library(
+    name = "uds",
+    srcs = glob(["src/**/*.cpp"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":uds_headers",
+        "//executables/referenceApp/transportConfiguration:transport_configuration",
+        "//executables/referenceApp/udsConfiguration:uds_configuration",
+        "//libs/bsw/async",
+        "//libs/bsw/bsp",
+        "//libs/bsw/common:configuration",
+    ],
+)


### PR DESCRIPTION
Migrate transport, transportRouterSimple and uds to Bazel

- libs/bsw/transport: transport cc_library
- libs/bsw/transportRouterSimple: transport_router_simple cc_library
- libs/bsw/uds: uds_headers cycle-break split, uds cc_library
- executables/referenceApp/transportConfiguration: transport_configuration
  cc_library
- executables/referenceApp/udsConfiguration: uds_configuration,
  uds_configuration_impl cc_libraries
