### PR TITLE
refactor(Middleware): return payload by const reference

### DIFF
--- a/libs/bsw/middleware/include/middleware/core/FutureDispatcher.h
+++ b/libs/bsw/middleware/include/middleware/core/FutureDispatcher.h
@@ -19,7 +19,7 @@
 #include <etl/array.h>
 #include <etl/delegate.h>
 #include <etl/expected.h>
-#include <etl/tuple.h>
+#include <etl/functional.h>
 #include <etl/vector.h>
 
 #include <cstdint>
@@ -57,7 +57,8 @@ struct CallbackHelper;
 template<typename ArgumentType>
 struct CallbackHelper<ArgumentType, etl::enable_if_t<(etl::is_void<ArgumentType>::value == false)>>
 {
-    using Callback = ::etl::delegate<void(etl::expected<ArgumentType, Future::State> const&)>;
+    using Result   = ::etl::expected<etl::reference_wrapper<ArgumentType const>, Future::State>;
+    using Callback = ::etl::delegate<void(Result const&)>;
 
     static void call(Callback const& callback, Message const& msg, Future::State const state)
     {
@@ -67,9 +68,9 @@ struct CallbackHelper<ArgumentType, etl::enable_if_t<(etl::is_void<ArgumentType>
         }
         else
         {
-            callback.call_if(etl::expected<ArgumentType, Future::State>(
+            callback.call_if(Result(
                 etl::in_place_t{},
-                MessagePayloadBuilder::getInstance().readPayload<ArgumentType>(msg)));
+                etl::cref(MessagePayloadBuilder::getInstance().readPayload<ArgumentType>(msg))));
         }
     }
 };
@@ -80,7 +81,8 @@ struct CallbackHelper<ArgumentType, etl::enable_if_t<(etl::is_void<ArgumentType>
 template<typename ArgumentType>
 struct CallbackHelper<ArgumentType, etl::enable_if_t<etl::is_void<ArgumentType>::value>>
 {
-    using Callback = ::etl::delegate<void(etl::expected<void, Future::State> const&&)>;
+    using Result   = etl::expected<void, Future::State>;
+    using Callback = ::etl::delegate<void(Result const&)>;
 
     static void call(Callback const& callback, Message const& /* msg */, Future::State const state)
     {
@@ -113,6 +115,7 @@ public:
     using Base         = FutureDispatcherBase;
     using ArgumentType = typename DispatcherTraits::ArgumentType;
     using Traits       = DispatcherTraits;
+    using Result       = typename internal::CallbackHelper<ArgumentType>::Result;
     using Callback     = typename internal::CallbackHelper<ArgumentType>::Callback;
 
     FutureDispatcher()

--- a/libs/bsw/middleware/include/middleware/core/Message.h
+++ b/libs/bsw/middleware/include/middleware/core/Message.h
@@ -199,8 +199,8 @@ public:
     }
 
     /**
-     * Create an error response message that originates from a skeleton and is targetted to a
-     * unique proxy, and sets the payload with value \param error.
+     * Create an error response message that originates from a skeleton and is targeted to a
+     * unique proxy, and sets the payload with \param error value.
      */
     static constexpr Message createErrorResponse(
         uint16_t const serviceId,

--- a/libs/bsw/middleware/include/middleware/core/MessagePayloadBuilder.h
+++ b/libs/bsw/middleware/include/middleware/core/MessagePayloadBuilder.h
@@ -10,12 +10,13 @@
 
 #pragma once
 
+#include "middleware/core/LoggerApi.h"
 #include "middleware/core/Message.h"
 #include "middleware/core/types.h"
+#include "middleware/memory/AllocatorSelector.h"
 
 #include <etl/iterator.h>
 #include <etl/memory.h>
-#include <etl/optional.h>
 #include <etl/span.h>
 #include <etl/type_traits.h>
 
@@ -40,10 +41,10 @@ public:
 
     /**
      * Allocates space for \p obj in the message payload.
-     * Chooses internal or external allocation based on whether T is trivially copyable
-     * and whether it fits in the internal buffer.
+     * Stores \p obj in the message's internal buffer when it fits, otherwise copy-constructs
+     * it into externally allocated memory.
      *
-     * \tparam T Payload type
+     * \tparam T Payload type (must be copy-constructible)
      * \param obj The object to allocate
      * \param msg The message to store the payload in
      * \param numberOfReferences Number of references sharing this payload (1 = unique)
@@ -53,76 +54,54 @@ public:
     [[nodiscard]] HRESULT
     allocate(T const& obj, Message& msg, uint8_t const numberOfReferences = 1U)
     {
-        if constexpr (!etl::is_trivially_copyable_v<T>)
-        {
-            HRESULT ret = HRESULT::CannotAllocatePayload;
+        static_assert(etl::is_copy_constructible_v<T>, "T must be copy-constructible");
+        static_assert(!etl::is_span_v<T>, "Use the span overload to allocate bytes");
 
-            size_t const payloadSize = T::AllocationPolicy::getNeededSize(obj);
-            etl::optional<etl::span<uint8_t>> buffer
-                = allocateNonTrivialType(payloadSize, msg, numberOfReferences);
-            if (buffer.has_value())
-            {
-                T::AllocationPolicy::serialize(obj, buffer.value());
-                ret = HRESULT::Ok;
-            }
-
-            return ret;
-        }
-        else if constexpr (sizeof(T) <= Message::MAX_PAYLOAD_SIZE)
+        if constexpr (sizeof(T) <= Message::MAX_PAYLOAD_SIZE)
         {
             msg.constructObjectAtPayload(obj);
             return HRESULT::Ok;
         }
         else
         {
-            return allocateTrivialType(&obj, sizeof(obj), msg, numberOfReferences);
+            return emplaceExternalPayload(obj, msg, numberOfReferences);
         }
     }
 
     /**
      * Specialization for byte spans to copy the span's data contents.
      *
-     * \param span Span of bytes to copy into the message
+     * \param src Span of bytes to copy into the message
      * \param msg The message to store the payload in
      * \param numberOfReferences Number of shared references
      * \return HRESULT indicating success or failure
      */
-    [[nodiscard]] HRESULT allocate(
-        etl::span<uint8_t const> const span, Message& msg, uint8_t const numberOfReferences = 1U)
-    {
-        if (span.size_bytes() <= Message::MAX_PAYLOAD_SIZE)
-        {
-            msg.copyRawBytesToPayload(span);
-            return HRESULT::Ok;
-        }
-        return allocateTrivialType(span.data(), span.size_bytes(), msg, numberOfReferences);
-    }
+    [[nodiscard]] static HRESULT
+    allocate(etl::span<uint8_t const> src, Message& msg, uint8_t numberOfReferences = 1U);
 
     /**
      * Reads an object of type T from the content of \p msg.
      *
+     * Returns a const reference directly into the middleware-managed buffer. The caller must
+     * consume the reference before the message is deallocated, as the middleware reclaims the
+     * buffer immediately after dispatch.
+     *
      * \tparam T The payload type to read
      * \param msg The message containing the payload
-     * \return The deserialized object
+     * \return A const reference to the object stored in the payload
      */
     template<typename T>
-    T readPayload(Message const& msg)
+    static T const& readPayload(Message const& msg)
     {
-        if constexpr (!etl::is_trivially_copyable_v<T>)
-        {
-            uint8_t* ptr = getAllocatorPointerFromMessage(msg);
-            T obj = T::AllocationPolicy::deserialize(etl::span<uint8_t>(ptr, msg.getPayloadSize()));
+        static_assert(!etl::is_span_v<T>, "Use readRawPayload() to read bytes");
 
-            return obj;
-        }
-        else if constexpr (sizeof(T) <= Message::MAX_PAYLOAD_SIZE)
+        if constexpr (sizeof(T) <= Message::MAX_PAYLOAD_SIZE)
         {
             return msg.getObjectStoredInPayload<T>();
         }
         else
         {
-            uint8_t* ptr = getAllocatorPointerFromMessage(msg);
-            return etl::get_object_at<T>(ptr);
+            return etl::get_object_at<T const>(getAllocatorPointerFromMessage(msg));
         }
     }
 
@@ -165,13 +144,61 @@ public:
     static MessagePayloadBuilder& getInstance() { return _instance; }
 
 private:
-    static HRESULT allocateTrivialType(
-        void const* objPtr, size_t objSize, Message& msg, uint8_t numberOfReferences);
-
-    static etl::optional<etl::span<uint8_t>>
-    allocateNonTrivialType(size_t payloadSize, Message& msg, uint8_t numberOfReferences);
+    /**
+     * Allocates space on the middleware allocators for a byte span by copying bytes.
+     *
+     * \param src Span of bytes to copy
+     * \param msg Reference to the middleware message
+     * \param numberOfReferences Number of references to the allocation
+     * \return HRESULT
+     */
+    static HRESULT allocAndCopyBytesToExternalPayload(
+        etl::span<uint8_t const> src, Message& msg, uint8_t numberOfReferences);
 
     static uint8_t* getAllocatorPointerFromMessage(Message const& msg);
+
+    /**
+     * Emplaces an object of type T into externally allocated memory using placement new.
+     *
+     * \tparam T Must be copy-constructible
+     * \param obj Object to copy-construct into the allocation
+     * \param msg Reference to the middleware message
+     * \param numberOfReferences Number of shared references
+     * \return HRESULT
+     */
+    template<typename T>
+    [[nodiscard]] HRESULT
+    emplaceExternalPayload(T const& obj, Message& msg, uint8_t const numberOfReferences)
+    {
+        static_assert(etl::is_copy_constructible<T>::value, "T must have a copy constructor!");
+
+        HRESULT ret = HRESULT::CannotAllocatePayload;
+
+        uint16_t const sid = msg.getHeader().serviceId;
+        uint8_t* const buffer
+            = msg.isEvent() ? memory::getAllocSharedFunction(sid)(sizeof(T), numberOfReferences)
+                            : memory::getAllocFunction(sid)(sizeof(T));
+
+        if (buffer != nullptr)
+        {
+            etl::construct_object_at(buffer, obj);
+            auto const offset = static_cast<ptrdiff_t>(
+                etl::distance(memory::getRegionStartFunction(sid)(), buffer));
+            msg.setExternalPayload(offset, static_cast<uint32_t>(sizeof(T)));
+            ret = HRESULT::Ok;
+        }
+        else
+        {
+            logger::logAllocationFailure(
+                logger::LogLevel::Error,
+                logger::Error::Allocation,
+                ret,
+                msg,
+                static_cast<uint32_t>(sizeof(T)));
+        }
+
+        return ret;
+    }
 
     MessagePayloadBuilder() = default;
 

--- a/libs/bsw/middleware/include/middleware/core/ProxyAttribute.h
+++ b/libs/bsw/middleware/include/middleware/core/ProxyAttribute.h
@@ -210,6 +210,7 @@ public:
     using SetterArgumentType     = typename SetterTraits::ArgumentType;
     using SetterCallback         = typename FutureDispatcher<SetterTraits, REQUEST_LIMIT>::Callback;
     using GetterDispatcherTraits = GetterTraits;
+    using GetterResult           = typename Base::GetterResult;
     using GetterCallback         = typename Base::GetterCallback;
 
     explicit ProxyAttribute(ProxyBase& proxy) : Base(proxy) {}

--- a/libs/bsw/middleware/include/middleware/core/ProxyAttributeBase.h
+++ b/libs/bsw/middleware/include/middleware/core/ProxyAttributeBase.h
@@ -37,7 +37,8 @@ class ProxyAttributeBase
 {
 public:
     using AttributeType  = typename DispatcherTraits::ArgumentType;
-    using GetterCallback = etl::delegate<void(etl::expected<AttributeType, Future::State> const&)>;
+    using GetterResult   = typename FutureDispatcher<DispatcherTraits, REQUEST_LIMIT>::Result;
+    using GetterCallback = typename FutureDispatcher<DispatcherTraits, REQUEST_LIMIT>::Callback;
 
     explicit ProxyAttributeBase(ProxyBase& proxy) : _proxy(&proxy) {}
 

--- a/libs/bsw/middleware/src/middleware/core/MessagePayloadBuilder.cpp
+++ b/libs/bsw/middleware/src/middleware/core/MessagePayloadBuilder.cpp
@@ -17,75 +17,41 @@
 #include "middleware/memory/AllocatorSelector.h"
 
 #include <etl/iterator.h>
-#include <etl/optional.h>
+#include <etl/memory.h>
 #include <etl/span.h>
 
 #include <cstdint>
-#include <cstring>
 
 namespace middleware::core
 {
 
 MessagePayloadBuilder MessagePayloadBuilder::_instance{};
 
-HRESULT MessagePayloadBuilder::allocateTrivialType(
-    void const* const objPtr, size_t const objSize, Message& msg, uint8_t const numberOfReferences)
+HRESULT MessagePayloadBuilder::allocAndCopyBytesToExternalPayload(
+    etl::span<uint8_t const> const src, Message& msg, uint8_t const numberOfReferences)
 {
-    HRESULT ret = HRESULT::CannotAllocatePayload;
+    uint16_t const sid  = msg.getHeader().serviceId;
+    uint8_t* const dest = msg.isEvent()
+                              ? memory::getAllocSharedFunction(sid)(src.size(), numberOfReferences)
+                              : memory::getAllocFunction(sid)(src.size());
 
-    uint16_t const sid    = msg.getHeader().serviceId;
-    uint8_t* const buffer = msg.isEvent()
-                                ? memory::getAllocSharedFunction(sid)(objSize, numberOfReferences)
-                                : memory::getAllocFunction(sid)(objSize);
-
-    if (buffer != nullptr)
-    {
-        std::memcpy(buffer, objPtr, objSize);
-        auto const offset
-            = static_cast<ptrdiff_t>(etl::distance(memory::getRegionStartFunction(sid)(), buffer));
-        msg.setExternalPayload(offset, static_cast<uint32_t>(objSize));
-        ret = HRESULT::Ok;
-    }
-    else
-    {
-        logger::logAllocationFailure(
-            logger::LogLevel::Error,
-            logger::Error::Allocation,
-            ret,
-            msg,
-            static_cast<uint32_t>(objSize));
-    }
-
-    return ret;
-}
-
-etl::optional<etl::span<uint8_t>> MessagePayloadBuilder::allocateNonTrivialType(
-    size_t const payloadSize, Message& msg, uint8_t const numberOfReferences)
-{
-    etl::optional<etl::span<uint8_t>> ret{};
-
-    uint16_t const sid = msg.getHeader().serviceId;
-    uint8_t* const buffer
-        = msg.isEvent() ? memory::getAllocSharedFunction(sid)(payloadSize, numberOfReferences)
-                        : memory::getAllocFunction(sid)(payloadSize);
-    if (buffer != nullptr)
-    {
-        auto const offset
-            = static_cast<ptrdiff_t>(etl::distance(memory::getRegionStartFunction(sid)(), buffer));
-        msg.setExternalPayload(offset, static_cast<uint32_t>(payloadSize));
-        ret.emplace(buffer, payloadSize);
-    }
-    else
+    if (dest == nullptr)
     {
         logger::logAllocationFailure(
             logger::LogLevel::Error,
             logger::Error::Allocation,
             HRESULT::CannotAllocatePayload,
             msg,
-            static_cast<uint32_t>(payloadSize));
+            static_cast<uint32_t>(src.size()));
+        return HRESULT::CannotAllocatePayload;
     }
 
-    return ret;
+    etl::mem_copy(src.data(), src.size(), dest);
+    auto const offset
+        = static_cast<ptrdiff_t>(etl::distance(memory::getRegionStartFunction(sid)(), dest));
+    msg.setExternalPayload(offset, static_cast<uint32_t>(src.size()));
+
+    return HRESULT::Ok;
 }
 
 uint8_t* MessagePayloadBuilder::getAllocatorPointerFromMessage(Message const& msg)
@@ -95,6 +61,17 @@ uint8_t* MessagePayloadBuilder::getAllocatorPointerFromMessage(Message const& ms
     uint8_t* const externalBufferPtr = etl::next(memory::getRegionStartFunction(sid)(), offset);
 
     return externalBufferPtr;
+}
+
+HRESULT MessagePayloadBuilder::allocate(
+    etl::span<uint8_t const> const src, Message& msg, uint8_t const numberOfReferences)
+{
+    if (src.size_bytes() <= Message::MAX_PAYLOAD_SIZE)
+    {
+        msg.copyRawBytesToPayload(src);
+        return HRESULT::Ok;
+    }
+    return allocAndCopyBytesToExternalPayload(src, msg, numberOfReferences);
 }
 
 void MessagePayloadBuilder::deallocate(Message const& msg)

--- a/libs/bsw/middleware/test/src/core/FutureDispatcherTest.cpp
+++ b/libs/bsw/middleware/test/src/core/FutureDispatcherTest.cpp
@@ -13,6 +13,7 @@
 #include <etl/array.h>
 #include <etl/delegate.h>
 #include <etl/expected.h>
+#include <etl/functional.h>
 #include <etl/type_traits.h>
 #include <etl/utility.h>
 #include <gmock/gmock.h>
@@ -47,8 +48,9 @@ public:
         MOCK_METHOD(
             void,
             receiveFutureData,
-            ((etl::
-                  expected<typename Config::TraitsUnderTest::ArgumentType, Future::State> const&)));
+            ((etl::expected<
+                etl::reference_wrapper<typename Config::TraitsUnderTest::ArgumentType const>,
+                Future::State> const&)));
     };
 
     void SetUp() override
@@ -87,8 +89,9 @@ TYPED_TEST_SUITE(FutureDispatcherTestSuite, TestConfigs);
 TYPED_TEST(FutureDispatcherTestSuite, TestObtainRequestId)
 {
     etl::optional<uint16_t> reqId{1U};
-    auto const callback = [](etl::expected<int, Future::State> const&) {};
-    reqId               = this->obtainRequestId(callback);
+    auto const callback
+        = [](etl::expected<etl::reference_wrapper<int const>, Future::State> const&) {};
+    reqId = this->obtainRequestId(callback);
     EXPECT_EQ(reqId.value(), 0U);
 }
 
@@ -96,8 +99,9 @@ TYPED_TEST(FutureDispatcherTestSuite, TestObtainRequestIdTwice)
 {
     etl::optional<uint16_t> reqId1{};
     etl::optional<uint16_t> reqId2{};
-    auto const callback = [](etl::expected<int, Future::State> const&) {};
-    reqId1              = this->obtainRequestId(callback);
+    auto const callback
+        = [](etl::expected<etl::reference_wrapper<int const>, Future::State> const&) {};
+    reqId1 = this->obtainRequestId(callback);
     this->cancelRequest(reqId1.value());
     reqId2 = this->obtainRequestId(callback);
     this->cancelRequest(reqId2.value());
@@ -110,7 +114,8 @@ TYPED_TEST(FutureDispatcherTestSuite, TestObtainRequestIdAboveDispatcherLimit)
     static constexpr uint8_t REQ_LIMIT = TypeParam::REQUEST_LIMIT;
     etl::optional<uint16_t> reqId{};
     etl::array<etl::optional<uint16_t>, REQ_LIMIT> reqIdArray{};
-    auto const callback = [](etl::expected<int, Future::State> const&) {};
+    auto const callback
+        = [](etl::expected<etl::reference_wrapper<int const>, Future::State> const&) {};
     for (auto& r : reqIdArray)
     {
         r = this->obtainRequestId(callback);
@@ -121,7 +126,8 @@ TYPED_TEST(FutureDispatcherTestSuite, TestObtainRequestIdAboveDispatcherLimit)
 
 TYPED_TEST(FutureDispatcherTestSuite, TestFutureMatchingRequestId)
 {
-    auto const callback                     = [](etl::expected<int, Future::State> const&) {};
+    auto const callback
+        = [](etl::expected<etl::reference_wrapper<int const>, Future::State> const&) {};
     etl::optional<uint16_t> const requestId = this->obtainRequestId(callback);
     Message msg = Message::createResponse(0U, 0U, requestId.value(), 0U, 0U, 0U, 0U);
 
@@ -134,7 +140,8 @@ TYPED_TEST(FutureDispatcherTestSuite, TestFutureMatchingRequestIdMultipleActiveR
 {
     etl::array<etl::optional<uint16_t>, TypeParam::REQUEST_LIMIT> requestIdArray{};
     etl::vector<Message, TypeParam::REQUEST_LIMIT> msgArray{};
-    auto const callback = [](etl::expected<int, Future::State> const&) {};
+    auto const callback
+        = [](etl::expected<etl::reference_wrapper<int const>, Future::State> const&) {};
 
     for (auto& reqId : requestIdArray)
     {
@@ -153,8 +160,9 @@ TYPED_TEST(FutureDispatcherTestSuite, TestFutureMatchingRequestIdMultipleActiveR
 TYPED_TEST(FutureDispatcherTestSuite, TestFutureMatchingRequestIdForInvalidRequest)
 {
     etl::optional<uint16_t> requestId{};
-    auto const callback = [](etl::expected<int, Future::State> const&) {};
-    requestId           = this->obtainRequestId(callback);
+    auto const callback
+        = [](etl::expected<etl::reference_wrapper<int const>, Future::State> const&) {};
+    requestId = this->obtainRequestId(callback);
 
     Message msg = Message::createResponse(0U, 0U, INVALID_REQUEST_ID, 0U, 0U, 0U, 0U);
 
@@ -176,8 +184,9 @@ TYPED_TEST(FutureDispatcherTestSuite, TestFutureMatchingRequestIdForInvalidReque
 TYPED_TEST(FutureDispatcherTestSuite, TestCancelRequestForActiveRequest)
 {
     etl::optional<uint16_t> requestId{};
-    auto const callback = [](etl::expected<int, Future::State> const&) {};
-    requestId           = this->obtainRequestId(callback);
+    auto const callback
+        = [](etl::expected<etl::reference_wrapper<int const>, Future::State> const&) {};
+    requestId = this->obtainRequestId(callback);
 
     Message msg = Message::createResponse(0U, 0U, requestId.value(), 0U, 0U, 0U, 0U);
 
@@ -197,8 +206,9 @@ TYPED_TEST(FutureDispatcherTestSuite, TestCancelRequestWithInvalidRequest)
 TYPED_TEST(FutureDispatcherTestSuite, TestFreeAll)
 {
     etl::optional<uint16_t> requestId{};
-    auto const callback = [](etl::expected<int, Future::State> const&) {};
-    requestId           = this->obtainRequestId(callback);
+    auto const callback
+        = [](etl::expected<etl::reference_wrapper<int const>, Future::State> const&) {};
+    requestId = this->obtainRequestId(callback);
     this->freeAll();
     requestId = this->obtainRequestId(callback);
     EXPECT_EQ(requestId, 0U);
@@ -208,7 +218,8 @@ TYPED_TEST(FutureDispatcherTestSuite, TestFreeAllWhenSeveralRequestsAreActive)
 {
     static constexpr uint8_t REQ_LIMIT = TypeParam::REQUEST_LIMIT;
     etl::array<etl::optional<uint16_t>, REQ_LIMIT> requestIdArray{};
-    auto const callback = [](etl::expected<int, Future::State> const&) {};
+    auto const callback
+        = [](etl::expected<etl::reference_wrapper<int const>, Future::State> const&) {};
 
     for (auto& reqId : requestIdArray)
     {
@@ -233,7 +244,8 @@ TYPED_TEST(FutureDispatcherTestSuite, TestFutureMatchingRequestIdForMessageWithE
         etl::make_pair(ErrorState::DeserializationError, Future::State::DeserializationError),
         etl::make_pair(ErrorState::QueueFullError, Future::State::CouldNotDeliverError));
     etl::optional<uint16_t> requestId{};
-    auto const callback = [](etl::expected<int, Future::State> const&) {};
+    auto const callback
+        = [](etl::expected<etl::reference_wrapper<int const>, Future::State> const&) {};
 
     for (auto& pair : expectedValues)
     {
@@ -281,8 +293,9 @@ TYPED_TEST(FutureDispatcherTestSuite, TestTimeoutDispatching)
     EXPECT_CALL(
         appMock,
         receiveFutureData(testing::Truly(
-            [](etl::expected<typename TraitsUnderTest::ArgumentType, Future::State> const& exp)
-            { return exp.error() == Future::State::Timeout; })))
+            [](etl::expected<
+                etl::reference_wrapper<typename TraitsUnderTest::ArgumentType const>,
+                Future::State> const& exp) { return exp.error() == Future::State::Timeout; })))
         .Times(1U);
 
     for (size_t timeCounter = 0U; timeCounter <= (TraitsUnderTest::TIMEOUT_VALUE); ++timeCounter)
@@ -294,7 +307,8 @@ TYPED_TEST(FutureDispatcherTestSuite, TestTimeoutDispatching)
 TYPED_TEST(FutureDispatcherTestSuite, TestRequestIdWraparound)
 {
     etl::optional<uint16_t> requestId{};
-    auto const callback = [](etl::expected<int, Future::State> const&) {};
+    auto const callback
+        = [](etl::expected<etl::reference_wrapper<int const>, Future::State> const&) {};
 
     for (size_t i = 0U; i <= INVALID_REQUEST_ID; ++i)
     {

--- a/libs/bsw/middleware/test/src/core/MessagePayloadBuilderTest.cpp
+++ b/libs/bsw/middleware/test/src/core/MessagePayloadBuilderTest.cpp
@@ -10,8 +10,8 @@
 
 #include <cstdint>
 
-#include <etl/byte_stream.h>
 #include <etl/memory.h>
+#include <etl/type_traits.h>
 #include <etl/vector.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -24,142 +24,90 @@
 
 namespace middleware::core::test
 {
-
-struct SmallTrivialType
+template<typename T>
+struct IntegralWrapper
 {
-    uint32_t a;
-    uint32_t b;
-    uint32_t c;
-    uint32_t d;
+    static_assert(etl::is_integral_v<T>, "IntegralWrapper requires an integral type");
+    T value;
+
+    bool operator==(IntegralWrapper const& rhs) const { return value == rhs.value; }
+
+    static IntegralWrapper make() { return {static_cast<T>(~T{0})}; }
 };
 
-struct BigTrivialType
+template<typename T, size_t SIZE>
+struct ArrayWrapper
 {
-    uint64_t a;
-    uint64_t b;
-    uint64_t c;
-    uint64_t d;
-    uint64_t e;
-    uint64_t f;
-    uint64_t g;
-    uint64_t h;
-    uint64_t i;
-};
+    etl::array<T, SIZE> buffer;
 
-} // namespace middleware::core::test
+    bool operator==(ArrayWrapper const& rhs) const { return buffer == rhs.buffer; }
 
-/// ETL user-defined type-traits specializations for trivially copyable test types.
-/// Required because OpenBSW ETL is configured with ETL_USER_DEFINED_TYPE_TRAITS,
-/// which only recognises arithmetic and pointer types as trivially copyable by default.
-namespace etl
-{
-template<>
-struct is_trivially_copyable<middleware::core::test::SmallTrivialType> : public etl::true_type
-{};
-
-template<>
-struct is_trivially_copyable<middleware::core::test::BigTrivialType> : public etl::true_type
-{};
-
-template<size_t N>
-struct is_trivially_copyable<etl::array<uint8_t, N>> : public etl::true_type
-{};
-
-template<size_t N>
-struct is_trivially_copyable<etl::array<uint8_t, N> const> : public etl::true_type
-{};
-} // namespace etl
-
-namespace middleware::core::test
-{
-
-namespace
-{
-/// Helper to create a default/empty message for allocator tests.
-/// Message has no public default constructor, so we use the factory with dummy values.
-Message makeEmptyMessage() { return Message::createRequest(0U, 0U, 0U, 0U, 0U, 0U, 0U); }
-} // namespace
-
-struct SmallNonTrivialType
-{
-    etl::vector<uint8_t, sizeof(SmallTrivialType)> data{};
-
-    struct AllocationPolicy
+    static ArrayWrapper make()
     {
-        static void serialize(SmallNonTrivialType const& obj, etl::span<uint8_t>& buffer)
-        {
-            etl::byte_stream_writer writer{buffer, etl::endian::native};
-            writer.write_unchecked(static_cast<uint32_t>(obj.data.size()));
-            for (auto element : obj.data)
-            {
-                writer.write_unchecked(element);
-            }
-        }
-
-        static size_t getNeededSize(SmallNonTrivialType const& obj)
-        {
-            return sizeof(uint32_t) + (obj.data.size() * sizeof(decltype(obj.data)::value_type));
-        }
-
-        static SmallNonTrivialType deserialize(etl::span<uint8_t> const& serializedBuffer)
-        {
-            etl::byte_stream_reader reader{
-                serializedBuffer.begin(), serializedBuffer.end(), etl::endian::native};
-            SmallNonTrivialType obj{};
-            uint32_t const size = reader.read_unchecked<uint32_t>();
-            for (uint32_t idx = 0U; idx < size; ++idx)
-            {
-                obj.data.push_back(reader.read_unchecked<decltype(obj.data)::value_type>());
-            }
-
-            return obj;
-        }
-    };
+        ArrayWrapper obj{};
+        obj.buffer.fill(static_cast<T>(~T{0}));
+        return obj;
+    }
 };
 
-struct BigNonTrivialType
+template<typename T, size_t SIZE>
+struct VectorWrapper
 {
-    uint32_t a;
-    uint32_t b;
-    etl::vector<uint8_t, Message::MAX_PAYLOAD_SIZE> data{};
+    etl::vector<T, SIZE> buffer;
 
-    struct AllocationPolicy
+    bool operator==(VectorWrapper const& rhs) const { return buffer == rhs.buffer; }
+
+    static VectorWrapper make()
     {
-        static void serialize(BigNonTrivialType const& obj, etl::span<uint8_t>& buffer)
+        VectorWrapper obj{};
+        for (size_t i = 0U; i < SIZE; ++i)
         {
-            etl::byte_stream_writer writer{buffer, etl::endian::native};
-            writer.write_unchecked(static_cast<uint32_t>(obj.a));
-            writer.write_unchecked(static_cast<uint32_t>(obj.b));
-            writer.write_unchecked(static_cast<uint32_t>(obj.data.size()));
-            for (auto element : obj.data)
-            {
-                writer.write_unchecked(element);
-            }
+            obj.buffer.push_back(static_cast<T>(~T{0}));
         }
-
-        static size_t getNeededSize(BigNonTrivialType const& obj)
-        {
-            return sizeof(obj.a) + sizeof(obj.b) + sizeof(uint32_t)
-                   + (obj.data.size() * sizeof(decltype(obj.data)::value_type));
-        }
-
-        static BigNonTrivialType deserialize(etl::span<uint8_t> const& serializedBuffer)
-        {
-            etl::byte_stream_reader reader{
-                serializedBuffer.begin(), serializedBuffer.end(), etl::endian::native};
-            BigNonTrivialType obj{};
-            obj.a               = reader.read_unchecked<decltype(obj.a)>();
-            obj.b               = reader.read_unchecked<decltype(obj.b)>();
-            uint32_t const size = reader.read_unchecked<uint32_t>();
-            for (uint32_t idx = 0U; idx < size; ++idx)
-            {
-                obj.data.push_back(reader.read_unchecked<decltype(obj.data)::value_type>());
-            }
-
-            return obj;
-        }
-    };
+        return obj;
+    }
 };
+
+using SmallTypes = ::testing::Types<
+    IntegralWrapper<uint8_t>,
+    IntegralWrapper<uint16_t>,
+    IntegralWrapper<uint32_t>,
+    IntegralWrapper<uint64_t>,
+    ArrayWrapper<uint8_t, 1U>,
+    ArrayWrapper<uint16_t, 1U>,
+    ArrayWrapper<uint32_t, 1U>,
+    ArrayWrapper<uint64_t, 1U>,
+    VectorWrapper<uint8_t, 1U>,
+    VectorWrapper<uint16_t, 1U>,
+    VectorWrapper<uint32_t, 1U>,
+    VectorWrapper<uint64_t, 1U>>;
+
+using BigTypes = ::testing::Types<
+    ArrayWrapper<uint8_t, Message::MAX_PAYLOAD_SIZE + 1U>,
+    ArrayWrapper<uint16_t, Message::MAX_PAYLOAD_SIZE + 1U>,
+    ArrayWrapper<uint32_t, Message::MAX_PAYLOAD_SIZE + 1U>,
+    ArrayWrapper<uint64_t, Message::MAX_PAYLOAD_SIZE + 1U>,
+    VectorWrapper<uint8_t, Message::MAX_PAYLOAD_SIZE + 1U>,
+    VectorWrapper<uint16_t, Message::MAX_PAYLOAD_SIZE + 1U>,
+    VectorWrapper<uint32_t, Message::MAX_PAYLOAD_SIZE + 1U>,
+    VectorWrapper<uint64_t, Message::MAX_PAYLOAD_SIZE + 1U>>;
+
+using SmallBuffers = ::testing::Types<
+    etl::array<uint8_t, 1U>,
+    etl::array<uint8_t, 2U>,
+    etl::array<uint8_t, 4U>,
+    etl::array<uint8_t, 8U>,
+    etl::array<uint8_t, 16U>,
+    etl::array<uint8_t, 32U>,
+    etl::array<uint8_t, Message::MAX_PAYLOAD_SIZE - 1U>,
+    etl::array<uint8_t, Message::MAX_PAYLOAD_SIZE>>;
+
+using BigBuffers = ::testing::Types<
+    etl::array<uint8_t, Message::MAX_PAYLOAD_SIZE + 1U>,
+    etl::array<uint8_t, 64U>,
+    etl::array<uint8_t, 128U>,
+    etl::array<uint8_t, 256U>,
+    etl::array<uint8_t, 511U>>;
 
 class AllocatorImpl
 {
@@ -173,13 +121,6 @@ public:
 
     template<size_t MAX_COUNT, size_t MAX_SIZE>
     using Storage = etl::vector<etl::array<uint8_t, MAX_SIZE>, MAX_COUNT>;
-
-    enum class PoolId : uint8_t
-    {
-        Pool128 = 0U,
-        Pool256,
-        Pool512
-    };
 
     uint8_t* allocate(uint32_t const size)
     {
@@ -208,44 +149,31 @@ public:
             {
                 _pool128.at(0).fill(0U);
                 _pool128.clear();
+                return;
             }
         }
-        else if (!_pool256.empty())
+        if (!_pool256.empty())
         {
             if (reinterpret_cast<decltype(_pool256)::iterator>(ptr) == _pool256.data())
             {
                 _pool256.at(0).fill(0U);
                 _pool256.clear();
+                return;
             }
         }
-        else if (!_pool512.empty())
+        if (!_pool512.empty())
         {
             if (reinterpret_cast<decltype(_pool512)::iterator>(ptr) == _pool512.data())
             {
                 _pool512.at(0).fill(0U);
                 _pool512.clear();
+                return;
             }
         }
-        else
-        {
-            FAIL() << "Pointer does not belong to any pool.";
-        }
+        FAIL() << "Pointer does not belong to any pool.";
     }
 
-    bool isAllocatorPoolFull(PoolId const poolId) const
-    {
-        bool ret = false;
-
-        switch (poolId)
-        {
-            case PoolId::Pool128: ret = _pool128.full(); break;
-            case PoolId::Pool256: ret = _pool256.full(); break;
-            case PoolId::Pool512: ret = _pool512.full(); break;
-            default:              break;
-        }
-
-        return ret;
-    }
+    bool isAnyPoolFull() const { return _pool128.full() || _pool256.full() || _pool512.full(); }
 
     uint8_t* regionStart() { return reinterpret_cast<uint8_t*>(_pool128.data()); }
 
@@ -289,227 +217,209 @@ protected:
     AllocatorImpl _allocator{};
 };
 
-TEST_F(TestMessagePayloadBuilder, TestSmallTrivialType)
+namespace
 {
+/// Helper to create a default/empty message for allocator tests.
+/// Message has no public default constructor, so we use the factory with dummy values.
+Message makeEmptyMessage() { return Message::createRequest(0U, 0U, 0U, 0U, 0U, 0U, 0U); }
+} // namespace
+
+template<typename T>
+class TestMessagePayloadBuilderSmallUserDefinedType : public TestMessagePayloadBuilder
+{};
+
+TYPED_TEST_SUITE(TestMessagePayloadBuilderSmallUserDefinedType, SmallTypes);
+
+TYPED_TEST(TestMessagePayloadBuilderSmallUserDefinedType, AllocateInternal)
+{
+    static_assert(
+        sizeof(TypeParam) <= Message::MAX_PAYLOAD_SIZE,
+        "TypeParam must fit in internal payload, this is a test logic error");
+
     // ARRANGE
-    SmallTrivialType const obj{
-        0xF1359EA0U,
-        0x51314BA1U,
-        0x1289CEA2U,
-        0x902C37FFU,
-    };
-    Message msg = makeEmptyMessage();
+    auto const obj = TypeParam::make();
+    Message msg    = makeEmptyMessage();
 
     // ACT
-    core::HRESULT ret    = MessagePayloadBuilder::getInstance().allocate(obj, msg);
-    auto const storedObj = MessagePayloadBuilder::getInstance().readPayload<SmallTrivialType>(msg);
-    MessagePayloadBuilder::deallocate(msg);
+    core::HRESULT ret     = MessagePayloadBuilder::getInstance().allocate(obj, msg);
+    auto const& storedObj = MessagePayloadBuilder::getInstance().readPayload<TypeParam>(msg);
 
     // ASSERT
     EXPECT_EQ(ret, core::HRESULT::Ok);
-    EXPECT_EQ(obj.a, storedObj.a);
-    EXPECT_EQ(obj.b, storedObj.b);
-    EXPECT_EQ(obj.c, storedObj.c);
-    EXPECT_EQ(obj.d, storedObj.d);
-}
-
-TEST_F(TestMessagePayloadBuilder, TestSmallSpan)
-{
-    // ARRANGE
-    etl::array<uint8_t, 8U> const buffer_{0x0DU, 0x0EU, 0x0AU, 0x0DU, 0x0BU, 0x0EU, 0x0EU, 0x0FU};
-    etl::span<uint8_t const> const obj{buffer_};
-    Message msg = makeEmptyMessage();
-
-    // ACT
-    core::HRESULT ret    = MessagePayloadBuilder::getInstance().allocate(obj, msg);
-    auto const storedObj = MessagePayloadBuilder::getInstance().readPayload<decltype(buffer_)>(msg);
-
-    // ASSERT
     EXPECT_FALSE(msg.hasExternalPayload());
-    EXPECT_EQ(ret, core::HRESULT::Ok);
-    EXPECT_TRUE(etl::equal(obj.begin(), obj.end(), storedObj.begin(), storedObj.end()));
+    EXPECT_EQ(obj, storedObj);
 
     // ACT
     MessagePayloadBuilder::deallocate(msg);
 }
 
-TEST_F(TestMessagePayloadBuilder, TestBigSpan)
+template<typename T>
+class TestMessagePayloadBuilderBigUserDefinedType : public TestMessagePayloadBuilder
+{};
+
+TYPED_TEST_SUITE(TestMessagePayloadBuilderBigUserDefinedType, BigTypes);
+
+TYPED_TEST(TestMessagePayloadBuilderBigUserDefinedType, AllocateExternal)
 {
+    static_assert(
+        sizeof(TypeParam) > Message::MAX_PAYLOAD_SIZE,
+        "TypeParam must NOT fit in internal payload, this is a test logic error");
+
     // ARRANGE
-    etl::array<uint8_t, Message::MAX_PAYLOAD_SIZE + 1U> buffer_{};
-    etl::fill(buffer_.begin(), buffer_.end(), 0x00U);
-    etl::span<uint8_t const> const obj{buffer_};
-    Message msg = makeEmptyMessage();
+    auto const obj = TypeParam::make();
+    Message msg    = makeEmptyMessage();
 
     // ACT
-    core::HRESULT ret    = MessagePayloadBuilder::getInstance().allocate(obj, msg);
-    auto const storedObj = MessagePayloadBuilder::getInstance().readPayload<decltype(buffer_)>(msg);
+    core::HRESULT ret     = MessagePayloadBuilder::getInstance().allocate(obj, msg);
+    auto const& storedObj = MessagePayloadBuilder::getInstance().readPayload<TypeParam>(msg);
 
     // ASSERT
+    EXPECT_EQ(ret, core::HRESULT::Ok);
     EXPECT_TRUE(msg.hasExternalPayload());
-    EXPECT_EQ(ret, core::HRESULT::Ok);
-    EXPECT_TRUE(etl::equal(obj.begin(), obj.end(), storedObj.begin(), storedObj.end()));
+    EXPECT_EQ(obj, storedObj);
 
     // ACT
     MessagePayloadBuilder::deallocate(msg);
 }
 
-TEST_F(TestMessagePayloadBuilder, TestBigTrivialType)
+TYPED_TEST(TestMessagePayloadBuilderBigUserDefinedType, AllocateExternalShared)
 {
+    static_assert(
+        sizeof(TypeParam) > Message::MAX_PAYLOAD_SIZE,
+        "TypeParam must NOT fit in internal payload, this is a test logic error");
+
     // ARRANGE
-    BigTrivialType const obj{
-        0xF1359EA0221A3749U,
-        0x51314BA1F17BCD21U,
-        0x1289CEA256BD29A4U,
-        0x1289CEA256BD29A4U,
-        0x1289CEA256BD29A4U,
-        0x1289CEA256BD29A4U,
-        0x1289CEA256BD29A4U,
-        0xA1B2C3D4E5F60718U,
-        0x0918273645546372U};
-    Message msg = makeEmptyMessage();
-
-    // ACT
-    core::HRESULT ret    = MessagePayloadBuilder::getInstance().allocate(obj, msg);
-    auto const storedObj = MessagePayloadBuilder::getInstance().readPayload<BigTrivialType>(msg);
-    MessagePayloadBuilder::deallocate(msg);
-
-    // ASSERT
-    EXPECT_EQ(ret, core::HRESULT::Ok);
-    EXPECT_EQ(obj.a, storedObj.a);
-    EXPECT_EQ(obj.b, storedObj.b);
-    EXPECT_EQ(obj.c, storedObj.c);
-}
-
-TEST_F(TestMessagePayloadBuilder, TestSmallNonTrivialType)
-{
-    // ARRANGE
-    SmallNonTrivialType obj{};
-    obj.data.push_back(0x31U);
-    obj.data.push_back(0x27U);
-    obj.data.push_back(0x99U);
-    obj.data.push_back(0x50U);
-    Message msg = makeEmptyMessage();
-
-    // ACT
-    core::HRESULT ret = MessagePayloadBuilder::getInstance().allocate(obj, msg);
-    auto const storedObj
-        = MessagePayloadBuilder::getInstance().readPayload<SmallNonTrivialType>(msg);
-    MessagePayloadBuilder::deallocate(msg);
-
-    // ASSERT
-    EXPECT_EQ(ret, core::HRESULT::Ok);
-    EXPECT_EQ(obj.data, storedObj.data);
-}
-
-TEST_F(TestMessagePayloadBuilder, BigNonTrivialType)
-{
-    // ARRANGE
-    BigNonTrivialType obj{};
-    obj.a = 0xF131125CU;
-    obj.b = 0x5DC09EA0U;
-    for (size_t i = 0x00U; i < obj.data.max_size(); i++)
-    {
-        obj.data.push_back(i);
-    }
-    Message msg = makeEmptyMessage();
-
-    // ACT
-    core::HRESULT ret    = MessagePayloadBuilder::getInstance().allocate(obj, msg);
-    auto const storedObj = MessagePayloadBuilder::getInstance().readPayload<BigNonTrivialType>(msg);
-    MessagePayloadBuilder::deallocate(msg);
-
-    // ASSERT
-    EXPECT_EQ(ret, core::HRESULT::Ok);
-    EXPECT_EQ(obj.a, storedObj.a);
-    EXPECT_EQ(obj.b, storedObj.b);
-    EXPECT_EQ(obj.data, storedObj.data);
-}
-
-TEST_F(TestMessagePayloadBuilder, TestBigTrivialTypeWithMultipleReferenceCounter)
-{
-    // ARRANGE
-    BigTrivialType const obj{
-        0xF1359EA0221A3749U,
-        0x51314BA1F17BCD21U,
-        0x1289CEA256BD29A4U,
-        0x1289CEA256BD29A4U,
-        0x1289CEA256BD29A4U,
-        0x1289CEA256BD29A4U,
-        0x1289CEA256BD29A4U,
-        0xA1B2C3D4E5F60718U,
-        0x0918273645546372U};
+    auto const obj                   = TypeParam::make();
     Message msg                      = Message::createEvent(123U, 128U, 1U, 0U);
     uint8_t const numberOfReferences = 5U;
 
     // ACT
-    EXPECT_EQ(
-        MessagePayloadBuilder::getInstance().allocate(obj, msg, numberOfReferences),
-        core::HRESULT::Ok);
+    core::HRESULT ret = MessagePayloadBuilder::getInstance().allocate(obj, msg, numberOfReferences);
 
     // ASSERT
-    for (size_t readings = 0U; readings < numberOfReferences; readings++)
+    EXPECT_EQ(ret, core::HRESULT::Ok);
+    EXPECT_TRUE(msg.hasExternalPayload());
+
+    for (size_t readings = 0U; readings < numberOfReferences; ++readings)
     {
-        EXPECT_TRUE(getAllocatorImpl().isAllocatorPoolFull(AllocatorImpl::PoolId::Pool128));
-        auto const storedObj
-            = MessagePayloadBuilder::getInstance().readPayload<BigTrivialType>(msg);
-        EXPECT_EQ(obj.a, storedObj.a);
-        EXPECT_EQ(obj.b, storedObj.b);
-        EXPECT_EQ(obj.c, storedObj.c);
+        EXPECT_TRUE(this->getAllocatorImpl().isAnyPoolFull());
+        auto const& storedObj = MessagePayloadBuilder::getInstance().readPayload<TypeParam>(msg);
+        EXPECT_EQ(obj, storedObj);
         MessagePayloadBuilder::deallocate(msg);
     }
-    EXPECT_FALSE(getAllocatorImpl().isAllocatorPoolFull(AllocatorImpl::PoolId::Pool128));
+    EXPECT_FALSE(this->getAllocatorImpl().isAnyPoolFull());
 }
 
-TEST_F(TestMessagePayloadBuilder, TestBigNonTrivialTypeWithMultipleReferenceCounter)
+template<typename T>
+class TestMessagePayloadBuilderSmallSpan : public TestMessagePayloadBuilder
+{};
+
+TYPED_TEST_SUITE(TestMessagePayloadBuilderSmallSpan, SmallBuffers);
+
+TYPED_TEST(TestMessagePayloadBuilderSmallSpan, AllocateInternal)
 {
+    using value_type = typename TypeParam::value_type;
+    static_assert(
+        sizeof(TypeParam) <= Message::MAX_PAYLOAD_SIZE,
+        "TypeParam must fit in internal payload, this is a test logic error");
+
     // ARRANGE
-    BigNonTrivialType obj{};
-    obj.a = 0xF131125CU;
-    obj.b = 0x5DC09EA0U;
-    for (size_t i = 0x00U; i < obj.data.max_size(); i++)
-    {
-        obj.data.push_back(i);
-    }
+    TypeParam obj;
+    obj.fill(static_cast<value_type>(~value_type{0U}));
+
+    etl::span<uint8_t const> const bytes{obj};
+    Message msg = makeEmptyMessage();
+
+    // ACT
+    core::HRESULT ret = MessagePayloadBuilder::getInstance().allocate(bytes, msg);
+    etl::span<uint8_t const> const storedBytes
+        = MessagePayloadBuilder::getInstance().readRawPayload(msg);
+
+    // ASSERT
+    EXPECT_EQ(ret, core::HRESULT::Ok);
+    EXPECT_FALSE(msg.hasExternalPayload());
+    EXPECT_TRUE(etl::equal(bytes.begin(), bytes.end(), storedBytes.begin(), storedBytes.end()));
+
+    // ACT
+    MessagePayloadBuilder::deallocate(msg);
+}
+
+template<typename T>
+class TestMessagePayloadBuilderBigSpan : public TestMessagePayloadBuilder
+{};
+
+TYPED_TEST_SUITE(TestMessagePayloadBuilderBigSpan, BigBuffers);
+
+TYPED_TEST(TestMessagePayloadBuilderBigSpan, AllocateExternal)
+{
+    using value_type = typename TypeParam::value_type;
+    static_assert(
+        sizeof(TypeParam) > Message::MAX_PAYLOAD_SIZE,
+        "TypeParam must NOT fit in internal payload, this is a test logic error");
+
+    // ARRANGE
+    TypeParam obj;
+    obj.fill(static_cast<value_type>(~value_type{0U}));
+
+    etl::span<uint8_t const> const bytes{obj};
+    Message msg = makeEmptyMessage();
+
+    // ACT
+    core::HRESULT ret = MessagePayloadBuilder::getInstance().allocate(bytes, msg);
+    etl::span<uint8_t const> const storedBytes
+        = MessagePayloadBuilder::getInstance().readRawPayload(msg);
+
+    // ASSERT
+    EXPECT_EQ(ret, core::HRESULT::Ok);
+    EXPECT_TRUE(msg.hasExternalPayload());
+    EXPECT_TRUE(etl::equal(bytes.begin(), bytes.end(), storedBytes.begin(), storedBytes.end()));
+
+    // ACT
+    MessagePayloadBuilder::deallocate(msg);
+}
+
+TYPED_TEST(TestMessagePayloadBuilderBigSpan, AllocateExternalShared)
+{
+    using value_type = typename TypeParam::value_type;
+    static_assert(
+        sizeof(TypeParam) > Message::MAX_PAYLOAD_SIZE,
+        "TypeParam must NOT fit in internal payload, this is a test logic error");
+
+    // ARRANGE
+    TypeParam obj;
+    obj.fill(static_cast<value_type>(~value_type{0U}));
+
+    etl::span<uint8_t const> const bytes{obj};
     Message msg                      = Message::createEvent(123U, 128U, 1U, 0U);
     uint8_t const numberOfReferences = 5U;
 
     // ACT
-    EXPECT_EQ(
-        MessagePayloadBuilder::getInstance().allocate(obj, msg, numberOfReferences),
-        core::HRESULT::Ok);
+    core::HRESULT ret
+        = MessagePayloadBuilder::getInstance().allocate(bytes, msg, numberOfReferences);
 
     // ASSERT
-    for (size_t readings = 0U; readings < numberOfReferences; readings++)
+    EXPECT_EQ(ret, core::HRESULT::Ok);
+    EXPECT_TRUE(msg.hasExternalPayload());
+
+    for (size_t readings = 0U; readings < numberOfReferences; ++readings)
     {
-        EXPECT_TRUE(getAllocatorImpl().isAllocatorPoolFull(AllocatorImpl::PoolId::Pool128));
-        auto const storedObj
-            = MessagePayloadBuilder::getInstance().readPayload<BigNonTrivialType>(msg);
-        EXPECT_EQ(obj.a, storedObj.a);
-        EXPECT_EQ(obj.b, storedObj.b);
-        EXPECT_EQ(obj.data, storedObj.data);
+        EXPECT_TRUE(this->getAllocatorImpl().isAnyPoolFull());
+        etl::span<uint8_t const> const storedBytes
+            = MessagePayloadBuilder::getInstance().readRawPayload(msg);
+        EXPECT_TRUE(etl::equal(bytes.begin(), bytes.end(), storedBytes.begin(), storedBytes.end()));
         MessagePayloadBuilder::deallocate(msg);
     }
-    EXPECT_FALSE(getAllocatorImpl().isAllocatorPoolFull(AllocatorImpl::PoolId::Pool128));
+    EXPECT_FALSE(this->getAllocatorImpl().isAnyPoolFull());
 }
 
-TEST_F(TestMessagePayloadBuilder, TestFailedAllocationForTrivialType)
+TEST_F(TestMessagePayloadBuilder, AllocateExternalFailsForObject)
 {
     // ARRANGE
-    BigTrivialType const obj{
-        0xF1359EA0221A3749U,
-        0x51314BA1F17BCD21U,
-        0x1289CEA256BD29A4U,
-        0x1289CEA256BD29A4U,
-        0x1289CEA256BD29A4U,
-        0x1289CEA256BD29A4U,
-        0x1289CEA256BD29A4U,
-        0xA1B2C3D4E5F60718U,
-        0x0918273645546372U};
-    Message msg1 = makeEmptyMessage();
-    Message msg2 = makeEmptyMessage();
-    Message msg3 = makeEmptyMessage();
-    Message msg4 = makeEmptyMessage();
+    auto const obj = ArrayWrapper<uint8_t, Message::MAX_PAYLOAD_SIZE + 1U>::make();
+    Message msg1   = makeEmptyMessage();
+    Message msg2   = makeEmptyMessage();
+    Message msg3   = makeEmptyMessage();
+    Message msg4   = makeEmptyMessage();
 
     // ACT
     core::HRESULT firstAllocationResult  = MessagePayloadBuilder::getInstance().allocate(obj, msg1);
@@ -539,16 +449,49 @@ TEST_F(TestMessagePayloadBuilder, TestFailedAllocationForTrivialType)
     MessagePayloadBuilder::deallocate(msg3);
 }
 
-TEST_F(TestMessagePayloadBuilder, TestFailedAllocationForNonTrivialType)
+TEST_F(TestMessagePayloadBuilder, AllocateExternalSharedFailsForObject)
 {
     // ARRANGE
-    BigNonTrivialType obj{};
-    obj.a = 0xF131125CU;
-    obj.b = 0x5DC09EA0U;
-    for (size_t i = 0x00U; i < obj.data.max_size(); i++)
-    {
-        obj.data.push_back(i);
-    }
+    auto const obj = ArrayWrapper<uint8_t, Message::MAX_PAYLOAD_SIZE + 1U>::make();
+    Message msg1   = makeEmptyMessage();
+    Message msg2   = makeEmptyMessage();
+    Message msg3   = makeEmptyMessage();
+    Message msg4   = Message::createEvent(123U, 128U, 1U, 0U);
+
+    // ACT
+    core::HRESULT firstAllocationResult  = MessagePayloadBuilder::getInstance().allocate(obj, msg1);
+    core::HRESULT secondAllocationResult = MessagePayloadBuilder::getInstance().allocate(obj, msg2);
+    core::HRESULT thirdAllocationResult  = MessagePayloadBuilder::getInstance().allocate(obj, msg3);
+
+    _loggerMock.EXPECT_EVENT_LOG(
+        logger::LogLevel::Error,
+        logger::Error::Allocation,
+        HRESULT::CannotAllocatePayload,
+        msg4.getHeader().srcClusterId,
+        msg4.getHeader().tgtClusterId,
+        msg4.getHeader().serviceId,
+        msg4.getHeader().serviceInstanceId,
+        msg4.getHeader().memberId,
+        msg4.getHeader().requestId,
+        static_cast<uint32_t>(sizeof(obj)));
+    core::HRESULT fourthAllocationResult = MessagePayloadBuilder::getInstance().allocate(obj, msg4);
+
+    // ASSERT
+    EXPECT_EQ(firstAllocationResult, core::HRESULT::Ok);
+    EXPECT_EQ(secondAllocationResult, core::HRESULT::Ok);
+    EXPECT_EQ(thirdAllocationResult, core::HRESULT::Ok);
+    EXPECT_EQ(fourthAllocationResult, core::HRESULT::CannotAllocatePayload);
+    MessagePayloadBuilder::deallocate(msg1);
+    MessagePayloadBuilder::deallocate(msg2);
+    MessagePayloadBuilder::deallocate(msg3);
+}
+
+TEST_F(TestMessagePayloadBuilder, AllocateExternalFailsForSpan)
+{
+    // ARRANGE
+    etl::array<uint8_t, Message::MAX_PAYLOAD_SIZE + 1U> buffer{};
+    buffer.fill(0xFFU);
+    etl::span<uint8_t const> const obj{buffer};
     Message msg1 = makeEmptyMessage();
     Message msg2 = makeEmptyMessage();
     Message msg3 = makeEmptyMessage();
@@ -569,7 +512,46 @@ TEST_F(TestMessagePayloadBuilder, TestFailedAllocationForNonTrivialType)
         msg4.getHeader().serviceInstanceId,
         msg4.getHeader().memberId,
         msg4.getHeader().requestId,
-        static_cast<uint32_t>(BigNonTrivialType::AllocationPolicy::getNeededSize(obj)));
+        static_cast<uint32_t>(obj.size_bytes()));
+    core::HRESULT fourthAllocationResult = MessagePayloadBuilder::getInstance().allocate(obj, msg4);
+
+    // ASSERT
+    EXPECT_EQ(firstAllocationResult, core::HRESULT::Ok);
+    EXPECT_EQ(secondAllocationResult, core::HRESULT::Ok);
+    EXPECT_EQ(thirdAllocationResult, core::HRESULT::Ok);
+    EXPECT_EQ(fourthAllocationResult, core::HRESULT::CannotAllocatePayload);
+    MessagePayloadBuilder::deallocate(msg1);
+    MessagePayloadBuilder::deallocate(msg2);
+    MessagePayloadBuilder::deallocate(msg3);
+}
+
+TEST_F(TestMessagePayloadBuilder, AllocateExternalSharedFailsForSpan)
+{
+    // ARRANGE
+    etl::array<uint8_t, Message::MAX_PAYLOAD_SIZE + 1U> buffer{};
+    buffer.fill(0xFFU);
+    etl::span<uint8_t const> const obj{buffer};
+    Message msg1 = makeEmptyMessage();
+    Message msg2 = makeEmptyMessage();
+    Message msg3 = makeEmptyMessage();
+    Message msg4 = Message::createEvent(123U, 128U, 1U, 0U);
+
+    // ACT
+    core::HRESULT firstAllocationResult  = MessagePayloadBuilder::getInstance().allocate(obj, msg1);
+    core::HRESULT secondAllocationResult = MessagePayloadBuilder::getInstance().allocate(obj, msg2);
+    core::HRESULT thirdAllocationResult  = MessagePayloadBuilder::getInstance().allocate(obj, msg3);
+
+    _loggerMock.EXPECT_EVENT_LOG(
+        logger::LogLevel::Error,
+        logger::Error::Allocation,
+        HRESULT::CannotAllocatePayload,
+        msg4.getHeader().srcClusterId,
+        msg4.getHeader().tgtClusterId,
+        msg4.getHeader().serviceId,
+        msg4.getHeader().serviceInstanceId,
+        msg4.getHeader().memberId,
+        msg4.getHeader().requestId,
+        static_cast<uint32_t>(obj.size_bytes()));
     core::HRESULT fourthAllocationResult = MessagePayloadBuilder::getInstance().allocate(obj, msg4);
 
     // ASSERT

--- a/libs/bsw/middleware/test/src/core/ReferenceApp.h
+++ b/libs/bsw/middleware/test/src/core/ReferenceApp.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <etl/expected.h>
+#include <etl/functional.h>
 #include <gmock/gmock.h>
 
 #include "middleware/core/Future.h"
@@ -22,7 +23,10 @@ template<typename ArgType>
 class RefApp
 {
 public:
-    MOCK_METHOD(void, methodCallback, ((etl::expected<ArgType, Future::State> const&)));
+    MOCK_METHOD(
+        void,
+        methodCallback,
+        ((etl::expected<etl::reference_wrapper<ArgType const>, Future::State> const&)));
     MOCK_METHOD(void, eventCallback, (ArgType const&));
 };
 


### PR DESCRIPTION
When sizeof(T) is large, returning by value risks blowing the stack depending on system configuration. readPayload<T>() now returns a T const& directly into the middleware-managed buffer. Callers must consume the reference before the message is deallocated, as the middleware reclaims the buffer immediately after dispatch.

- readPayload<T>() now returns T const& instead of T, eliminating unnecessary copies when reading from message payloads

- FutureDispatcher callbacks now receive etl::reference_wrapper<ArgumentType const> instead of T by value

- Replace allocateTrivialType/allocateNonTrivialType with emplaceExternalPayload (uses placement new for proper construction) and allocAndCopyBytesToExternalPayload (for byte span copies)

- Drop AllocationPolicy-based serialization path; T must now be copy-constructible (enforced via static_assert)