### PR TITLE
Migrate ThreadX RTOS to Bazel build system

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,5 +8,6 @@ build:s32k148_relwithdebinfo --config=s32k148
 build:s32k148_relwithdebinfo --copt=-g3
 build:s32k148_relwithdebinfo --copt=-O2
 build:s32k148_relwithdebinfo --copt=-DNDEBUG
-
+build:s32k148_threadx --config=s32k148
+build:s32k148_threadx --//bazel/config/rtos=threadx
 test --//bazel/config/executable_config=unit_test

--- a/executables/referenceApp/platforms/posix/main/BUILD.bazel
+++ b/executables/referenceApp/platforms/posix/main/BUILD.bazel
@@ -12,8 +12,24 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(
     name = "freertos_os_hooks",
-    srcs = ["src/osHooks/freertos/osHooks.cpp"],
+    srcs = [
+        "src/osHooks/freertos/osHooks.cpp",
+    ],
+    implementation_deps = [
+        "//libs/3rdparty/freeRtos:freertos_headers",
+    ],
     target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//libs/3rdparty/freeRtos:__pkg__"],
-    deps = ["//libs/3rdparty/freeRtos:freertos_headers"],
+)
+
+cc_library(
+    name = "threadx_os_hooks",
+    srcs = [
+        "src/osHooks/threadx/osHooks.cpp",
+    ],
+    implementation_deps = [
+        "//libs/3rdparty/threadx:threadx_headers",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//libs/3rdparty/threadx:__pkg__"],
 )

--- a/executables/referenceApp/platforms/posix/threadXCoreConfiguration/BUILD.bazel
+++ b/executables/referenceApp/platforms/posix/threadXCoreConfiguration/BUILD.bazel
@@ -1,0 +1,18 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "threadx_core_configuration",
+    hdrs = ["include/tx_user.h"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)

--- a/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
@@ -12,11 +12,32 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(
     name = "freertos_os_hooks",
-    srcs = ["src/osHooks/freertos/osHooks.cpp"],
-    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
-    visibility = ["//libs/3rdparty/freeRtos:__pkg__"],
-    deps = [
+    srcs = [
+        "src/osHooks/freertos/osHooks.cpp",
+    ],
+    implementation_deps = [
         "//libs/3rdparty/freeRtos:freertos_headers",
         "//libs/bsw/common",
     ],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//libs/3rdparty/freeRtos:__pkg__"],
+)
+
+cc_library(
+    name = "threadx_os_hooks",
+    srcs = [
+        "src/osHooks/threadx/osHooks.cpp",
+    ],
+    hdrs = [
+        "include/osHooks/threadx/osHooks.h",
+    ],
+    implementation_deps = [
+        "//libs/3rdparty/threadx:threadx_headers",
+        "//libs/bsw/asyncThreadX:threadx_configuration",
+        "//libs/bsw/common",
+        "//platforms/s32k1xx/3rdparty/threadx:threadx_cortex_m4",
+    ],
+    strip_include_prefix = "include/osHooks/threadx",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//libs/3rdparty/threadx:__pkg__"],
 )

--- a/executables/referenceApp/platforms/s32k148evb/threadXCoreConfiguration/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/threadXCoreConfiguration/BUILD.bazel
@@ -1,0 +1,19 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "threadx_core_configuration",
+    hdrs = ["include/tx_user.h"],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+)

--- a/libs/3rdparty/threadx/BUILD.bazel
+++ b/libs/3rdparty/threadx/BUILD.bazel
@@ -1,0 +1,99 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+alias(
+    name = "threadx_port_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints/soc:s32k148": "//platforms/s32k1xx/3rdparty/threadx:threadx_cortex_m4_port_headers",
+            "@platforms//os:linux": "//platforms/posix/3rdparty/threadx:threadx_linux_port_headers",
+        },
+        no_match_error = "No ThreadX port for this platform. Override --//libs/3rdparty/threadx:threadx_port_headers with your own port target.",
+    ),
+)
+
+# ThreadX port (tx_port.h).
+#   Default:  select based on the target platform (S32K148, POSIX)
+#   Override: --//libs/3rdparty/threadx:threadx_port_headers=//path/to:your_port_headers
+label_flag(
+    name = "threadx_port_headers",
+    build_setting_default = ":threadx_port_default",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "threadx_port_impl_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints/soc:s32k148": "//platforms/s32k1xx/3rdparty/threadx:threadx_cortex_m4",
+            "@platforms//os:linux": "//platforms/posix/3rdparty/threadx:threadx_linux",
+        },
+        no_match_error = "No ThreadX port implementation for this platform. Override --//libs/3rdparty/threadx:threadx_port_impl with your own port target.",
+    ),
+)
+
+# ThreadX port implementation
+#   Default:  select based on the target platform (S32K148, POSIX)
+#   Override: --//libs/3rdparty/threadx:threadx_port_impl=//path/to:your_port_impl
+label_flag(
+    name = "threadx_port_impl",
+    build_setting_default = ":threadx_port_impl_default",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "threadx_os_hooks_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints/soc:s32k148": "//executables/referenceApp/platforms/s32k148evb/main:threadx_os_hooks",
+            "@platforms//os:linux": "//executables/referenceApp/platforms/posix/main:threadx_os_hooks",
+        },
+        no_match_error = "No ThreadX OS hooks for this platform. Override --//libs/3rdparty/threadx:threadx_os_hooks with your own hooks target.",
+    ),
+)
+
+# ThreadX OS hooks
+#   Default:  select based on the target platform (S32K148, POSIX)
+#   Override: --//libs/3rdparty/threadx:threadx_os_hooks=//path/to:your_os_hooks
+label_flag(
+    name = "threadx_os_hooks",
+    build_setting_default = ":threadx_os_hooks_default",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "threadx_headers",
+    hdrs = glob(["common/inc/**/*.h"]),
+    includes = ["common/inc"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":threadx_port_headers",
+        "//libs/bsw/asyncThreadX:threadx_configuration",
+    ],
+)
+
+# Circular dependency present on the CMake side: threadX -> osHooks -> asyncThreadX -> threadX
+# Split off threadx_headers to break the circular dependency for Bazel
+cc_library(
+    name = "threadx",
+    srcs = glob(["common/src/*.c"]),
+    copts = ["-Wno-error=unused-parameter"],
+    implementation_deps = [
+        ":threadx_os_hooks",
+        ":threadx_port_impl",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":threadx_headers",
+        "//libs/bsw/platform",
+    ],
+)

--- a/libs/bsw/async/BUILD.bazel
+++ b/libs/bsw/async/BUILD.bazel
@@ -11,13 +11,33 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 alias(
+    name = "async_rtos_impl_default",
+    actual = select(
+        {
+            "//bazel/config/rtos:support_freertos": "//libs/bsw/asyncFreeRtos:async_freertos_impl",
+            "//bazel/config/rtos:support_threadx": "//libs/bsw/asyncThreadX:async_threadx_impl",
+        },
+        no_match_error = "async_rtos_impl: build with --//bazel/config/rtos=freertos or --//bazel/config/rtos=threadx, or override --//libs/bsw/async:async_rtos_impl.",
+    ),
+)
+
+# Async compiled RTOS implementation
+#   Default:  select based on //bazel/config/rtos
+#   Override: --//libs/bsw/async:async_rtos_impl=//path/to:your_rtos_impl
+label_flag(
+    name = "async_rtos_impl",
+    build_setting_default = ":async_rtos_impl_default",
+    visibility = ["//visibility:public"],
+)
+
+alias(
     name = "async_platform_default",
     actual = select(
         {
             "//bazel/config/rtos:support_freertos": "//libs/bsw/asyncFreeRtos:async_freertos",
-            # TODO: Add  threadX support here once libs/3rdparty/threadx has been migrated
+            "//bazel/config/rtos:support_threadx": "//libs/bsw/asyncThreadX:async_threadx",
         },
-        no_match_error = "async: only the FREERTOS asyncPlatform is migrated; build with --//bazel/config/rtos=freertos (ThreadX deferred), or override --//libs/bsw/async:async_platform.",
+        no_match_error = "async: build with --//bazel/config/rtos=freertos or --//bazel/config/rtos=threadx, or override --//libs/bsw/async:async_platform.",
     ),
 )
 

--- a/libs/bsw/asyncThreadX/BUILD.bazel
+++ b/libs/bsw/asyncThreadX/BUILD.bazel
@@ -1,0 +1,91 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+alias(
+    name = "threadx_core_configuration_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints/soc:s32k148": "//executables/referenceApp/platforms/s32k148evb/threadXCoreConfiguration:threadx_core_configuration",
+            "@platforms//os:linux": "//executables/referenceApp/platforms/posix/threadXCoreConfiguration:threadx_core_configuration",
+        },
+        no_match_error = "No ThreadX core configuration for this platform. Override --//libs/bsw/asyncThreadX:threadx_core_configuration with your own configuration target.",
+    ),
+)
+
+# ThreadX core configuration (Hook.h, ThreadCConfig.h and platform wiring).
+#   Default:  select based on the target platform (S32K148, POSIX)
+#   Override: --//libs/bsw/asyncThreadX:threadx_core_configuration=//path/to:your_config
+label_flag(
+    name = "threadx_core_configuration",
+    build_setting_default = ":threadx_core_configuration_default",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "async_threadx",
+    hdrs = glob(["include/**/*.h"]),
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/threadx",
+        "//libs/bsp/bspInterrupts:bsp_interrupts_impl",
+        "//libs/bsw/asyncImpl:async_impl",
+        "//libs/bsw/bsp",
+        "//libs/bsw/common",
+        "//libs/bsw/timer",
+    ],
+)
+
+# Async core configuration (provides tx_user.h and platform-specific async config).
+#   Default:  referenceApp asyncCoreConfiguration
+#   Override: --//libs/bsw/asyncThreadX:async_core_configuration=//path/to:your_config
+# TODO: Select based on executable_config once unit_test build is migrated.
+label_flag(
+    name = "async_core_configuration",
+    build_setting_default = "//executables/referenceApp/asyncCoreConfiguration:async_core_configuration",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "threadx_configuration",
+    hdrs = [
+        "threadXConfiguration/ThreadXConfig.h",
+        "threadXConfiguration/async/Hook.h",
+    ],
+    strip_include_prefix = "threadXConfiguration",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":async_core_configuration",
+        ":threadx_core_configuration",
+        "//libs/bsw/platform",
+    ],
+)
+
+cc_library(
+    name = "async_threadx_impl",
+    srcs = [
+        "src/async/FutureSupport.cpp",
+        "src/async/Types.cpp",
+    ],
+    implementation_deps = [
+        ":async_threadx",
+        ":threadx_configuration",
+        "//libs/3rdparty/etl",
+        "//libs/bsw/async:async_binding",
+        "//libs/bsw/util",
+    ],
+    target_compatible_with = select({
+        "//bazel/config/rtos:support_threadx": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/libs/bsw/storage/BUILD.bazel
+++ b/libs/bsw/storage/BUILD.bazel
@@ -10,14 +10,14 @@
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
-# TODO: Add asyncThreadXImpl branch once ThreadX has been migrated.
 alias(
     name = "storage_rtos_impl",
     actual = select(
         {
             "//bazel/config/rtos:support_freertos": "//libs/bsw/asyncFreeRtos:async_freertos_impl",
+            "//bazel/config/rtos:support_threadx": "//libs/bsw/asyncThreadX:async_threadx_impl",
         },
-        no_match_error = "storage: asyncFreeRtosImpl only migrated for FreeRTOS; build with --//bazel/config/rtos=freertos (ThreadX deferred).",
+        no_match_error = "storage: build with --//bazel/config/rtos=freertos or --//bazel/config/rtos=threadx.",
     ),
 )
 

--- a/platforms/posix/3rdparty/freeRtosPosix/BUILD.bazel
+++ b/platforms/posix/3rdparty/freeRtosPosix/BUILD.bazel
@@ -1,3 +1,13 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(

--- a/platforms/posix/3rdparty/threadx/BUILD.bazel
+++ b/platforms/posix/3rdparty/threadx/BUILD.bazel
@@ -1,0 +1,54 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "threadx_linux",
+    srcs = [
+        "ports/linux/gnu/src/tx_initialize_low_level.c",
+        "ports/linux/gnu/src/tx_thread_context_restore.c",
+        "ports/linux/gnu/src/tx_thread_context_save.c",
+        "ports/linux/gnu/src/tx_thread_interrupt_control.c",
+        "ports/linux/gnu/src/tx_thread_schedule.c",
+        "ports/linux/gnu/src/tx_thread_stack_build.c",
+        "ports/linux/gnu/src/tx_thread_system_return.c",
+        "ports/linux/gnu/src/tx_timer_interrupt.c",
+    ],
+    copts = ["--warn-no-unused-result"],
+    linkopts = ["-lpthread"],
+    local_defines = ["TX_INCLUDE_USER_DEFINE_FILE"],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/threadx:threadx_headers",
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//libs/bsw/asyncThreadX:threadx_core_configuration",
+    ],
+)
+
+cc_library(
+    name = "threadx_linux_port_headers",
+    hdrs = [
+        "ports/linux/gnu/inc/tx_port.h",
+    ],
+    defines = [
+        "TX_INCLUDE_USER_DEFINE_FILE",
+        "_GNU_SOURCE",
+        "TX_LINUX_DEBUG_ENABLE",
+    ],
+    linkopts = ["-lpthread"],
+    strip_include_prefix = "ports/linux/gnu/inc",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/bsw/asyncThreadX:threadx_core_configuration",
+    ],
+)

--- a/platforms/posix/bsp/bspInterruptsImpl/BUILD.bazel
+++ b/platforms/posix/bsp/bspInterruptsImpl/BUILD.bazel
@@ -11,13 +11,48 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(
-    name = "bsp_interrupts_impl",
-    srcs = ["freertos/src/interrupts/suspendResumeAllInterrupts.cpp"],
-    hdrs = ["freertos/include/interrupts/suspendResumeAllInterrupts.h"],
-    strip_include_prefix = "freertos/include",
-    visibility = ["//visibility:public"],
-    deps = [
+    name = "bsp_interrupts_impl_freertos",
+    srcs = [
+        "freertos/src/interrupts/suspendResumeAllInterrupts.cpp",
+    ],
+    hdrs = [
+        "freertos/include/interrupts/suspendResumeAllInterrupts.h",
+    ],
+    implementation_deps = [
         "//libs/3rdparty/freeRtos:freertos_headers",
+    ],
+    strip_include_prefix = "freertos/include",
+    deps = [
         "//libs/bsw/platform",
     ],
+)
+
+cc_library(
+    name = "bsp_interrupts_impl_threadx",
+    srcs = [
+        "threadx/src/interrupts/suspendResumeAllInterrupts.cpp",
+    ],
+    hdrs = [
+        "threadx/include/interrupts/suspendResumeAllInterrupts.h",
+    ],
+    implementation_deps = [
+        "//libs/3rdparty/threadx:threadx_headers",
+    ],
+    strip_include_prefix = "threadx/include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/bsw/platform",
+    ],
+)
+
+alias(
+    name = "bsp_interrupts_impl",
+    actual = select(
+        {
+            "//bazel/config/rtos:support_freertos": ":bsp_interrupts_impl_freertos",
+            "//bazel/config/rtos:support_threadx": ":bsp_interrupts_impl_threadx",
+        },
+        no_match_error = "bsp_interrupts_impl: build with --//bazel/config/rtos=freertos or --//bazel/config/rtos=threadx.",
+    ),
+    visibility = ["//visibility:public"],
 )

--- a/platforms/s32k1xx/3rdparty/freertos_cm4_sysTick/BUILD.bazel
+++ b/platforms/s32k1xx/3rdparty/freertos_cm4_sysTick/BUILD.bazel
@@ -1,3 +1,13 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(

--- a/platforms/s32k1xx/3rdparty/threadx/BUILD.bazel
+++ b/platforms/s32k1xx/3rdparty/threadx/BUILD.bazel
@@ -1,0 +1,46 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "threadx_cortex_m4",
+    srcs = [
+        "ports/cortex_m4/gnu/src/tx_thread_context_restore.S",
+        "ports/cortex_m4/gnu/src/tx_thread_context_save.S",
+        "ports/cortex_m4/gnu/src/tx_thread_interrupt_control.S",
+        "ports/cortex_m4/gnu/src/tx_thread_schedule.S",
+        "ports/cortex_m4/gnu/src/tx_thread_stack_build.S",
+        "ports/cortex_m4/gnu/src/tx_thread_system_return.S",
+        "ports/cortex_m4/gnu/src/tx_timer_interrupt.S",
+    ],
+    local_defines = ["TX_INCLUDE_USER_DEFINE_FILE"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/threadx:threadx_headers",
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//libs/bsw/asyncThreadX:threadx_core_configuration",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+    ],
+)
+
+cc_library(
+    name = "threadx_cortex_m4_port_headers",
+    hdrs = [
+        "ports/cortex_m4/gnu/inc/tx_port.h",
+    ],
+    defines = ["TX_INCLUDE_USER_DEFINE_FILE"],
+    strip_include_prefix = "ports/cortex_m4/gnu/inc",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/bsw/asyncThreadX:threadx_core_configuration",
+    ],
+)

--- a/platforms/s32k1xx/bsp/bspInterruptsImpl/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspInterruptsImpl/BUILD.bazel
@@ -23,14 +23,23 @@ cc_library(
     target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
 )
 
+cc_library(
+    name = "bsp_interrupts_impl_threadx_hdrs",
+    hdrs = ["threadx/include/interrupts/suspendResumeAllInterrupts.h"],
+    strip_include_prefix = "threadx/include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = ["//libs/3rdparty/threadx:threadx_headers"],
+)
+
 alias(
     name = "bsp_interrupts_impl_rtos_hdrs",
     actual = select(
         {
             "//bazel/config/rtos:support_freertos": ":bsp_interrupts_impl_freertos_hdrs",
-            # TODO: add a "//bazel/config/rtos:support_threadx" branch once ThreadX is migrated.
+            "//bazel/config/rtos:support_threadx": ":bsp_interrupts_impl_threadx_hdrs",
         },
-        no_match_error = "s32k1xx bsp_interrupts_impl supports only --//bazel/config/rtos=freertos; ThreadX is not yet migrated.",
+        no_match_error = "s32k1xx bsp_interrupts_impl supports only --//bazel/config/rtos=freertos or --//bazel/config/rtos=threadx.",
     ),
 )
 


### PR DESCRIPTION
Migrate ThreadX RTOS to Bazel build system

New BUILD files:
- libs/3rdparty/threadx: Core ThreadX library with label_flags for
  port, port_impl, os_hooks and core_configuration selection
- libs/bsw/asyncThreadX: async_threadx, async_threadx_impl and
  threadx_configuration targets with threadx_core_configuration
  label_flag
- platforms/s32k1xx/3rdparty/threadx: Cortex-M4 port implementation and port headers for s32k148
- platforms/posix/3rdparty/threadx: Linux port implementation and
  port headers for POSIX
- executables/referenceApp/platforms/s32k148evb/main: threadx_os_hooks
- executables/referenceApp/platforms/s32k148evb/threadXCoreConfiguration
- executables/referenceApp/platforms/posix/threadXCoreConfiguration

Modified BUILD files:
- libs/bsw/async: Added support_threadx branch to async_platform_default
- platforms/s32k1xx/bsp/bspInterruptsImpl: Added threadx RTOS headers
  and wired into bsp_interrupts_impl_rtos_hdrs alias
- platforms/posix/bsp/bspInterruptsImpl: Added threadx variant

Key Bazel patterns used:
- - label_flag + alias + select() for platform/RTOS-specific selection
- target_compatible_with to restrict platform-specific targets
- async_threadx_impl and async_freertos_impl marked incompatible for
  opposite RTOS configs to prevent build failures in bazel build //...
- Circular dependency threadX -> osHooks -> asyncThreadX -> threadX
  broken by depending on threadx_headers instead of threadx

Added --config=s32k148_threadx to .bazelrc combining s32k148 platform
and threadx RTOS flag. 