### PR TITLE
Fix clang-tidy warnings in UDS

### DIFF
--- a/libs/bsw/uds/include/uds/base/AbstractDiagJob.h
+++ b/libs/bsw/uds/include/uds/base/AbstractDiagJob.h
@@ -14,7 +14,10 @@
 #include "uds/UdsConstants.h"
 #include "uds/session/DiagSession.h"
 
+#include <etl/algorithm.h>
+#include <etl/array.h>
 #include <etl/error_handler.h>
+#include <etl/span.h>
 #include <etl/uncopyable.h>
 
 #include <platform/estdint.h>
@@ -54,7 +57,8 @@ class DiagJobRoot;
 class AbstractDiagJob : public ::etl::uncopyable
 {
 public:
-    using DiagSessionMask = DiagSession::DiagSessionMask;
+    using DiagSessionMask                                        = DiagSession::DiagSessionMask;
+    static constexpr size_t MAX_OWNED_IMPLEMENTED_REQUEST_LENGTH = 4U;
 
     static uint8_t const EMPTY_REQUEST = 0U;
 
@@ -104,7 +108,9 @@ public:
         uint8_t const requestLength,
         uint8_t const prefixLength,
         DiagSessionMask const sessionMask = DiagSession::ALL_SESSIONS())
-    : fpImplementedRequest(implementedRequest)
+    : fOwnedImplementedRequest()
+    , fOwnsImplementedRequest(false)
+    , fpImplementedRequest(implementedRequest)
     , fpFirstChild(nullptr)
     , fpNextJob(nullptr)
     , fAllowedSessions(sessionMask)
@@ -119,6 +125,35 @@ public:
         {
             ETL_ASSERT(
                 requestLength > prefixLength,
+                ETL_ERROR_GENERIC("requested length must be greater than the prefix length"));
+        }
+    }
+
+    template<size_t N>
+    AbstractDiagJob(
+        ::etl::array<uint8_t, N> const& implementedRequest,
+        uint8_t const prefixLength,
+        DiagSessionMask const sessionMask = DiagSession::ALL_SESSIONS())
+    : fOwnedImplementedRequest(makeOwnedImplementedRequest(implementedRequest))
+    , fOwnsImplementedRequest(true)
+    , fpImplementedRequest(fOwnedImplementedRequest.data())
+    , fpFirstChild(nullptr)
+    , fpNextJob(nullptr)
+    , fAllowedSessions(sessionMask)
+    , fResponseLength(VARIABLE_RESPONSE_LENGTH)
+    , fRequestLength(static_cast<uint8_t>(N))
+    , fPrefixLength(prefixLength)
+    , fRequestPayloadLength(VARIABLE_REQUEST_LENGTH)
+    , fDefaultDiagReturnCode(DiagReturnCode::ISO_GENERAL_REJECT)
+    , fSuppressPositiveResponseBitEnabled(false)
+    {
+        static_assert(
+            N <= MAX_OWNED_IMPLEMENTED_REQUEST_LENGTH,
+            "owned implemented request exceeds supported length");
+        if (N > 0U)
+        {
+            ETL_ASSERT(
+                N > prefixLength,
                 ETL_ERROR_GENERIC("requested length must be greater than the prefix length"));
         }
     }
@@ -147,7 +182,9 @@ public:
         uint8_t const requestPayloadLength,
         uint8_t const responseLength,
         DiagSessionMask const sessionMask = DiagSession::ALL_SESSIONS())
-    : fpImplementedRequest(implementedRequest)
+    : fOwnedImplementedRequest()
+    , fOwnsImplementedRequest(false)
+    , fpImplementedRequest(implementedRequest)
     , fpFirstChild(nullptr)
     , fpNextJob(nullptr)
     , fAllowedSessions(sessionMask)
@@ -162,6 +199,37 @@ public:
         {
             ETL_ASSERT(
                 requestLength > prefixLength,
+                ETL_ERROR_GENERIC("requested length must be greater than the prefix length"));
+        }
+    }
+
+    template<size_t N>
+    AbstractDiagJob(
+        ::etl::array<uint8_t, N> const& implementedRequest,
+        uint8_t const prefixLength,
+        uint8_t const requestPayloadLength,
+        uint8_t const responseLength,
+        DiagSessionMask const sessionMask = DiagSession::ALL_SESSIONS())
+    : fOwnedImplementedRequest(makeOwnedImplementedRequest(implementedRequest))
+    , fOwnsImplementedRequest(true)
+    , fpImplementedRequest(fOwnedImplementedRequest.data())
+    , fpFirstChild(nullptr)
+    , fpNextJob(nullptr)
+    , fAllowedSessions(sessionMask)
+    , fResponseLength(responseLength)
+    , fRequestLength(static_cast<uint8_t>(N))
+    , fPrefixLength(prefixLength)
+    , fRequestPayloadLength(requestPayloadLength)
+    , fDefaultDiagReturnCode(DiagReturnCode::ISO_GENERAL_REJECT)
+    , fSuppressPositiveResponseBitEnabled(false)
+    {
+        static_assert(
+            N <= MAX_OWNED_IMPLEMENTED_REQUEST_LENGTH,
+            "owned implemented request exceeds supported length");
+        if (N > 0U)
+        {
+            ETL_ASSERT(
+                N > prefixLength,
                 ETL_ERROR_GENERIC("requested length must be greater than the prefix length"));
         }
     }
@@ -259,7 +327,10 @@ protected:
      * \see AsyncDiagJob
      */
     explicit AbstractDiagJob(AbstractDiagJob const* const pJob)
-    : fpImplementedRequest(pJob->fpImplementedRequest)
+    : fOwnedImplementedRequest(copyOwnedImplementedRequest(*pJob))
+    , fOwnsImplementedRequest(pJob->fOwnsImplementedRequest)
+    , fpImplementedRequest(
+          fOwnsImplementedRequest ? fOwnedImplementedRequest.data() : pJob->fpImplementedRequest)
     , fpFirstChild(nullptr)
     , fpNextJob(nullptr)
     , fAllowedSessions(pJob->fAllowedSessions)
@@ -368,6 +439,7 @@ protected:
     DiagSession::DiagSessionMask const getAllowedSessions() const;
 
     uint8_t const* getImplementedRequest() const;
+    ::etl::span<uint8_t const> getImplementedRequestView() const;
 
     uint8_t getRequestLength() const;
 
@@ -419,6 +491,30 @@ private:
     void checkSuppressPositiveResponseBit(
         IncomingDiagConnection& connection, uint8_t const request[]) const;
 
+    template<size_t N>
+    static ::etl::array<uint8_t, MAX_OWNED_IMPLEMENTED_REQUEST_LENGTH>
+    makeOwnedImplementedRequest(::etl::array<uint8_t, N> const& implementedRequest)
+    {
+        static_assert(
+            N <= MAX_OWNED_IMPLEMENTED_REQUEST_LENGTH,
+            "owned implemented request exceeds supported length");
+        ::etl::array<uint8_t, MAX_OWNED_IMPLEMENTED_REQUEST_LENGTH> ownedImplementedRequest = {};
+        ::etl::ranges::copy(implementedRequest, ownedImplementedRequest.begin());
+        return ownedImplementedRequest;
+    }
+
+    static ::etl::array<uint8_t, MAX_OWNED_IMPLEMENTED_REQUEST_LENGTH>
+    copyOwnedImplementedRequest(AbstractDiagJob const& job)
+    {
+        return job.fOwnsImplementedRequest
+                   ? job.fOwnedImplementedRequest
+                   : ::etl::array<uint8_t, MAX_OWNED_IMPLEMENTED_REQUEST_LENGTH>{};
+    }
+
+    /** Owned storage for implemented requests constructed from array values. */
+    ::etl::array<uint8_t, MAX_OWNED_IMPLEMENTED_REQUEST_LENGTH> fOwnedImplementedRequest;
+    /** Indicates whether fpImplementedRequest points to fOwnedImplementedRequest. */
+    bool const fOwnsImplementedRequest;
     /** Array containing the request implemented by this job */
     uint8_t const* const fpImplementedRequest;
     /** Pointer to first child. A child has fpImplementedRequest as its prefix */
@@ -474,6 +570,11 @@ inline DiagSession::DiagSessionMask const AbstractDiagJob::getAllowedSessions() 
 inline uint8_t const* AbstractDiagJob::getImplementedRequest() const
 {
     return fpImplementedRequest;
+}
+
+inline ::etl::span<uint8_t const> AbstractDiagJob::getImplementedRequestView() const
+{
+    return ::etl::span<uint8_t const>(fpImplementedRequest, fRequestLength);
 }
 
 inline uint8_t AbstractDiagJob::getRequestLength() const { return fRequestLength; }

--- a/libs/bsw/uds/include/uds/base/Service.h
+++ b/libs/bsw/uds/include/uds/base/Service.h
@@ -43,9 +43,7 @@ protected:
     DiagReturnCode::Type verify(uint8_t const request[], uint16_t requestLength) override;
 
 private:
-    void init(uint8_t service);
-
-    uint8_t fService[1];
+    void init();
 };
 
 } // namespace uds

--- a/libs/bsw/uds/include/uds/connection/IncomingDiagConnection.h
+++ b/libs/bsw/uds/include/uds/connection/IncomingDiagConnection.h
@@ -18,6 +18,7 @@
 #include "uds/connection/ErrorCode.h"
 #include "uds/connection/PositiveResponse.h"
 
+#include <etl/array.h>
 #include <etl/closure.h>
 #include <etl/uncopyable.h>
 #include <etl/vector.h>
@@ -287,8 +288,9 @@ private:
     transport::TransportMessage _pendingMessage  = {};
     transport::TransportMessage _responseMessage = {};
     PositiveResponse _positiveResponse;
-    uint8_t _pendingMessageBuffer[PENDING_MESSAGE_BUFFER_LENGTH]                     = {};
-    uint8_t _negativeResponseTempBuffer[DiagCodes::NEGATIVE_RESPONSE_MESSAGE_LENGTH] = {};
+    ::etl::array<uint8_t, PENDING_MESSAGE_BUFFER_LENGTH> _pendingMessageBuffer{};
+    ::etl::array<uint8_t, DiagCodes::NEGATIVE_RESPONSE_MESSAGE_LENGTH>
+        _negativeResponseTempBuffer{};
     ::etl::vector<uint8_t, MAXIMUM_NUMBER_OF_IDENTIFIERS> _identifiers;
     uint32_t _pendingTimeOut          = DEFAULT_PENDING_TIMEOUT_MS;
     NestedDiagRequest* _nestedRequest = nullptr;

--- a/libs/bsw/uds/include/uds/jobs/DataIdentifierJob.h
+++ b/libs/bsw/uds/include/uds/jobs/DataIdentifierJob.h
@@ -12,6 +12,8 @@
 
 #include "uds/base/AbstractDiagJob.h"
 
+#include <etl/array.h>
+
 namespace uds
 {
 /**
@@ -34,11 +36,25 @@ public:
     {}
 
     DataIdentifierJob(
+        ::etl::array<uint8_t, 3U> const& implementedRequest,
+        DiagSessionMask const sessionMask = DiagSession::ALL_SESSIONS())
+    : AbstractDiagJob(implementedRequest, 1U, sessionMask)
+    {}
+
+    DataIdentifierJob(
         uint8_t const* const implementedRequest,
         uint8_t const requestPayloadLength,
         uint8_t const responseLength,
         DiagSessionMask const sessionMask = DiagSession::ALL_SESSIONS())
     : AbstractDiagJob(implementedRequest, 3U, 1U, requestPayloadLength, responseLength, sessionMask)
+    {}
+
+    DataIdentifierJob(
+        ::etl::array<uint8_t, 3U> const& implementedRequest,
+        uint8_t const requestPayloadLength,
+        uint8_t const responseLength,
+        DiagSessionMask const sessionMask = DiagSession::ALL_SESSIONS())
+    : AbstractDiagJob(implementedRequest, 1U, requestPayloadLength, responseLength, sessionMask)
     {}
 
     DiagReturnCode::Type verify(uint8_t const request[], uint16_t requestLength) override;

--- a/libs/bsw/uds/include/uds/jobs/ReadIdentifierFromMemory.h
+++ b/libs/bsw/uds/include/uds/jobs/ReadIdentifierFromMemory.h
@@ -41,7 +41,6 @@ private:
         uint8_t const request[],
         uint16_t requestLength) override;
 
-    uint8_t _implementedRequest[3];
     ::etl::span<uint8_t const> _responseSlice;
 };
 

--- a/libs/bsw/uds/include/uds/jobs/ReadIdentifierFromSliceRef.h
+++ b/libs/bsw/uds/include/uds/jobs/ReadIdentifierFromSliceRef.h
@@ -36,7 +36,6 @@ private:
         uint8_t const request[],
         uint16_t requestLength) override;
 
-    uint8_t _implementedRequest[3];
     ::etl::span<uint8_t const> const& _responseSlice;
 };
 

--- a/libs/bsw/uds/include/uds/jobs/WriteIdentifierToMemory.h
+++ b/libs/bsw/uds/include/uds/jobs/WriteIdentifierToMemory.h
@@ -39,7 +39,6 @@ private:
         uint8_t const request[],
         uint16_t requestLength) override;
 
-    uint8_t _implementedRequest[3];
     ::etl::span<uint8_t> const _memory;
 };
 

--- a/libs/bsw/uds/include/uds/services/ecureset/EnableRapidPowerShutdown.h
+++ b/libs/bsw/uds/include/uds/services/ecureset/EnableRapidPowerShutdown.h
@@ -14,6 +14,8 @@
 #include "uds/base/Subfunction.h"
 #include "uds/lifecycle/IUdsLifecycleConnector.h"
 
+#include <etl/array.h>
+
 namespace uds
 {
 class EnableRapidPowerShutdown : public Subfunction
@@ -22,7 +24,7 @@ public:
     explicit EnableRapidPowerShutdown(IUdsLifecycleConnector& udsLifecycleConnector);
 
 private:
-    static uint8_t const sfImplementedRequest[2];
+    static ::etl::array<uint8_t, 2U> const sfImplementedRequest;
     static uint8_t const RESPONSE_LENGTH = 1U;
 
     virtual DiagReturnCode::Type process(

--- a/libs/bsw/uds/include/uds/services/ecureset/HardReset.h
+++ b/libs/bsw/uds/include/uds/services/ecureset/HardReset.h
@@ -14,6 +14,8 @@
 #include "uds/base/Subfunction.h"
 #include "uds/lifecycle/IUdsLifecycleConnector.h"
 
+#include <etl/array.h>
+
 namespace uds
 {
 class DiagDispatcher;
@@ -34,7 +36,7 @@ private:
     IUdsLifecycleConnector& fUdsLifecycleConnector;
     DiagDispatcher& fDiagDispatcher;
 
-    static uint8_t const sfImplementedRequest[2];
+    static ::etl::array<uint8_t, 2U> const sfImplementedRequest;
 };
 
 } // namespace uds

--- a/libs/bsw/uds/include/uds/services/ecureset/PowerDown.h
+++ b/libs/bsw/uds/include/uds/services/ecureset/PowerDown.h
@@ -13,6 +13,8 @@
 #include "uds/base/Subfunction.h"
 #include "uds/lifecycle/IUdsLifecycleConnector.h"
 
+#include <etl/array.h>
+
 namespace uds
 {
 class PowerDown : public Subfunction
@@ -21,7 +23,7 @@ public:
     explicit PowerDown(IUdsLifecycleConnector& udsLifecycleConnector);
 
 private:
-    static uint8_t const sfImplementedRequest[2];
+    static ::etl::array<uint8_t, 2U> const sfImplementedRequest;
 
     virtual DiagReturnCode::Type process(
         IncomingDiagConnection& connection, uint8_t const request[], uint16_t requestLength) final;

--- a/libs/bsw/uds/include/uds/services/ecureset/SoftReset.h
+++ b/libs/bsw/uds/include/uds/services/ecureset/SoftReset.h
@@ -14,6 +14,8 @@
 #include "uds/base/Subfunction.h"
 #include "uds/lifecycle/IUdsLifecycleConnector.h"
 
+#include <etl/array.h>
+
 namespace uds
 {
 class DiagDispatcher;
@@ -26,7 +28,7 @@ public:
     void responseSent(IncomingDiagConnection& connection, ResponseSendResult result) override;
 
 private:
-    static uint8_t const sfImplementedRequest[2];
+    static ::etl::array<uint8_t, 2U> const sfImplementedRequest;
 
     DiagReturnCode::Type process(
         IncomingDiagConnection& connection,

--- a/libs/bsw/uds/include/uds/services/routinecontrol/RequestRoutineResults.h
+++ b/libs/bsw/uds/include/uds/services/routinecontrol/RequestRoutineResults.h
@@ -12,6 +12,8 @@
 
 #include "uds/base/Subfunction.h"
 
+#include <etl/array.h>
+
 namespace uds
 {
 /**
@@ -24,7 +26,7 @@ public:
     RequestRoutineResults();
 
 private:
-    static uint8_t const sfImplementedRequest[2];
+    static ::etl::array<uint8_t, 2U> const sfImplementedRequest;
 };
 
 } // namespace uds

--- a/libs/bsw/uds/include/uds/services/routinecontrol/StartRoutine.h
+++ b/libs/bsw/uds/include/uds/services/routinecontrol/StartRoutine.h
@@ -12,6 +12,8 @@
 
 #include "uds/base/Subfunction.h"
 
+#include <etl/array.h>
+
 namespace uds
 {
 /**
@@ -24,7 +26,7 @@ public:
     StartRoutine();
 
 private:
-    static uint8_t const sfImplementedRequest[2];
+    static ::etl::array<uint8_t, 2U> const sfImplementedRequest;
 };
 
 } // namespace uds

--- a/libs/bsw/uds/include/uds/services/routinecontrol/StopRoutine.h
+++ b/libs/bsw/uds/include/uds/services/routinecontrol/StopRoutine.h
@@ -12,6 +12,8 @@
 
 #include "uds/base/Subfunction.h"
 
+#include <etl/array.h>
+
 namespace uds
 {
 /**
@@ -24,7 +26,7 @@ public:
     StopRoutine();
 
 private:
-    static uint8_t const sfImplementedRequest[2];
+    static ::etl::array<uint8_t, 2U> const sfImplementedRequest;
 };
 
 } // namespace uds

--- a/libs/bsw/uds/src/uds/DiagDispatcher.cpp
+++ b/libs/bsw/uds/src/uds/DiagDispatcher.cpp
@@ -170,7 +170,9 @@ void sendBusyResponse(
 
     busyMessage.setSourceAddress(configuration.DiagAddress);
     busyMessage.setTargetAddress(message->getSourceId());
-    busyMessage.getPayload()[1] = message->getServiceId();
+    ::etl::span<uint8_t> const payloadView(
+        busyMessage.getPayload(), DiagCodes::NEGATIVE_RESPONSE_MESSAGE_LENGTH);
+    payloadView[1U] = message->getServiceId();
 
     ITransportMessageListener::ReceiveResult const status
         = providingListenerHelper.messageReceived(configuration.DiagBusId, busyMessage, nullptr);

--- a/libs/bsw/uds/src/uds/base/AbstractDiagJob.cpp
+++ b/libs/bsw/uds/src/uds/base/AbstractDiagJob.cpp
@@ -50,6 +50,7 @@ void AbstractDiagJob::setDefaultDiagSessionManager(IDiagSessionManager& sessionM
 DiagReturnCode::Type AbstractDiagJob::execute(
     IncomingDiagConnection& connection, uint8_t const* const request, uint16_t const requestLength)
 {
+    ::etl::span<uint8_t const> const requestView(request, requestLength);
     DiagReturnCode::Type status = verify(request, requestLength);
     DiagJobRoot* jobRoot        = getDiagJobRoot();
     if (status == DiagReturnCode::OK)
@@ -66,8 +67,12 @@ DiagReturnCode::Type AbstractDiagJob::execute(
         }
         if (jobRoot != nullptr)
         {
-            DiagReturnCode::Type const vsistat = jobRoot->verifySupplierIndication(
-                request - fPrefixLength, requestLength + fPrefixLength);
+            // AbstractDiagJob dispatch passes child requests as prefix-trimmed views;
+            // supplier indication needs the full request view.
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            uint8_t const* const fullRequest = request - fPrefixLength;
+            DiagReturnCode::Type const vsistat
+                = jobRoot->verifySupplierIndication(fullRequest, requestLength + fPrefixLength);
             if (vsistat != DiagReturnCode::OK)
             {
                 acceptJob(connection, request, requestLength);
@@ -96,15 +101,16 @@ DiagReturnCode::Type AbstractDiagJob::execute(
                 return DiagReturnCode::ISO_RESPONSE_TOO_LONG;
             }
         }
-        checkSuppressPositiveResponseBit(connection, request + (fRequestLength - fPrefixLength));
+        checkSuppressPositiveResponseBit(
+            connection, requestView.subspan(fRequestLength - fPrefixLength).data());
         acceptJob(
             connection,
-            request + (fRequestLength - fPrefixLength),
+            requestView.subspan(fRequestLength - fPrefixLength).data(),
             requestLength - (static_cast<uint16_t>(fRequestLength) - fPrefixLength));
         Logger::debug(UDS, "Process diag job 0x%X", getRequestId());
         return process(
             connection,
-            request + (fRequestLength - fPrefixLength),
+            requestView.subspan(fRequestLength - fPrefixLength).data(),
             requestLength - (static_cast<uint16_t>(fRequestLength) - fPrefixLength));
     }
 
@@ -114,8 +120,12 @@ DiagReturnCode::Type AbstractDiagJob::execute(
             && (status != DiagReturnCode::ISO_SERVICE_NOT_SUPPORTED_IN_ACTIVE_SESSION)
             && (status != DiagReturnCode::ISO_SECURITY_ACCESS_DENIED))
         {
-            DiagReturnCode::Type const vsistat = jobRoot->verifySupplierIndication(
-                request - fPrefixLength, requestLength + fPrefixLength);
+            // AbstractDiagJob dispatch passes child requests as prefix-trimmed views;
+            // supplier indication needs the full request view.
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            uint8_t const* const fullRequest = request - fPrefixLength;
+            DiagReturnCode::Type const vsistat
+                = jobRoot->verifySupplierIndication(fullRequest, requestLength + fPrefixLength);
             if (vsistat != DiagReturnCode::OK)
             {
                 status = vsistat;
@@ -135,7 +145,7 @@ uint32_t AbstractDiagJob::getRequestId() const
         for (uint8_t i = 0; (i < 4) && (i < fRequestLength); ++i)
         {
             res <<= 8U;
-            res += fpImplementedRequest[i];
+            res += getImplementedRequestView()[i];
         }
     }
     return res;
@@ -364,10 +374,11 @@ void AbstractDiagJob::checkSuppressPositiveResponseBit(
 {
     if (fSuppressPositiveResponseBitEnabled)
     {
-        if ((request[0] & SUPPRESS_POSITIVE_RESPONSE_MASK) > 0U)
+        ::etl::span<uint8_t> const requestView(const_cast<uint8_t*>(request), 1U);
+        if ((requestView[0U] & SUPPRESS_POSITIVE_RESPONSE_MASK) > 0U)
         {
             // remove suppressPositiveResponse bit
-            const_cast<uint8_t*>(request)[0] &= 0x7FU;
+            requestView[0U] &= 0x7FU;
             connection.suppressPositiveResponse();
         }
     }

--- a/libs/bsw/uds/src/uds/base/DiagJobRoot.cpp
+++ b/libs/bsw/uds/src/uds/base/DiagJobRoot.cpp
@@ -41,6 +41,7 @@ DiagReturnCode::Type DiagJobRoot::verify(uint8_t const* const request, uint16_t 
 DiagReturnCode::Type DiagJobRoot::execute(
     IncomingDiagConnection& connection, uint8_t const* const request, uint16_t const requestLength)
 {
+    ::etl::span<uint8_t const> const requestView(request, requestLength);
     if (connection.serviceId == 0x7FU) // no response to incoming NRC
     {
         connection.terminate();
@@ -51,7 +52,7 @@ DiagReturnCode::Type DiagJobRoot::execute(
         if (connection.serviceId == uds::ServiceId::TESTER_PRESENT)
         {
             if ((!getDiagSessionManager().isSessionTimeoutActive()) && (requestLength > 1U)
-                && (((request[1] & SUPPRESS_POSITIVE_RESPONSE_MASK)) > 0U))
+                && (((requestView[1U] & SUPPRESS_POSITIVE_RESPONSE_MASK)) > 0U))
             {
                 connection.terminate();
                 return DiagReturnCode::OK;

--- a/libs/bsw/uds/src/uds/base/Service.cpp
+++ b/libs/bsw/uds/src/uds/base/Service.cpp
@@ -16,16 +16,20 @@
 
 namespace uds
 {
+namespace
+{
+::etl::array<uint8_t, 1U> makeImplementedRequest(uint8_t const service) { return {{service}}; }
+} // namespace
+
 Service::Service(uint8_t const service, DiagSession::DiagSessionMask const sessionMask)
 : AbstractDiagJob(
-    fService,
-    1U,
+    makeImplementedRequest(service),
     0U,
     AbstractDiagJob::VARIABLE_REQUEST_LENGTH,
     AbstractDiagJob::VARIABLE_RESPONSE_LENGTH,
     sessionMask)
 {
-    init(service);
+    init();
 }
 
 Service::Service(
@@ -33,21 +37,19 @@ Service::Service(
     uint8_t const requestPayloadLength,
     uint8_t const responseLength,
     DiagSession::DiagSessionMask const sessionMask)
-: AbstractDiagJob(fService, 1U, 0U, requestPayloadLength, responseLength, sessionMask)
+: AbstractDiagJob(
+    makeImplementedRequest(service), 0U, requestPayloadLength, responseLength, sessionMask)
 {
-    init(service);
+    init();
 }
 
-void Service::init(uint8_t const service)
-{
-    fService[0] = service;
-    setDefaultDiagReturnCode(DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED);
-}
+void Service::init() { setDefaultDiagReturnCode(DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED); }
 
 DiagReturnCode::Type
 Service::verify(uint8_t const* const request, uint16_t const /* requestLength */)
 {
-    if (request[0] != fpImplementedRequest[0])
+    ::etl::span<uint8_t const> const requestView(request, 1U);
+    if (requestView[0U] != getImplementedRequestView()[0U])
     {
         return DiagReturnCode::NOT_RESPONSIBLE;
     }

--- a/libs/bsw/uds/src/uds/base/Subfunction.cpp
+++ b/libs/bsw/uds/src/uds/base/Subfunction.cpp
@@ -40,7 +40,8 @@ DiagReturnCode::Type Subfunction::verify(uint8_t const* const request, uint16_t 
     {
         return DiagReturnCode::ISO_INVALID_FORMAT;
     }
-    if (request[0] != getImplementedRequest()[1])
+    ::etl::span<uint8_t const> const requestView(request, requestLength);
+    if (requestView[0U] != getImplementedRequestView()[1U])
     {
         return DiagReturnCode::NOT_RESPONSIBLE;
     }

--- a/libs/bsw/uds/src/uds/connection/IncomingDiagConnection.cpp
+++ b/libs/bsw/uds/src/uds/connection/IncomingDiagConnection.cpp
@@ -24,6 +24,7 @@
 
 #include <async/Async.h>
 
+#include <etl/algorithm.h>
 #include <etl/error_handler.h>
 #include <etl/span.h>
 
@@ -91,7 +92,27 @@ void IncomingDiagConnection::addIdentifier()
     }
     else if ((nullptr != requestMessage) && (_identifiers.size() < _identifiers.max_size()))
     {
-        _identifiers.push_back(requestMessage->getPayload()[_identifiers.size()]);
+        uint16_t const payloadLength   = requestMessage->getPayloadLength();
+        uint16_t const validBytes      = requestMessage->getValidBytes();
+        uint16_t const availableLength = (payloadLength > validBytes) ? payloadLength : validBytes;
+        size_t const nextIdentifierIdx = _identifiers.size();
+        if ((nextIdentifierIdx == 0U) && (availableLength == 0U))
+        {
+            _identifiers.push_back(serviceId);
+            return;
+        }
+
+        ::etl::span<uint8_t const> const payload(requestMessage->getPayload(), availableLength);
+        if (nextIdentifierIdx >= payload.size())
+        {
+            Logger::error(
+                UDS,
+                "IncomingDiagConnection::addIdentifier(): payload too short, idx=%u len=%u",
+                static_cast<unsigned>(nextIdentifierIdx),
+                static_cast<unsigned>(payload.size()));
+            return;
+        }
+        _identifiers.push_back(payload[nextIdentifierIdx]);
     }
     else
     {
@@ -179,10 +200,9 @@ void IncomingDiagConnection::asyncSendPositiveResponse(
         responseMessage->setTargetAddress(tmpSourceId);
         if (DiagReturnCode::NEGATIVE_RESPONSE_IDENTIFIER == responseMessage->getServiceId())
         { // we did send a negative response before --> restore payload
-            for (uint8_t i = 0U; i < DiagCodes::NEGATIVE_RESPONSE_MESSAGE_LENGTH; ++i)
-            {
-                responseMessage->getPayload()[i] = _negativeResponseTempBuffer[i];
-            }
+            ::etl::span<uint8_t> const payload(
+                responseMessage->getPayload(), DiagCodes::NEGATIVE_RESPONSE_MESSAGE_LENGTH);
+            ::etl::ranges::copy(_negativeResponseTempBuffer, payload.begin());
         }
         responseMessage->resetValidBytes();
         for (auto& identifier : _identifiers)
@@ -193,8 +213,10 @@ void IncomingDiagConnection::asyncSendPositiveResponse(
         (void)responseMessage->increaseValidBytes(length);
         responseMessage->setPayloadLength(_identifiers.size() + length);
         _sender = pSender;
+        ::etl::span<uint8_t> const responsePayload(
+            responseMessage->getPayload(), responseMessage->getPayloadLength());
         diagSessionManager->responseSent(
-            *this, DiagReturnCode::OK, &((*responseMessage)[_identifiers.size()]), length);
+            *this, DiagReturnCode::OK, responsePayload.subspan(_identifiers.size()).data(), length);
     }
     if ((!_suppressPositiveResponse) || _responsePendingSent)
     { // this is not a positive response to a suppressed request --> send
@@ -240,9 +262,8 @@ DiagReturnCode::Type IncomingDiagConnection::startNestedRequest(
     _identifiers.resize(nestedRequest.prefixLength);
     nestedRequest.init(
         sender,
-        ::etl::span<uint8_t>(
-            responseMessage->getBuffer() + _identifiers.size(),
-            responseMessage->getBufferLength() - _identifiers.size()),
+        ::etl::span<uint8_t>(responseMessage->getBuffer(), responseMessage->getBufferLength())
+            .subspan(_identifiers.size()),
         ::etl::span<uint8_t const>(request, static_cast<size_t>(requestLength)));
     _nestedRequest = &nestedRequest;
     triggerNextNestedRequest();
@@ -354,7 +375,7 @@ void IncomingDiagConnection::asyncSendNegativeResponse(
                 {
                     buildResponsePendingTransportMessage(
                         _pendingMessage,
-                        _pendingMessageBuffer,
+                        _pendingMessageBuffer.data(),
                         sourceAddress,
                         responseSourceAddress,
                         serviceId);
@@ -381,10 +402,9 @@ void IncomingDiagConnection::asyncSendNegativeResponse(
     responseMessage->setTargetAddress(sourceAddress);
     if (DiagReturnCode::NEGATIVE_RESPONSE_IDENTIFIER != responseMessage->getServiceId())
     { // make a backup only the first time a negative response is sent!
-        for (uint8_t i = 0U; i < DiagCodes::NEGATIVE_RESPONSE_MESSAGE_LENGTH; ++i)
-        {
-            _negativeResponseTempBuffer[i] = responseMessage->getPayload()[i];
-        }
+        ::etl::span<uint8_t const> const payload(
+            responseMessage->getPayload(), DiagCodes::NEGATIVE_RESPONSE_MESSAGE_LENGTH);
+        ::etl::ranges::copy(payload, _negativeResponseTempBuffer.begin());
     }
     responseMessage->resetValidBytes();
     (void)responseMessage->append(DiagReturnCode::NEGATIVE_RESPONSE_IDENTIFIER);
@@ -393,10 +413,12 @@ void IncomingDiagConnection::asyncSendNegativeResponse(
     _sender = pSender;
     if (responseCode != static_cast<uint8_t>(DiagReturnCode::ISO_RESPONSE_PENDING))
     {
+        ::etl::span<uint8_t> const payload(
+            responseMessage->getPayload(), responseMessage->getPayloadLength());
         diagSessionManager->responseSent(
             *this,
             static_cast<DiagReturnCode::Type>(responseCode),
-            responseMessage->getPayload() + DiagCodes::NEGATIVE_RESPONSE_MESSAGE_LENGTH,
+            payload.subspan(DiagCodes::NEGATIVE_RESPONSE_MESSAGE_LENGTH).data(),
             0U);
     }
     if (!((TransportConfiguration::isFunctionalAddress(targetAddress))
@@ -533,7 +555,7 @@ void IncomingDiagConnection::asyncTransportMessageProcessed(
             {
                 buildResponsePendingTransportMessage(
                     _pendingMessage,
-                    _pendingMessageBuffer,
+                    _pendingMessageBuffer.data(),
                     sourceAddress,
                     responseSourceAddress,
                     serviceId);
@@ -604,7 +626,7 @@ void IncomingDiagConnection::expired(::async::RunnableType const& timeout)
             {
                 buildResponsePendingTransportMessage(
                     _pendingMessage,
-                    _pendingMessageBuffer,
+                    _pendingMessageBuffer.data(),
                     sourceAddress,
                     responseSourceAddress,
                     serviceId);

--- a/libs/bsw/uds/src/uds/jobs/DataIdentifierJob.cpp
+++ b/libs/bsw/uds/src/uds/jobs/DataIdentifierJob.cpp
@@ -15,9 +15,15 @@
 namespace uds
 {
 DiagReturnCode::Type
-DataIdentifierJob::verify(uint8_t const* const request, uint16_t const /* requestLength */)
+DataIdentifierJob::verify(uint8_t const* const request, uint16_t const requestLength)
 {
-    if (!compare(request, getImplementedRequest() + 1U, 2U))
+    if (requestLength < 2U)
+    {
+        return DiagReturnCode::ISO_INVALID_FORMAT;
+    }
+
+    auto const implementedRequest = getImplementedRequestView();
+    if (!compare(request, implementedRequest.subspan(1U, 2U).data(), 2U))
     {
         return DiagReturnCode::NOT_RESPONSIBLE;
     }

--- a/libs/bsw/uds/src/uds/jobs/ReadIdentifierFromMemory.cpp
+++ b/libs/bsw/uds/src/uds/jobs/ReadIdentifierFromMemory.cpp
@@ -14,6 +14,17 @@
 
 namespace uds
 {
+namespace
+{
+::etl::array<uint8_t, 3U> makeImplementedRequest(uint16_t const identifier)
+{
+    return {
+        {0x22U,
+         static_cast<uint8_t>((identifier >> 8U) & 0xFFU),
+         static_cast<uint8_t>(identifier & 0xFFU)}};
+}
+} // namespace
+
 ReadIdentifierFromMemory::ReadIdentifierFromMemory(
     uint16_t const identifier,
     uint8_t const* const responseData,
@@ -27,12 +38,8 @@ ReadIdentifierFromMemory::ReadIdentifierFromMemory(
     uint16_t const identifier,
     ::etl::span<uint8_t const> const& responseData,
     DiagSessionMask const sessionMask)
-: DataIdentifierJob(_implementedRequest, sessionMask), _responseSlice(responseData)
-{
-    _implementedRequest[0] = 0x22U;
-    _implementedRequest[1] = (identifier >> 8) & 0xFFU;
-    _implementedRequest[2] = identifier & 0xFFU;
-}
+: DataIdentifierJob(makeImplementedRequest(identifier), sessionMask), _responseSlice(responseData)
+{}
 
 DiagReturnCode::Type ReadIdentifierFromMemory::process(
     IncomingDiagConnection& connection,

--- a/libs/bsw/uds/src/uds/jobs/ReadIdentifierFromSliceRef.cpp
+++ b/libs/bsw/uds/src/uds/jobs/ReadIdentifierFromSliceRef.cpp
@@ -14,16 +14,23 @@
 
 namespace uds
 {
+namespace
+{
+::etl::array<uint8_t, 3U> makeImplementedRequest(uint16_t const identifier)
+{
+    return {
+        {0x22U,
+         static_cast<uint8_t>((identifier >> 8U) & 0xFFU),
+         static_cast<uint8_t>(identifier & 0xFFU)}};
+}
+} // namespace
+
 ReadIdentifierFromSliceRef::ReadIdentifierFromSliceRef(
     uint16_t const identifier,
     ::etl::span<uint8_t const> const& responseData,
     DiagSessionMask const sessionMask)
-: DataIdentifierJob(_implementedRequest, sessionMask), _responseSlice(responseData)
-{
-    _implementedRequest[0] = 0x22U;
-    _implementedRequest[1] = static_cast<uint8_t>((identifier >> 8) & 0xFFU);
-    _implementedRequest[2] = static_cast<uint8_t>(identifier & 0xFFU);
-}
+: DataIdentifierJob(makeImplementedRequest(identifier), sessionMask), _responseSlice(responseData)
+{}
 
 DiagReturnCode::Type ReadIdentifierFromSliceRef::process(
     IncomingDiagConnection& connection,

--- a/libs/bsw/uds/src/uds/jobs/RoutineControlJob.cpp
+++ b/libs/bsw/uds/src/uds/jobs/RoutineControlJob.cpp
@@ -35,8 +35,11 @@ AbstractDiagJob& RoutineControlJob::getRequestRoutineResults()
 DiagReturnCode::Type
 RoutineControlJob::verify(uint8_t const* const request, uint16_t const /* requestLength */)
 {
+    auto const implementedRequest = getImplementedRequestView();
     if (!compare(
-            request, getImplementedRequest() + 2U, static_cast<uint16_t>(getRequestLength()) - 2U))
+            request,
+            implementedRequest.subspan(2U).data(),
+            static_cast<uint16_t>(implementedRequest.size() - 2U)))
     {
         return DiagReturnCode::NOT_RESPONSIBLE;
     }

--- a/libs/bsw/uds/src/uds/jobs/WriteIdentifierToMemory.cpp
+++ b/libs/bsw/uds/src/uds/jobs/WriteIdentifierToMemory.cpp
@@ -16,23 +16,31 @@
 
 namespace uds
 {
+namespace
+{
+::etl::array<uint8_t, 3U> makeImplementedRequest(uint16_t const identifier)
+{
+    return {
+        {0x2EU,
+         static_cast<uint8_t>((identifier >> 8U) & 0xFFU),
+         static_cast<uint8_t>(identifier & 0xFFU)}};
+}
+} // namespace
+
 WriteIdentifierToMemory::WriteIdentifierToMemory(
     uint16_t const identifier,
     ::etl::span<uint8_t> const& memory,
     DiagSessionMask const sessionMask)
-: DataIdentifierJob(_implementedRequest, sessionMask), _memory(memory)
-{
-    _implementedRequest[0] = 0x2EU;
-    _implementedRequest[1] = static_cast<uint8_t>((identifier >> 8U) & 0xFFU);
-    _implementedRequest[2] = static_cast<uint8_t>(identifier & 0xFFU);
-}
+: DataIdentifierJob(makeImplementedRequest(identifier), sessionMask), _memory(memory)
+{}
 
 DiagReturnCode::Type
 WriteIdentifierToMemory::verify(uint8_t const* const request, uint16_t const requestLength)
 {
-    if (!compare(request, getImplementedRequest() + 1U, 2U))
+    DiagReturnCode::Type const result = DataIdentifierJob::verify(request, requestLength);
+    if (result != DiagReturnCode::OK)
     {
-        return DiagReturnCode::NOT_RESPONSIBLE;
+        return result;
     }
 
     if (requestLength != (_memory.size() + 2))

--- a/libs/bsw/uds/src/uds/services/communicationcontrol/CommunicationControl.cpp
+++ b/libs/bsw/uds/src/uds/services/communicationcontrol/CommunicationControl.cpp
@@ -10,6 +10,8 @@
 
 #include "uds/services/communicationcontrol/CommunicationControl.h"
 
+#include <etl/span.h>
+
 #include "uds/UdsLogger.h"
 #include "uds/connection/IncomingDiagConnection.h"
 #include "uds/session/ApplicationExtendedSession.h"
@@ -117,8 +119,15 @@ DiagReturnCode::Type CommunicationControl::process(
     {
         return ret;
     }
-    uint8_t const controlType         = request[0];
-    uint8_t const communicationTypeLo = request[1] & 0x0FU;
+
+    if (requestLength < EXPECTED_REQUEST_LENGTH)
+    {
+        return DiagReturnCode::ISO_INVALID_FORMAT;
+    }
+
+    ::etl::span<uint8_t const> const requestView(request, requestLength);
+    uint8_t const controlType         = requestView[0U];
+    uint8_t const communicationTypeLo = requestView[1U] & 0x0FU;
     uint16_t rcvNode                  = 0U;
 
     /* if communicationTypeHi is set with value 0xF0 it means :
@@ -127,7 +136,7 @@ DiagReturnCode::Type CommunicationControl::process(
        if between 0x10 .. 0xE0 it could be a NM by number.
     */
 
-    uint8_t const communicationTypeHi = request[1U] & 0xF0U;
+    uint8_t const communicationTypeHi = requestView[1U] & 0xF0U;
 
     if ((((static_cast<uint8_t>(ENABLE_RX_AND_DISABLE_TX_WITH_ENHANCED_ADDRESS_INFORMATION)
            == controlType)
@@ -242,7 +251,7 @@ DiagReturnCode::Type CommunicationControl::process(
         {
             if (static_cast<uint8_t>(NORMAL_COMMUNICATION_MESSAGES) == communicationTypeLo)
             {
-                rcvNode = ::etl::be_uint16_t(&request[2]);
+                rcvNode = ::etl::be_uint16_t(requestView.subspan(2U, 2U).data());
                 if (0U == fSubNodeIdDisabledTx)
                 {
                     if (notifySubListeners(
@@ -278,7 +287,7 @@ DiagReturnCode::Type CommunicationControl::process(
         {
             if (static_cast<uint8_t>(NORMAL_COMMUNICATION_MESSAGES) == communicationTypeLo)
             {
-                rcvNode = ::etl::be_uint16_t(&request[2]);
+                rcvNode = ::etl::be_uint16_t(requestView.subspan(2U, 2U).data());
                 if (rcvNode == fSubNodeIdDisabledTx)
                 {
                     if (notifySubListeners(

--- a/libs/bsw/uds/src/uds/services/controldtcsetting/ControlDTCSetting.cpp
+++ b/libs/bsw/uds/src/uds/services/controldtcsetting/ControlDTCSetting.cpp
@@ -37,7 +37,8 @@ DiagReturnCode::Type ControlDTCSetting::process(
     uint8_t const* const request,
     uint16_t const /* requestLength */)
 {
-    uint8_t const dtcSettingType = request[0];
+    ::etl::span<uint8_t const> const requestView(request, 1U);
+    uint8_t const dtcSettingType = requestView[0U];
     Logger::debug(UDS, "ControlDTCSetting %d", dtcSettingType);
     switch (dtcSettingType)
     {

--- a/libs/bsw/uds/src/uds/services/ecureset/EnableRapidPowerShutdown.cpp
+++ b/libs/bsw/uds/src/uds/services/ecureset/EnableRapidPowerShutdown.cpp
@@ -19,11 +19,12 @@
 
 namespace uds
 {
-uint8_t const EnableRapidPowerShutdown::sfImplementedRequest[2] = {ServiceId::ECU_RESET, 0x04U};
+::etl::array<uint8_t, 2U> const EnableRapidPowerShutdown::sfImplementedRequest
+    = {ServiceId::ECU_RESET, 0x04U};
 
 EnableRapidPowerShutdown::EnableRapidPowerShutdown(IUdsLifecycleConnector& udsLifecycleConnector)
 : Subfunction(
-    &sfImplementedRequest[0],
+    sfImplementedRequest.data(),
     AbstractDiagJob::EMPTY_REQUEST,
     RESPONSE_LENGTH,
     DiagSessionMask::getInstance() << DiagSession::APPLICATION_DEFAULT_SESSION()

--- a/libs/bsw/uds/src/uds/services/ecureset/HardReset.cpp
+++ b/libs/bsw/uds/src/uds/services/ecureset/HardReset.cpp
@@ -18,11 +18,11 @@
 
 namespace uds
 {
-uint8_t const HardReset::sfImplementedRequest[] = {ServiceId::ECU_RESET, 0x01U};
+::etl::array<uint8_t, 2U> const HardReset::sfImplementedRequest = {ServiceId::ECU_RESET, 0x01U};
 
 HardReset::HardReset(IUdsLifecycleConnector& udsLifecycleConnector, DiagDispatcher& diagDispatcher)
 : Subfunction(
-    &sfImplementedRequest[0],
+    sfImplementedRequest.data(),
     AbstractDiagJob::EMPTY_REQUEST,
     AbstractDiagJob::EMPTY_RESPONSE,
     DiagSession::ALL_SESSIONS())

--- a/libs/bsw/uds/src/uds/services/ecureset/PowerDown.cpp
+++ b/libs/bsw/uds/src/uds/services/ecureset/PowerDown.cpp
@@ -18,11 +18,11 @@
 
 namespace uds
 {
-uint8_t const PowerDown::sfImplementedRequest[2] = {ServiceId::ECU_RESET, 0x41U};
+::etl::array<uint8_t, 2U> const PowerDown::sfImplementedRequest = {ServiceId::ECU_RESET, 0x41U};
 
 PowerDown::PowerDown(IUdsLifecycleConnector& udsLifecycleConnector)
 : Subfunction(
-    &sfImplementedRequest[0],
+    sfImplementedRequest.data(),
     AbstractDiagJob::EMPTY_REQUEST,
     AbstractDiagJob::EMPTY_RESPONSE,
     DiagSessionMask::getInstance() << DiagSession::APPLICATION_DEFAULT_SESSION()

--- a/libs/bsw/uds/src/uds/services/ecureset/SoftReset.cpp
+++ b/libs/bsw/uds/src/uds/services/ecureset/SoftReset.cpp
@@ -21,11 +21,11 @@
 
 namespace uds
 {
-uint8_t const SoftReset::sfImplementedRequest[2] = {ServiceId::ECU_RESET, 0x03U};
+::etl::array<uint8_t, 2U> const SoftReset::sfImplementedRequest = {ServiceId::ECU_RESET, 0x03U};
 
 SoftReset::SoftReset(IUdsLifecycleConnector& udsLifecycleConnector, DiagDispatcher& diagDispatcher)
 : Subfunction(
-    &sfImplementedRequest[0],
+    sfImplementedRequest.data(),
     AbstractDiagJob::EMPTY_REQUEST,
     AbstractDiagJob::EMPTY_RESPONSE,
     DiagSessionMask::getInstance()

--- a/libs/bsw/uds/src/uds/services/inputoutputcontrol/InputOutputControlByIdentifier.cpp
+++ b/libs/bsw/uds/src/uds/services/inputoutputcontrol/InputOutputControlByIdentifier.cpp
@@ -25,6 +25,7 @@ DiagReturnCode::Type
 InputOutputControlByIdentifier::verify(uint8_t const* const request, uint16_t const requestLength)
 {
     static constexpr uint8_t MIN_REQUEST_LEN = 4U;
+    ::etl::span<uint8_t const> const requestView(request, requestLength);
 
     DiagReturnCode::Type result = Service::verify(request, requestLength);
     if (DiagReturnCode::OK == result)
@@ -41,7 +42,7 @@ InputOutputControlByIdentifier::verify(uint8_t const* const request, uint16_t co
          * */
         uint8_t const controlParamOffset = 3U;
         InputOutputControlByIdentifier::IOControlParameter::ID const controlParameter
-            = static_cast<IOControlParameter::ID>(request[controlParamOffset]);
+            = static_cast<IOControlParameter::ID>(requestView[controlParamOffset]);
 
         if ((controlParameter == IOControlParameter::SHORT_TERM_ADJUSTMENT)
             && (requestLength < static_cast<uint8_t>(MIN_REQUEST_LEN + 1U)))

--- a/libs/bsw/uds/src/uds/services/readdata/MultipleReadDataByIdentifier.cpp
+++ b/libs/bsw/uds/src/uds/services/readdata/MultipleReadDataByIdentifier.cpp
@@ -14,16 +14,18 @@
 #include "uds/connection/IncomingDiagConnection.h"
 #include "uds/session/DiagSession.h"
 
+#include <etl/array.h>
 #include <etl/memory.h>
 #include <transport/TransportMessage.h>
 
 namespace uds
 {
 
-uint8_t const thisimplementedRequest[] = {ServiceId::READ_DATA_BY_IDENTIFIER};
+static ::etl::array<uint8_t, 1U> const thisimplementedRequest
+    = {ServiceId::READ_DATA_BY_IDENTIFIER};
 
 MultipleReadDataByIdentifier::MultipleReadDataByIdentifier(IAsyncDiagHelper& asyncHelper)
-: AbstractDiagJob(&thisimplementedRequest[0], 1U, 0U, DiagSession::ALL_SESSIONS())
+: AbstractDiagJob(thisimplementedRequest.data(), 1U, 0U, DiagSession::ALL_SESSIONS())
 , NestedDiagRequest(1U)
 , fAsyncJobHelper(asyncHelper, *this)
 , fFirstJob(*this)
@@ -39,7 +41,7 @@ MultipleReadDataByIdentifier::MultipleReadDataByIdentifier(IAsyncDiagHelper& asy
 
 MultipleReadDataByIdentifier::MultipleReadDataByIdentifier(
     IAsyncDiagHelper& asyncHelper, AbstractDiagJob& firstJob)
-: AbstractDiagJob(&thisimplementedRequest[0], 1U, 0U, DiagSession::ALL_SESSIONS())
+: AbstractDiagJob(thisimplementedRequest.data(), 1U, 0U, DiagSession::ALL_SESSIONS())
 , NestedDiagRequest(1U)
 , fAsyncJobHelper(asyncHelper, *this)
 , fFirstJob(firstJob)
@@ -75,7 +77,13 @@ void MultipleReadDataByIdentifier::setCheckResponse(CheckResponseType const chec
 DiagReturnCode::Type
 MultipleReadDataByIdentifier::verify(uint8_t const* const request, uint16_t const requestLength)
 {
-    if (request[0] == ServiceId::READ_DATA_BY_IDENTIFIER)
+    if ((request == nullptr) || (requestLength < 1U))
+    {
+        return DiagReturnCode::ISO_INVALID_FORMAT;
+    }
+
+    ::etl::span<uint8_t const> const requestView(request, requestLength);
+    if (requestView[0U] == ServiceId::READ_DATA_BY_IDENTIFIER)
     {
         if ((requestLength >= 3U) && (((requestLength - 1U) % 2U) == 0U))
         {

--- a/libs/bsw/uds/src/uds/services/readdtcinformation/ReadDTCInformation.cpp
+++ b/libs/bsw/uds/src/uds/services/readdtcinformation/ReadDTCInformation.cpp
@@ -13,6 +13,8 @@
 #include "uds/connection/IncomingDiagConnection.h"
 #include "uds/session/DiagSession.h"
 
+#include <etl/array.h>
+
 namespace uds
 {
 ReadDTCInformation::ReadDTCInformation()
@@ -30,7 +32,12 @@ ReadDTCInformation::verify(uint8_t const* const request, uint16_t const requestL
 DiagReturnCode::Type ReadDTCInformation::process(
     IncomingDiagConnection& connection, uint8_t const* const request, uint16_t const requestLength)
 {
-    uint8_t const subFunction = request[0];
+    if (requestLength < 1U)
+    {
+        return DiagReturnCode::ISO_INVALID_FORMAT;
+    }
+    ::etl::span<uint8_t const> const requestView(request, requestLength);
+    uint8_t const subFunction = requestView[0U];
     switch (subFunction)
     {
         case REPORT_DTC_BY_STATUS_MASK:
@@ -39,7 +46,7 @@ DiagReturnCode::Type ReadDTCInformation::process(
             {
                 return DiagReturnCode::ISO_INVALID_FORMAT;
             }
-            uint8_t const dtcData[] = {
+            ::etl::array<uint8_t, 5U> const dtcData = {
                 0xFFU, // DTCStatusAvailabilityMask
                 0x12U,
                 0x34U,
@@ -48,7 +55,7 @@ DiagReturnCode::Type ReadDTCInformation::process(
             };
             PositiveResponse& response = connection.releaseRequestGetResponse();
             (void)response.appendUint8(subFunction);
-            (void)response.appendData(dtcData, sizeof(dtcData));
+            (void)response.appendData(dtcData.data(), static_cast<uint16_t>(dtcData.size()));
             (void)connection.sendPositiveResponseInternal(response.getLength(), *this);
             return DiagReturnCode::OK;
         }

--- a/libs/bsw/uds/src/uds/services/routinecontrol/RequestRoutineResults.cpp
+++ b/libs/bsw/uds/src/uds/services/routinecontrol/RequestRoutineResults.cpp
@@ -18,13 +18,13 @@
 
 namespace uds
 {
-uint8_t const RequestRoutineResults::sfImplementedRequest[2]
+::etl::array<uint8_t, 2U> const RequestRoutineResults::sfImplementedRequest
     = {ServiceId::ROUTINE_CONTROL,
        static_cast<::etl::underlying_type<RoutineControl::Subfunction>::type>(
            RoutineControl::Subfunction::REQUEST_ROUTINE_RESULTS)};
 
 RequestRoutineResults::RequestRoutineResults()
-: Subfunction(&sfImplementedRequest[0], DiagSession::ALL_SESSIONS())
+: Subfunction(sfImplementedRequest.data(), DiagSession::ALL_SESSIONS())
 {
     setDefaultDiagReturnCode(DiagReturnCode::ISO_REQUEST_OUT_OF_RANGE);
 }

--- a/libs/bsw/uds/src/uds/services/routinecontrol/StartRoutine.cpp
+++ b/libs/bsw/uds/src/uds/services/routinecontrol/StartRoutine.cpp
@@ -18,12 +18,12 @@
 
 namespace uds
 {
-uint8_t const StartRoutine::sfImplementedRequest[2]
+::etl::array<uint8_t, 2U> const StartRoutine::sfImplementedRequest
     = {ServiceId::ROUTINE_CONTROL,
        static_cast<::etl::underlying_type<RoutineControl::Subfunction>::type>(
            RoutineControl::Subfunction::START_ROUTINE)};
 
-StartRoutine::StartRoutine() : Subfunction(&sfImplementedRequest[0], DiagSession::ALL_SESSIONS())
+StartRoutine::StartRoutine() : Subfunction(sfImplementedRequest.data(), DiagSession::ALL_SESSIONS())
 {
     setDefaultDiagReturnCode(DiagReturnCode::ISO_REQUEST_OUT_OF_RANGE);
 }

--- a/libs/bsw/uds/src/uds/services/routinecontrol/StopRoutine.cpp
+++ b/libs/bsw/uds/src/uds/services/routinecontrol/StopRoutine.cpp
@@ -18,12 +18,12 @@
 
 namespace uds
 {
-uint8_t const StopRoutine::sfImplementedRequest[2]
+::etl::array<uint8_t, 2U> const StopRoutine::sfImplementedRequest
     = {ServiceId::ROUTINE_CONTROL,
        static_cast<::etl::underlying_type<RoutineControl::Subfunction>::type>(
            RoutineControl::Subfunction::STOP_ROUTINE)};
 
-StopRoutine::StopRoutine() : Subfunction(&sfImplementedRequest[0], DiagSession::ALL_SESSIONS())
+StopRoutine::StopRoutine() : Subfunction(sfImplementedRequest.data(), DiagSession::ALL_SESSIONS())
 {
     setDefaultDiagReturnCode(DiagReturnCode::ISO_REQUEST_OUT_OF_RANGE);
 }

--- a/libs/bsw/uds/src/uds/services/sessioncontrol/DiagnosticSessionControl.cpp
+++ b/libs/bsw/uds/src/uds/services/sessioncontrol/DiagnosticSessionControl.cpp
@@ -103,8 +103,9 @@ DiagReturnCode::Type DiagnosticSessionControl::process(
     {
         return DiagReturnCode::ISO_INVALID_FORMAT;
     }
+    ::etl::span<uint8_t const> const requestView(request, requestLength);
     DiagSession::SessionType const requestedSession
-        = static_cast<DiagSession::SessionType>(request[0]);
+        = static_cast<DiagSession::SessionType>(requestView[0U]);
     Logger::debug(UDS, "%d -> %d", fpCurrentSession->getType(), requestedSession);
 
     if (fpCurrentSession == nullptr)

--- a/libs/bsw/uds/src/uds/services/testerpresent/TesterPresent.cpp
+++ b/libs/bsw/uds/src/uds/services/testerpresent/TesterPresent.cpp
@@ -38,7 +38,8 @@ DiagReturnCode::Type TesterPresent::process(
     uint8_t const* const request,
     uint16_t const /* requestLength */)
 {
-    if (request[0] == TESTER_PRESENT_ANSWER)
+    ::etl::span<uint8_t const> const requestView(request, 1U);
+    if (requestView[0U] == TESTER_PRESENT_ANSWER)
     {
         PositiveResponse& response = connection.releaseRequestGetResponse();
         (void)response.appendUint8(TESTER_PRESENT_ANSWER);

--- a/libs/bsw/uds/src/util/RoutineControlOptionParser.cpp
+++ b/libs/bsw/uds/src/util/RoutineControlOptionParser.cpp
@@ -10,6 +10,7 @@
 
 #include "util/RoutineControlOptionParser.h"
 
+#include <etl/span.h>
 #include <etl/unaligned_type.h>
 
 namespace uds
@@ -45,8 +46,9 @@ RoutineControlOptionParser::parseParameter(uint8_t const* const buffer, uint8_t 
         }
         case 3U:
         {
-            return (static_cast<uint32_t>(*buffer) << 16)
-                   | static_cast<uint32_t>(::etl::be_uint16_t(buffer + 1));
+            ::etl::span<uint8_t const> const bufferView(buffer, 3U);
+            return (static_cast<uint32_t>(bufferView[0U]) << 16)
+                   | static_cast<uint32_t>(::etl::be_uint16_t(bufferView.subspan(1U, 2U).data()));
         }
         case 4U:
         {

--- a/libs/bsw/uds/test/src/uds/jobs/RoutineControlJobTest.cpp
+++ b/libs/bsw/uds/test/src/uds/jobs/RoutineControlJobTest.cpp
@@ -127,6 +127,8 @@ struct RoutineControlJobTest : ::testing::Test
         fRequestBuffer[1] = DUMMY_VALUE; // default value which have to be set in the tests
         fRequestBuffer[2] = TestableRoutineControlJob::ROUTINE_IDENTIFIER[0];
         fRequestBuffer[3] = TestableRoutineControlJob::ROUTINE_IDENTIFIER[1];
+        fMessage.setPayloadLength(4U);
+        (void)fMessage.increaseValidBytes(4U);
 
         fRoutineControlJobExtended.setDefaultDiagSessionManager(fDiagSessionManager);
         fIncomingDiagConnection.requestMessage = &fMessage;

--- a/libs/bsw/uds/test/src/uds/jobs/WritedentifierToMemoryJobTest.cpp
+++ b/libs/bsw/uds/test/src/uds/jobs/WritedentifierToMemoryJobTest.cpp
@@ -18,6 +18,8 @@
 #include <transport/TransportMessage.h>
 #include <transport/TransportMessageWithBuffer.h>
 
+#include <array>
+
 #include <gtest/gtest.h>
 
 namespace
@@ -44,7 +46,7 @@ protected:
     static uint8_t const SOURCE_ID       = 0xF1U;
     static uint8_t const TARGET_ID       = 0x10U;
 
-    uint8_t _testBuffer[4U];
+    std::array<uint8_t, 4U> _testBuffer{};
     StrictMock<DiagSessionManagerMock> _sessionManager;
     StrictMock<IncomingDiagConnectionMock> _incomingDiagConnection{::async::CONTEXT_INVALID};
     WriteIdentifierToMemory _cut;
@@ -52,13 +54,16 @@ protected:
 
 TEST_F(WriteIdentifierToMemoryJobTest, execute_valid_request)
 {
-    uint8_t const VALID_REQUEST[]
+    std::array<uint8_t, 6U> const validRequest
         = {TESTIDENTIFIER >> 8U & 0xFFU, TESTIDENTIFIER & 0xFFU, 0x42U, 0x42U, 0x42U, 0x42U};
 
-    ::etl::mem_set(_testBuffer, sizeof(_testBuffer), static_cast<uint8_t>(0));
+    ::etl::mem_set(_testBuffer.data(), _testBuffer.size(), static_cast<uint8_t>(0));
 
     TransportMessageWithBuffer request(
-        SOURCE_ID, TARGET_ID, VALID_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
+        SOURCE_ID,
+        TARGET_ID,
+        ::etl::span<uint8_t const>(validRequest.data(), validRequest.size()),
+        AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
     _incomingDiagConnection.requestMessage = request.get();
 
@@ -70,22 +75,23 @@ TEST_F(WriteIdentifierToMemoryJobTest, execute_valid_request)
 
     EXPECT_EQ(
         DiagReturnCode::OK,
-        _cut.execute(_incomingDiagConnection, VALID_REQUEST, sizeof(VALID_REQUEST)));
+        _cut.execute(_incomingDiagConnection, validRequest.data(), validRequest.size()));
 
-    EXPECT_THAT(
-        ::etl::span<uint8_t const>(_testBuffer),
-        ElementsAreArray(&VALID_REQUEST[2], sizeof(_testBuffer)));
+    EXPECT_THAT(_testBuffer, ElementsAre(0x42U, 0x42U, 0x42U, 0x42U));
 }
 
 TEST_F(WriteIdentifierToMemoryJobTest, execute_wrong_size_request)
 {
-    uint8_t const VALID_REQUEST[]
+    std::array<uint8_t, 4U> const validRequest
         = {TESTIDENTIFIER >> 8U & 0xFFU, TESTIDENTIFIER & 0xFFU, 0x42U, 0x42U};
 
-    ::etl::mem_set(_testBuffer, sizeof(_testBuffer), static_cast<uint8_t>(0));
+    ::etl::mem_set(_testBuffer.data(), _testBuffer.size(), static_cast<uint8_t>(0));
 
     TransportMessageWithBuffer request(
-        SOURCE_ID, TARGET_ID, VALID_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
+        SOURCE_ID,
+        TARGET_ID,
+        ::etl::span<uint8_t const>(validRequest.data(), validRequest.size()),
+        AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
     _incomingDiagConnection.requestMessage = request.get();
 
@@ -97,15 +103,30 @@ TEST_F(WriteIdentifierToMemoryJobTest, execute_wrong_size_request)
 
     EXPECT_EQ(
         DiagReturnCode::ISO_INVALID_FORMAT,
-        _cut.execute(_incomingDiagConnection, VALID_REQUEST, sizeof(VALID_REQUEST)));
+        _cut.execute(_incomingDiagConnection, validRequest.data(), validRequest.size()));
 
-    EXPECT_THAT(::etl::span<uint8_t const>(_testBuffer), ElementsAre(0, 0, 0, 0));
+    EXPECT_THAT(_testBuffer, ElementsAre(0, 0, 0, 0));
 
-    uint8_t const INVALID_REQUEST[] = {0x00U, 0x00U, 0x00U, 0x00U};
+    std::array<uint8_t, 4U> const invalidRequest = {0x00U, 0x00U, 0x00U, 0x00U};
 
     EXPECT_EQ(
         DiagReturnCode::NOT_RESPONSIBLE,
-        _cut.execute(_incomingDiagConnection, INVALID_REQUEST, sizeof(INVALID_REQUEST)));
+        _cut.execute(_incomingDiagConnection, invalidRequest.data(), invalidRequest.size()));
+}
+
+TEST_F(WriteIdentifierToMemoryJobTest, execute_too_short_request)
+{
+    std::array<uint8_t, 1U> const invalidRequest = {TESTIDENTIFIER >> 8U & 0xFFU};
+
+    EXPECT_CALL(_sessionManager, getActiveSession())
+        .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
+
+    EXPECT_CALL(_sessionManager, acceptedJob(_, _, _, _))
+        .WillRepeatedly(Return(uds::DiagReturnCode::OK));
+
+    EXPECT_EQ(
+        DiagReturnCode::ISO_INVALID_FORMAT,
+        _cut.execute(_incomingDiagConnection, invalidRequest.data(), invalidRequest.size()));
 }
 
 } // namespace

--- a/libs/bsw/uds/test/src/uds/services/CommunicationControlTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/CommunicationControlTest.cpp
@@ -21,7 +21,9 @@
 #include "uds/session/ApplicationExtendedSession.h"
 #include "uds/session/DiagSessionManagerMock.h"
 
+#include <etl/span.h>
 #include <gtest/gtest.h>
+#include <array>
 
 namespace
 {
@@ -34,11 +36,22 @@ class TestCommunicationControl : public CommunicationControl
 {
 public:
     virtual DiagReturnCode::Type
-    process(IncomingDiagConnection& connection, uint8_t const request[], uint16_t requestLength)
+    process(IncomingDiagConnection& connection, uint8_t const* request, uint16_t requestLength)
     {
         return CommunicationControl::process(connection, request, requestLength);
     }
 };
+
+template<size_t N>
+DiagReturnCode::Type processRequest(
+    TestCommunicationControl& service,
+    IncomingDiagConnection& connection,
+    std::array<uint8_t, N> const& request)
+{
+    auto const requestPayload
+        = ::etl::span<uint8_t const>(request.data(), request.size()).subspan(1U);
+    return service.process(connection, requestPayload.data(), requestPayload.size());
+}
 
 class CommunicationControlListener : public uds::ICommunicationStateListener
 {
@@ -114,22 +127,34 @@ TEST_F(CommunicationControlTest, VariableLengthConstructor)
 
 TEST_F(CommunicationControlTest, Returns_ISO_INVALID_FORMAT)
 {
-    uint8_t const request[] = {0x00, 0x00, 0x00}; // invalid requestedSession
+    std::array<uint8_t, 3U> const request = {0x00, 0x00, 0x00}; // invalid requestedSession
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
     ASSERT_EQ(
-        DiagReturnCode::ISO_INVALID_FORMAT, _service.process(_conn, request, sizeof(request)));
+        DiagReturnCode::ISO_INVALID_FORMAT,
+        _service.process(_conn, request.data(), request.size()));
+}
+
+TEST_F(CommunicationControlTest, Returns_ISO_INVALID_FORMAT_for_short_request)
+{
+    std::array<uint8_t, 1U> const request = {0x00};
+
+    EXPECT_CALL(_sessionManager, getActiveSession())
+        .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
+    ASSERT_EQ(
+        DiagReturnCode::ISO_INVALID_FORMAT,
+        _service.process(_conn, request.data(), request.size()));
 }
 
 TEST_F(CommunicationControlTest, EnableRxAndTx)
 {
     _listener.fState = ICommunicationStateListener::DISABLE_NORMAL_MESSAGE_TRANSMISSION;
 
-    uint8_t request[] = {ServiceId::COMMUNICATION_CONTROL, 0x00, 0x01};
+    std::array<uint8_t, 3U> request = {ServiceId::COMMUNICATION_CONTROL, 0x00, 0x01};
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 2));
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
     ASSERT_EQ(ICommunicationStateListener::ENABLE_NORMAL_MESSAGE_TRANSMISSION, _listener.fState);
 }
 
@@ -137,10 +162,10 @@ TEST_F(CommunicationControlTest, EnableRxAndTxNNMessage)
 {
     _listener.fState = ICommunicationStateListener::DISABLE_NM_MESSAGE_TRANSMISSION;
 
-    uint8_t request[] = {ServiceId::COMMUNICATION_CONTROL, 0x00, 0x02};
+    std::array<uint8_t, 3U> request = {ServiceId::COMMUNICATION_CONTROL, 0x00, 0x02};
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 2));
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
 
     ASSERT_EQ(ICommunicationStateListener::ENABLE_NN_MESSAGE_TRANSMISSION, _listener.fState);
 }
@@ -149,10 +174,10 @@ TEST_F(CommunicationControlTest, EnableRxAndTxALLMessage)
 {
     _listener.fState = ICommunicationStateListener::DISABLE_ALL_MESSAGE_TRANSMISSION;
 
-    uint8_t request[] = {ServiceId::COMMUNICATION_CONTROL, 0x00, 0x07};
+    std::array<uint8_t, 3U> request = {ServiceId::COMMUNICATION_CONTROL, 0x00, 0x07};
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 2));
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
 
     ASSERT_EQ(ICommunicationStateListener::ENABLE_ALL_MESSAGE_TRANSMISSION, _listener.fState);
 }
@@ -163,13 +188,13 @@ TEST_F(CommunicationControlTest, DisableRxAndTx)
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
 
-    uint8_t request_on[] = {ServiceId::COMMUNICATION_CONTROL, 0x00, 0x01};
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request_on[1], 2));
+    std::array<uint8_t, 3U> requestOn = {ServiceId::COMMUNICATION_CONTROL, 0x00, 0x01};
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, requestOn));
 
     _listener.fState
         = ICommunicationStateListener::ENABLE_REC_DISABLE_NORMAL_MESSAGE_SEND_TRANSMISSION;
-    uint8_t request[] = {ServiceId::COMMUNICATION_CONTROL, 0x03, 0x01};
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 2));
+    std::array<uint8_t, 3U> request = {ServiceId::COMMUNICATION_CONTROL, 0x03, 0x01};
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
     ASSERT_EQ(ICommunicationStateListener::DISABLE_NORMAL_MESSAGE_TRANSMISSION, _listener.fState);
 }
 
@@ -179,13 +204,13 @@ TEST_F(CommunicationControlTest, DisableRxAndTxNNMessage)
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
 
-    uint8_t request_on[] = {ServiceId::COMMUNICATION_CONTROL, 0x00, 0x02};
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request_on[1], 2));
+    std::array<uint8_t, 3U> requestOn = {ServiceId::COMMUNICATION_CONTROL, 0x00, 0x02};
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, requestOn));
 
     _listener.fState = ICommunicationStateListener::DISABLE_NM_MESSAGE_TRANSMISSION;
 
-    uint8_t request[] = {ServiceId::COMMUNICATION_CONTROL, 0x03, 0x02};
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 2));
+    std::array<uint8_t, 3U> request = {ServiceId::COMMUNICATION_CONTROL, 0x03, 0x02};
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
 
     ASSERT_EQ(ICommunicationStateListener::DISABLE_NM_MESSAGE_TRANSMISSION, _listener.fState);
 }
@@ -196,12 +221,12 @@ TEST_F(CommunicationControlTest, EnableDisableRxAndTxNNMessage)
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
 
-    uint8_t request_on[] = {ServiceId::COMMUNICATION_CONTROL, 0x03, 0x02};
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request_on[1], 2));
+    std::array<uint8_t, 3U> requestOn = {ServiceId::COMMUNICATION_CONTROL, 0x03, 0x02};
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, requestOn));
 
-    _listener.fState  = ICommunicationStateListener::ENABLE_REC_DISABLE_NM_SEND_TRANSMISSION;
-    uint8_t request[] = {ServiceId::COMMUNICATION_CONTROL, 0x01, 0x02};
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 2));
+    _listener.fState = ICommunicationStateListener::ENABLE_REC_DISABLE_NM_SEND_TRANSMISSION;
+    std::array<uint8_t, 3U> request = {ServiceId::COMMUNICATION_CONTROL, 0x01, 0x02};
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
     ASSERT_EQ(
         ICommunicationStateListener::ENABLE_REC_DISABLE_NM_SEND_TRANSMISSION, _listener.fState);
 }
@@ -212,12 +237,12 @@ TEST_F(CommunicationControlTest, EnableDisableRxAndTxALLMessage)
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
 
-    uint8_t request_on[] = {ServiceId::COMMUNICATION_CONTROL, 0x03, 0x08};
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request_on[1], 2));
+    std::array<uint8_t, 3U> requestOn = {ServiceId::COMMUNICATION_CONTROL, 0x03, 0x08};
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, requestOn));
 
-    _listener.fState  = ICommunicationStateListener::ENABLE_REC_DISABLE_ALL_SEND_TRANSMISSION;
-    uint8_t request[] = {ServiceId::COMMUNICATION_CONTROL, 0x01, 0x08};
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 2));
+    _listener.fState = ICommunicationStateListener::ENABLE_REC_DISABLE_ALL_SEND_TRANSMISSION;
+    std::array<uint8_t, 3U> request = {ServiceId::COMMUNICATION_CONTROL, 0x01, 0x08};
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
     ASSERT_EQ(
         ICommunicationStateListener::ENABLE_REC_DISABLE_ALL_SEND_TRANSMISSION, _listener.fState);
 }
@@ -227,10 +252,10 @@ TEST_F(CommunicationControlTest, DisableTxEnableRx)
     // Currently implemented to do nothing.
     _listener.fState = ICommunicationStateListener::DISABLE_NORMAL_MESSAGE_TRANSMISSION;
 
-    uint8_t request[] = {ServiceId::COMMUNICATION_CONTROL, 0x01, 0x01};
+    std::array<uint8_t, 3U> request = {ServiceId::COMMUNICATION_CONTROL, 0x01, 0x01};
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 2));
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
     ASSERT_EQ(
         ICommunicationStateListener::ENABLE_REC_DISABLE_NORMAL_MESSAGE_SEND_TRANSMISSION,
         _listener.fState);
@@ -240,10 +265,10 @@ TEST_F(CommunicationControlTest, DisableRxEnableTx)
 {
     _listener.fState = ICommunicationStateListener::DISABLE_NORMAL_MESSAGE_TRANSMISSION;
 
-    uint8_t request[] = {ServiceId::COMMUNICATION_CONTROL, 0x02, 0x01};
+    std::array<uint8_t, 3U> request = {ServiceId::COMMUNICATION_CONTROL, 0x02, 0x01};
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 2));
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
 
     /* no op */
     ASSERT_EQ(
@@ -255,11 +280,11 @@ TEST_F(CommunicationControlTest, DisableRxEnableTxNMMessage)
 {
     _listener.fState = ICommunicationStateListener::DISABLE_NORMAL_MESSAGE_TRANSMISSION;
 
-    uint8_t request[] = {ServiceId::COMMUNICATION_CONTROL, 0x02, 0x02};
+    std::array<uint8_t, 3U> request = {ServiceId::COMMUNICATION_CONTROL, 0x02, 0x02};
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 2));
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
 
     /* no op */
     ASSERT_EQ(
@@ -270,11 +295,11 @@ TEST_F(CommunicationControlTest, DisableRxEnableTxALLMessage)
 {
     _listener.fState = ICommunicationStateListener::DISABLE_NORMAL_MESSAGE_TRANSMISSION;
 
-    uint8_t request[] = {ServiceId::COMMUNICATION_CONTROL, 0x02, 0x03};
+    std::array<uint8_t, 3U> request = {ServiceId::COMMUNICATION_CONTROL, 0x02, 0x03};
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 2));
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
 
     /* no op */
     ASSERT_EQ(
@@ -283,10 +308,10 @@ TEST_F(CommunicationControlTest, DisableRxEnableTxALLMessage)
 
 TEST_F(CommunicationControlTest, DisableRxEnableTxEnhanced)
 {
-    uint8_t request[] = {ServiceId::COMMUNICATION_CONTROL, 0x04, 0xF1, 0x0, 0x37};
+    std::array<uint8_t, 5U> request = {ServiceId::COMMUNICATION_CONTROL, 0x04, 0xF1, 0x0, 0x37};
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_EXTENDED_SESSION()));
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 4));
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
 
     /* no op */
     ASSERT_EQ(
@@ -302,11 +327,11 @@ TEST_F(CommunicationControlTest, EnableEnhancedFailed)
     _sublistener.fState
         = ICommunicationSubStateListener::ENABLE_REC_DISABLE_ENHANCED_SEND_TRANSMISSION;
 
-    uint8_t request[] = {ServiceId::COMMUNICATION_CONTROL, 0x05, 0xF1, 0x0, 0x37};
+    std::array<uint8_t, 5U> request = {ServiceId::COMMUNICATION_CONTROL, 0x05, 0xF1, 0x0, 0x37};
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_EXTENDED_SESSION()));
     ASSERT_EQ(
-        DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED, _service.process(_conn, &request[1], 4));
+        DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED, processRequest(_service, _conn, request));
 }
 
 /*
@@ -314,25 +339,25 @@ TEST_F(CommunicationControlTest, EnableEnhancedFailed)
  */
 TEST_F(CommunicationControlTest, DisableEnableEnhanced)
 {
-    uint8_t request[]  = {ServiceId::COMMUNICATION_CONTROL, 0x04, 0xF1, 0x0, 0x37},
-            request1[] = {ServiceId::COMMUNICATION_CONTROL, 0x05, 0xF1, 0x0, 0x37},
-            request2[] = {ServiceId::COMMUNICATION_CONTROL, 0x05, 0xF1, 0x0, 0x38};
+    std::array<uint8_t, 5U> request  = {ServiceId::COMMUNICATION_CONTROL, 0x04, 0xF1, 0x0, 0x37};
+    std::array<uint8_t, 5U> request1 = {ServiceId::COMMUNICATION_CONTROL, 0x05, 0xF1, 0x0, 0x37};
+    std::array<uint8_t, 5U> request2 = {ServiceId::COMMUNICATION_CONTROL, 0x05, 0xF1, 0x0, 0x38};
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_EXTENDED_SESSION()));
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 4));
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
     ASSERT_EQ(
         ICommunicationSubStateListener::ENABLE_REC_DISABLE_ENHANCED_SEND_TRANSMISSION,
         _sublistener.fState);
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_EXTENDED_SESSION()));
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request1[1], 4));
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request1));
     ASSERT_EQ(ICommunicationSubStateListener::ENABLE_ENHANCED_TRANSMISSION, _sublistener.fState);
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_EXTENDED_SESSION()));
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 4));
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
     ASSERT_EQ(
         ICommunicationSubStateListener::ENABLE_REC_DISABLE_ENHANCED_SEND_TRANSMISSION,
         _sublistener.fState);
@@ -340,7 +365,7 @@ TEST_F(CommunicationControlTest, DisableEnableEnhanced)
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_EXTENDED_SESSION()));
     ASSERT_EQ(
-        DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED, _service.process(_conn, &request2[1], 4));
+        DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED, processRequest(_service, _conn, request2));
 
     _service.getCommunicationState();
 
@@ -349,7 +374,7 @@ TEST_F(CommunicationControlTest, DisableEnableEnhanced)
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_EXTENDED_SESSION()));
     ASSERT_EQ(
-        DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED, _service.process(_conn, &request1[1], 4));
+        DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED, processRequest(_service, _conn, request1));
 }
 
 /*
@@ -357,49 +382,49 @@ TEST_F(CommunicationControlTest, DisableEnableEnhanced)
  */
 TEST_F(CommunicationControlTest, DisableEnableEnhanced2)
 {
-    uint8_t request[]  = {ServiceId::COMMUNICATION_CONTROL, 0x04, 0xF1, 0x0, 0x37},
-            request1[] = {ServiceId::COMMUNICATION_CONTROL, 0x00, 0xF1};
+    std::array<uint8_t, 5U> request  = {ServiceId::COMMUNICATION_CONTROL, 0x04, 0xF1, 0x0, 0x37};
+    std::array<uint8_t, 3U> request1 = {ServiceId::COMMUNICATION_CONTROL, 0x00, 0xF1};
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_EXTENDED_SESSION()));
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request[1], 4));
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request));
     ASSERT_EQ(
         ICommunicationSubStateListener::ENABLE_REC_DISABLE_ENHANCED_SEND_TRANSMISSION,
         _sublistener.fState);
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_EXTENDED_SESSION()));
-    ASSERT_EQ(DiagReturnCode::OK, _service.process(_conn, &request1[1], 2));
+    ASSERT_EQ(DiagReturnCode::OK, processRequest(_service, _conn, request1));
     ASSERT_EQ(ICommunicationSubStateListener::ENABLE_ENHANCED_TRANSMISSION, _sublistener.fState);
 }
 
 TEST_F(CommunicationControlTest, DisableEnableEnhanced4)
 {
-    uint8_t request1[] = {0x00, 0x05, 0xF1, 0x0, 0x37};
+    std::array<uint8_t, 5U> request1 = {0x00, 0x05, 0xF1, 0x0, 0x37};
 
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_EXTENDED_SESSION()));
 
     ASSERT_EQ(
-        DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED, _service.process(_conn, &request1[1], 4));
+        DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED, processRequest(_service, _conn, request1));
 }
 
 TEST_F(CommunicationControlTest, ControlTypeVMS)
 {
     _listener.fState = ICommunicationStateListener::DISABLE_NORMAL_MESSAGE_TRANSMISSION;
 
-    uint8_t request[] = {ServiceId::COMMUNICATION_CONTROL, 0x41, 0x01};
+    std::array<uint8_t, 3U> request = {ServiceId::COMMUNICATION_CONTROL, 0x41, 0x01};
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
-    ASSERT_EQ(DiagReturnCode::NOT_RESPONSIBLE, _service.process(_conn, &request[1], 2));
+    ASSERT_EQ(DiagReturnCode::NOT_RESPONSIBLE, processRequest(_service, _conn, request));
 
     _listener.fState = ICommunicationStateListener::DISABLE_NORMAL_MESSAGE_TRANSMISSION;
 
-    uint8_t request1[] = {0x00, 0x39, 0x17};
+    std::array<uint8_t, 3U> request1 = {0x00, 0x39, 0x17};
     EXPECT_CALL(_sessionManager, getActiveSession())
         .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
     ASSERT_EQ(
-        DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED, _service.process(_conn, &request1[1], 2));
+        DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED, processRequest(_service, _conn, request1));
 }
 
 } // namespace

--- a/libs/bsw/uds/test/src/uds/services/readdata/MultipleReadDataByIdentifierTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/readdata/MultipleReadDataByIdentifierTest.cpp
@@ -23,6 +23,8 @@
 #include <transport/TransportConfiguration.h>
 #include <transport/TransportMessageWithBuffer.h>
 
+#include <array>
+
 #include <gtest/gtest.h>
 
 #define CONTEXT_EXECUTE fContext.execute()
@@ -107,13 +109,13 @@ public:
         return MultipleReadDataByIdentifier::getDefaultDiagReturnCode();
     }
 
-    virtual DiagReturnCode::Type verify(uint8_t const request[], uint16_t requestLength)
+    virtual DiagReturnCode::Type verify(uint8_t const* request, uint16_t requestLength)
     {
         return MultipleReadDataByIdentifier::verify(request, requestLength);
     }
 
     virtual DiagReturnCode::Type
-    process(IncomingDiagConnection& connection, uint8_t const request[], uint16_t requestLength)
+    process(IncomingDiagConnection& connection, uint8_t const* request, uint16_t requestLength)
     {
         return MultipleReadDataByIdentifier::process(connection, request, requestLength);
     }
@@ -128,14 +130,14 @@ public:
     , fMyMultipleReadDataByIdentifier(fAsyncHelper)
     , fMyMultipleReadDataByIdentifierWithFirstJob(fAsyncHelper, fDiagJob)
     , fDiagJob(
-          READ_DATA_BY_IDENTIFIER_REQUEST_1,
-          sizeof(READ_DATA_BY_IDENTIFIER_REQUEST_1),
+          READ_DATA_BY_IDENTIFIER_REQUEST_1.data(),
+          READ_DATA_BY_IDENTIFIER_REQUEST_1.size(),
           1U // prefix length
           ,
           DiagSession::ALL_SESSIONS())
     , fDiagJob2(
-          READ_DATA_BY_IDENTIFIER_REQUEST_2,
-          sizeof(READ_DATA_BY_IDENTIFIER_REQUEST_2),
+          READ_DATA_BY_IDENTIFIER_REQUEST_2.data(),
+          READ_DATA_BY_IDENTIFIER_REQUEST_2.size(),
           1U // prefix length
           ,
           DiagSession::ALL_SESSIONS())
@@ -193,42 +195,42 @@ protected:
 
     static uint8_t const WRONG_SERVICE_ID = 0x31U;
     static uint8_t const SOME_DATA        = 0x11U;
-    static uint8_t const VALID_DATA_IDENTIFIER_1[2U];
-    static uint8_t const VALID_DATA_IDENTIFIER_2[2U];
-    static uint8_t const INVALID_DATA_IDENTIFIER_1[2U];
-    static uint8_t const INVALID_DATA_IDENTIFIER_2[2U];
+    static std::array<uint8_t, 2U> const VALID_DATA_IDENTIFIER_1;
+    static std::array<uint8_t, 2U> const VALID_DATA_IDENTIFIER_2;
+    static std::array<uint8_t, 2U> const INVALID_DATA_IDENTIFIER_1;
+    static std::array<uint8_t, 2U> const INVALID_DATA_IDENTIFIER_2;
 
-    static uint8_t const READ_DATA_BY_IDENTIFIER_REQUEST_1[3U];
-    static uint8_t const READ_DATA_BY_IDENTIFIER_REQUEST_2[3U];
+    static std::array<uint8_t, 3U> const READ_DATA_BY_IDENTIFIER_REQUEST_1;
+    static std::array<uint8_t, 3U> const READ_DATA_BY_IDENTIFIER_REQUEST_2;
 };
 
-uint8_t const MultipleReadDataByIdentifierTest::VALID_DATA_IDENTIFIER_1[]
+std::array<uint8_t, 2U> const MultipleReadDataByIdentifierTest::VALID_DATA_IDENTIFIER_1
     = {0xF1U, 0x8BU}; // ReadProductionDate dataIdentifier
 
-uint8_t const MultipleReadDataByIdentifierTest::VALID_DATA_IDENTIFIER_2[]
+std::array<uint8_t, 2U> const MultipleReadDataByIdentifierTest::VALID_DATA_IDENTIFIER_2
     = {0xA0U, 0x7FU}; // ReadProductionDate dataIdentifier
 
-uint8_t const MultipleReadDataByIdentifierTest::INVALID_DATA_IDENTIFIER_1[]
+std::array<uint8_t, 2U> const MultipleReadDataByIdentifierTest::INVALID_DATA_IDENTIFIER_1
     = {0x44U, 0x44U}; // random dataIdentifier
 
-uint8_t const MultipleReadDataByIdentifierTest::INVALID_DATA_IDENTIFIER_2[]
+std::array<uint8_t, 2U> const MultipleReadDataByIdentifierTest::INVALID_DATA_IDENTIFIER_2
     = {0x55U, 0x55U}; // random dataIdentifier
 
-uint8_t const MultipleReadDataByIdentifierTest::READ_DATA_BY_IDENTIFIER_REQUEST_1[] = {
-    0x22U, // ReadDataByIdentifier Service ID
-    0xF1U, // ReadProductionDate dataIdentifier
-    0x8BU  // ReadProductionDate dataIdentifier
+std::array<uint8_t, 3U> const MultipleReadDataByIdentifierTest::READ_DATA_BY_IDENTIFIER_REQUEST_1
+    = {
+        0x22U, // ReadDataByIdentifier Service ID
+        0xF1U, // ReadProductionDate dataIdentifier
+        0x8BU  // ReadProductionDate dataIdentifier
 };
 
-uint8_t const MultipleReadDataByIdentifierTest::READ_DATA_BY_IDENTIFIER_REQUEST_2[] = {
-    0x22U, // ReadDataByIdentifier Service ID
-    0xA0U, // ReadProductionDate dataIdentifier
-    0x7FU  // ReadProductionDate dataIdentifier
+std::array<uint8_t, 3U> const MultipleReadDataByIdentifierTest::READ_DATA_BY_IDENTIFIER_REQUEST_2
+    = {
+        0x22U, // ReadDataByIdentifier Service ID
+        0xA0U, // ReadProductionDate dataIdentifier
+        0x7FU  // ReadProductionDate dataIdentifier
 };
 
-TEST_F(
-    MultipleReadDataByIdentifierTest,
-    a_MultipleReadDataByIdentifier_object_should_set_DefaultDiagReturnCode_to_ISO_REQUEST_OUT_OF_RANGE)
+TEST_F(MultipleReadDataByIdentifierTest, sets_default_diag_return_code_to_iso_request_out_of_range)
 {
     EXPECT_EQ(
         DiagReturnCode::ISO_REQUEST_OUT_OF_RANGE,
@@ -242,35 +244,45 @@ TEST_F(
 TEST_F(
     MultipleReadDataByIdentifierTest, verify_returns_the_DiagReturnCode_OK_if_the_request_is_valid)
 {
-    uint8_t const VALID_REQUEST[]
+    std::array<uint8_t, 3U> const validRequest
         = {ServiceId::READ_DATA_BY_IDENTIFIER,
            VALID_DATA_IDENTIFIER_1[0U],
            VALID_DATA_IDENTIFIER_1[1U]};
 
     EXPECT_EQ(
         DiagReturnCode::OK,
-        fMyMultipleReadDataByIdentifier.verify(VALID_REQUEST, sizeof(VALID_REQUEST)));
+        fMyMultipleReadDataByIdentifier.verify(validRequest.data(), validRequest.size()));
 }
 
 TEST_F(
     MultipleReadDataByIdentifierTest,
     verify_returns_the_DiagReturnCode_ISO_INVALID_FORMAT_if_the_request_length_is_invalid)
 {
-    uint8_t const INVALID_REQUEST[] = {
+    std::array<uint8_t, 2U> const invalidRequest = {
         ServiceId::READ_DATA_BY_IDENTIFIER, VALID_DATA_IDENTIFIER_1[0U]
         // at least dataIdentifier 2 is missing
     };
 
     EXPECT_EQ(
         DiagReturnCode::ISO_INVALID_FORMAT,
-        fMyMultipleReadDataByIdentifier.verify(INVALID_REQUEST, sizeof(INVALID_REQUEST)));
+        fMyMultipleReadDataByIdentifier.verify(invalidRequest.data(), invalidRequest.size()));
+}
+
+TEST_F(
+    MultipleReadDataByIdentifierTest,
+    verify_returns_the_DiagReturnCode_ISO_INVALID_FORMAT_if_the_request_is_empty)
+{
+    EXPECT_EQ(
+        DiagReturnCode::ISO_INVALID_FORMAT, fMyMultipleReadDataByIdentifier.verify(nullptr, 0U));
+    EXPECT_EQ(
+        DiagReturnCode::ISO_INVALID_FORMAT, fMyMultipleReadDataByIdentifier.verify(nullptr, 1U));
 }
 
 TEST_F(
     MultipleReadDataByIdentifierTest,
     verify_returns_the_DiagReturnCode_ISO_INVALID_FORMAT_if_the_request_length_is_even)
 {
-    uint8_t const INVALID_REQUEST[]
+    std::array<uint8_t, 4U> const invalidRequest
         = {ServiceId::READ_DATA_BY_IDENTIFIER,
            VALID_DATA_IDENTIFIER_1[0U],
            VALID_DATA_IDENTIFIER_1[1U],
@@ -278,33 +290,33 @@ TEST_F(
 
     EXPECT_EQ(
         DiagReturnCode::ISO_INVALID_FORMAT,
-        fMyMultipleReadDataByIdentifier.verify(INVALID_REQUEST, sizeof(INVALID_REQUEST)));
+        fMyMultipleReadDataByIdentifier.verify(invalidRequest.data(), invalidRequest.size()));
 }
 
 TEST_F(
     MultipleReadDataByIdentifierTest,
     verify_returns_the_DiagReturnCode_NOT_RESPONSIBLE_if_the_request_service_id_is_wrong)
 {
-    uint8_t const INVALID_REQUEST[]
+    std::array<uint8_t, 3U> const invalidRequest
         = {WRONG_SERVICE_ID, VALID_DATA_IDENTIFIER_1[0U], VALID_DATA_IDENTIFIER_1[1U]};
 
     EXPECT_EQ(
         DiagReturnCode::NOT_RESPONSIBLE,
-        fMyMultipleReadDataByIdentifier.verify(INVALID_REQUEST, sizeof(INVALID_REQUEST)));
+        fMyMultipleReadDataByIdentifier.verify(invalidRequest.data(), invalidRequest.size()));
 }
 
 TEST_F(
     MultipleReadDataByIdentifierTest,
     execute_deals_with_one_valid_and_one_invalid_dataIdentifier_and_return_one_positive_response)
 {
-    uint8_t const DATA_IDENTIFIERS_REQUEST[]
+    std::array<uint8_t, 5U> const dataIdentifiersRequest
         = {ServiceId::READ_DATA_BY_IDENTIFIER,
            VALID_DATA_IDENTIFIER_1[0U],
            VALID_DATA_IDENTIFIER_1[1U],
            INVALID_DATA_IDENTIFIER_1[0U],
            INVALID_DATA_IDENTIFIER_1[1U]};
 
-    uint8_t const EXPECTED_RESPONSE[] = {
+    std::array<uint8_t, 6U> const expectedResponse = {
         0x62U, // positive response to 0x22 (ReadDataByIdentifier)
         0xF1U, // ReadProductionDate dataIdentifier
         0x8BU, // ReadProductionDate dataIdentifier
@@ -314,7 +326,10 @@ TEST_F(
     };
 
     TransportMessageWithBuffer pRequest(
-        SOURCE_ID, TARGET_ID, DATA_IDENTIFIERS_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
+        SOURCE_ID,
+        TARGET_ID,
+        ::etl::span<uint8_t const>(dataIdentifiersRequest.data(), dataIdentifiersRequest.size()),
+        AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
     fIncomingDiagConnection.requestMessage     = pRequest.get();
     fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
@@ -337,7 +352,7 @@ TEST_F(
     EXPECT_EQ(
         DiagReturnCode::OK,
         fMyMultipleReadDataByIdentifier.execute(
-            fIncomingDiagConnection, DATA_IDENTIFIERS_REQUEST, sizeof(DATA_IDENTIFIERS_REQUEST)));
+            fIncomingDiagConnection, dataIdentifiersRequest.data(), dataIdentifiersRequest.size()));
     CONTEXT_EXECUTE;
 
     Mock::VerifyAndClearExpectations(&fDiagJob);
@@ -357,21 +372,19 @@ TEST_F(
         fIncomingDiagConnection.responseMessage->getPayload(),
         fIncomingDiagConnection.responseMessage->getPayloadLength());
 
-    EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
+    EXPECT_THAT(buffer, ElementsAreArray(expectedResponse));
 }
 
-TEST_F(
-    MultipleReadDataByIdentifierTest,
-    execute_deals_with_one_valid_dataIdentifier_return_error_and_one_valid_dataIdentifier_and_return_one_positive_response)
+TEST_F(MultipleReadDataByIdentifierTest, processes_mixed_did_results_into_positive_response)
 {
-    uint8_t const DATA_IDENTIFIERS_REQUEST[]
+    std::array<uint8_t, 5U> const dataIdentifiersRequest
         = {ServiceId::READ_DATA_BY_IDENTIFIER,
            VALID_DATA_IDENTIFIER_2[0U],
            VALID_DATA_IDENTIFIER_2[1U],
            VALID_DATA_IDENTIFIER_1[0U],
            VALID_DATA_IDENTIFIER_1[1U]};
 
-    uint8_t const EXPECTED_RESPONSE[] = {
+    std::array<uint8_t, 6U> const expectedResponse = {
         0x62U, // positive response to 0x22 (ReadDataByIdentifier)
         0xF1U, // ReadProductionDate dataIdentifier
         0x8BU, // ReadProductionDate dataIdentifier
@@ -383,7 +396,10 @@ TEST_F(
     fDiagRoot.addAbstractDiagJob(fDiagJob2);
 
     TransportMessageWithBuffer pRequest(
-        SOURCE_ID, TARGET_ID, DATA_IDENTIFIERS_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
+        SOURCE_ID,
+        TARGET_ID,
+        ::etl::span<uint8_t const>(dataIdentifiersRequest.data(), dataIdentifiersRequest.size()),
+        AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
     fIncomingDiagConnection.requestMessage     = pRequest.get();
     fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
@@ -412,7 +428,7 @@ TEST_F(
     EXPECT_EQ(
         DiagReturnCode::OK,
         fMyMultipleReadDataByIdentifier.execute(
-            fIncomingDiagConnection, DATA_IDENTIFIERS_REQUEST, sizeof(DATA_IDENTIFIERS_REQUEST)));
+            fIncomingDiagConnection, dataIdentifiersRequest.data(), dataIdentifiersRequest.size()));
     CONTEXT_EXECUTE;
 
     Mock::VerifyAndClearExpectations(&fDiagJob);
@@ -439,21 +455,21 @@ TEST_F(
         fIncomingDiagConnection.responseMessage->getPayload(),
         fIncomingDiagConnection.responseMessage->getPayloadLength());
 
-    EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
+    EXPECT_THAT(buffer, ElementsAreArray(expectedResponse));
 }
 
 TEST_F(
     MultipleReadDataByIdentifierTest,
     execute_deals_with_one_invalid_and_one_valid_dataIdentifier_and_return_one_positive_response)
 {
-    uint8_t const DATA_IDENTIFIERS_REQUEST[]
+    std::array<uint8_t, 5U> const dataIdentifiersRequest
         = {ServiceId::READ_DATA_BY_IDENTIFIER,
            INVALID_DATA_IDENTIFIER_1[0U],
            INVALID_DATA_IDENTIFIER_1[1U],
            VALID_DATA_IDENTIFIER_1[0U],
            VALID_DATA_IDENTIFIER_1[1U]};
 
-    uint8_t const EXPECTED_RESPONSE[] = {
+    std::array<uint8_t, 6U> const expectedResponse = {
         0x62U, // positive response to 0x22 (ReadDataByIdentifier)
         0xF1U, // ReadProductionDate dataIdentifier
         0x8BU, // ReadProductionDate dataIdentifier
@@ -463,7 +479,10 @@ TEST_F(
     };
 
     TransportMessageWithBuffer pRequest(
-        SOURCE_ID, TARGET_ID, DATA_IDENTIFIERS_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
+        SOURCE_ID,
+        TARGET_ID,
+        ::etl::span<uint8_t const>(dataIdentifiersRequest.data(), dataIdentifiersRequest.size()),
+        AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
     fMyMultipleReadDataByIdentifier.setCheckResponse(
         MultipleReadDataByIdentifier::CheckResponseType::create<
@@ -504,7 +523,7 @@ TEST_F(
     EXPECT_EQ(
         DiagReturnCode::OK,
         fMyMultipleReadDataByIdentifier.execute(
-            fIncomingDiagConnection, DATA_IDENTIFIERS_REQUEST, sizeof(DATA_IDENTIFIERS_REQUEST)));
+            fIncomingDiagConnection, dataIdentifiersRequest.data(), dataIdentifiersRequest.size()));
     CONTEXT_EXECUTE;
 
     EXPECT_CALL(
@@ -518,21 +537,21 @@ TEST_F(
         fIncomingDiagConnection.responseMessage->getPayload(),
         fIncomingDiagConnection.responseMessage->getPayloadLength());
 
-    EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
+    EXPECT_THAT(buffer, ElementsAreArray(expectedResponse));
 }
 
 TEST_F(
     MultipleReadDataByIdentifierTest,
     execute_deals_with_two_valid_dataIdentifiers_and_return_one_positive_response_for_both)
 {
-    uint8_t const DATA_IDENTIFIERS_REQUEST[]
+    std::array<uint8_t, 5U> const dataIdentifiersRequest
         = {ServiceId::READ_DATA_BY_IDENTIFIER,
            VALID_DATA_IDENTIFIER_1[0U],
            VALID_DATA_IDENTIFIER_1[1U],
            VALID_DATA_IDENTIFIER_1[0U],
            VALID_DATA_IDENTIFIER_1[1U]};
 
-    uint8_t const EXPECTED_RESPONSE[] = {
+    std::array<uint8_t, 11U> const expectedResponse = {
         0x62U, // Positive response to 0x22 (ReadDataByIdentifier)
         0xF1U, // ReadProductionDate dataIdentifier
         0x8BU, // ReadProductionDate dataIdentifier
@@ -547,7 +566,10 @@ TEST_F(
     };
 
     TransportMessageWithBuffer pRequest(
-        SOURCE_ID, TARGET_ID, DATA_IDENTIFIERS_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
+        SOURCE_ID,
+        TARGET_ID,
+        ::etl::span<uint8_t const>(dataIdentifiersRequest.data(), dataIdentifiersRequest.size()),
+        AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
     fIncomingDiagConnection.requestMessage     = pRequest.get();
     fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
@@ -570,7 +592,7 @@ TEST_F(
     EXPECT_EQ(
         DiagReturnCode::OK,
         fMyMultipleReadDataByIdentifier.execute(
-            fIncomingDiagConnection, DATA_IDENTIFIERS_REQUEST, sizeof(DATA_IDENTIFIERS_REQUEST)));
+            fIncomingDiagConnection, dataIdentifiersRequest.data(), dataIdentifiersRequest.size()));
     CONTEXT_EXECUTE;
 
     Mock::VerifyAndClearExpectations(&fDiagJob);
@@ -605,21 +627,21 @@ TEST_F(
         fIncomingDiagConnection.responseMessage->getPayload(),
         fIncomingDiagConnection.responseMessage->getPayloadLength());
 
-    EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
+    EXPECT_THAT(buffer, ElementsAreArray(expectedResponse));
 }
 
 TEST_F(
     MultipleReadDataByIdentifierTest,
     execute_deals_with_two_invalid_dataIdentifiers_and_return_negative_response)
 {
-    uint8_t const INVALID_DATA_IDENTIFIERS_REQUEST[]
+    std::array<uint8_t, 5U> const invalidDataIdentifiersRequest
         = {ServiceId::READ_DATA_BY_IDENTIFIER,
            INVALID_DATA_IDENTIFIER_1[0U],
            INVALID_DATA_IDENTIFIER_1[1U],
            INVALID_DATA_IDENTIFIER_2[0U],
            INVALID_DATA_IDENTIFIER_2[1U]};
 
-    uint8_t const EXPECTED_RESPONSE[] = {
+    std::array<uint8_t, 3U> const expectedResponse = {
         0x7FU, // Negative Response Identifier
         0x22U, // ReadDataByIdentifier SID
         0x31U  // Negative Response Code if no DID's are valid
@@ -628,7 +650,8 @@ TEST_F(
     TransportMessageWithBuffer pRequest(
         SOURCE_ID,
         TARGET_ID,
-        INVALID_DATA_IDENTIFIERS_REQUEST,
+        ::etl::span<uint8_t const>(
+            invalidDataIdentifiersRequest.data(), invalidDataIdentifiersRequest.size()),
         AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
     fIncomingDiagConnection.requestMessage     = pRequest.get();
@@ -663,29 +686,29 @@ TEST_F(
         DiagReturnCode::OK,
         fMyMultipleReadDataByIdentifier.execute(
             fIncomingDiagConnection,
-            INVALID_DATA_IDENTIFIERS_REQUEST,
-            sizeof(INVALID_DATA_IDENTIFIERS_REQUEST)));
+            invalidDataIdentifiersRequest.data(),
+            invalidDataIdentifiersRequest.size()));
     CONTEXT_EXECUTE;
 
     auto buffer = ::etl::span<uint8_t const>(
         fIncomingDiagConnection.responseMessage->getPayload(),
         fIncomingDiagConnection.responseMessage->getPayloadLength());
 
-    EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
+    EXPECT_THAT(buffer, ElementsAreArray(expectedResponse));
 }
 
 TEST_F(
     MultipleReadDataByIdentifierTest,
     execute_deals_with_an_valid_dataIdentifiers_returning_negative_response)
 {
-    uint8_t const INVALID_DATA_IDENTIFIERS_REQUEST[]
+    std::array<uint8_t, 5U> const invalidDataIdentifiersRequest
         = {ServiceId::READ_DATA_BY_IDENTIFIER,
            INVALID_DATA_IDENTIFIER_1[0U],
            INVALID_DATA_IDENTIFIER_1[1U],
            INVALID_DATA_IDENTIFIER_2[0U],
            INVALID_DATA_IDENTIFIER_2[1U]};
 
-    uint8_t const EXPECTED_RESPONSE[] = {
+    std::array<uint8_t, 3U> const expectedResponse = {
         0x7FU, // Negative Response Identifier
         0x22U, // ReadDataByIdentifier SID
         0x36U  // Negative Response Code if no DID's are valid
@@ -694,7 +717,8 @@ TEST_F(
     TransportMessageWithBuffer pRequest(
         SOURCE_ID,
         TARGET_ID,
-        INVALID_DATA_IDENTIFIERS_REQUEST,
+        ::etl::span<uint8_t const>(
+            invalidDataIdentifiersRequest.data(), invalidDataIdentifiersRequest.size()),
         AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
     fIncomingDiagConnection.requestMessage     = pRequest.get();
@@ -727,27 +751,27 @@ TEST_F(
         DiagReturnCode::OK,
         fMyMultipleReadDataByIdentifier.execute(
             fIncomingDiagConnection,
-            INVALID_DATA_IDENTIFIERS_REQUEST,
-            sizeof(INVALID_DATA_IDENTIFIERS_REQUEST)));
+            invalidDataIdentifiersRequest.data(),
+            invalidDataIdentifiersRequest.size()));
     CONTEXT_EXECUTE;
 
     auto buffer = ::etl::span<uint8_t const>(
         fIncomingDiagConnection.responseMessage->getPayload(),
         fIncomingDiagConnection.responseMessage->getPayloadLength());
 
-    EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
+    EXPECT_THAT(buffer, ElementsAreArray(expectedResponse));
 }
 
 TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_checked_if_available)
 {
-    uint8_t const DATA_IDENTIFIERS_REQUEST[]
+    std::array<uint8_t, 5U> const dataIdentifiersRequest
         = {ServiceId::READ_DATA_BY_IDENTIFIER,
            VALID_DATA_IDENTIFIER_1[0U],
            VALID_DATA_IDENTIFIER_1[1U],
            VALID_DATA_IDENTIFIER_1[0U],
            VALID_DATA_IDENTIFIER_1[1U]};
 
-    uint8_t const EXPECTED_RESPONSE[] = {
+    std::array<uint8_t, 11U> const expectedResponse = {
         0x62U, // Positive response to 0x22 (ReadDataByIdentifier)
         0xF1U, // ReadProductionDate dataIdentifier
         0x8BU, // ReadProductionDate dataIdentifier
@@ -767,7 +791,10 @@ TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_checked_if_
             &MultipleReadDataByIdentifierTest::getDidLimit>(*this));
 
     TransportMessageWithBuffer pRequest(
-        SOURCE_ID, TARGET_ID, DATA_IDENTIFIERS_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
+        SOURCE_ID,
+        TARGET_ID,
+        ::etl::span<uint8_t const>(dataIdentifiersRequest.data(), dataIdentifiersRequest.size()),
+        AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
     fIncomingDiagConnection.requestMessage     = pRequest.get();
     fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
@@ -792,7 +819,7 @@ TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_checked_if_
     EXPECT_EQ(
         DiagReturnCode::OK,
         fMyMultipleReadDataByIdentifier.execute(
-            fIncomingDiagConnection, DATA_IDENTIFIERS_REQUEST, sizeof(DATA_IDENTIFIERS_REQUEST)));
+            fIncomingDiagConnection, dataIdentifiersRequest.data(), dataIdentifiersRequest.size()));
     CONTEXT_EXECUTE;
 
     Mock::VerifyAndClearExpectations(&fDiagJob);
@@ -827,19 +854,19 @@ TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_checked_if_
         fIncomingDiagConnection.responseMessage->getPayload(),
         fIncomingDiagConnection.responseMessage->getPayloadLength());
 
-    EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
+    EXPECT_THAT(buffer, ElementsAreArray(expectedResponse));
 }
 
 TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_not_checked_if_zero)
 {
-    uint8_t const DATA_IDENTIFIERS_REQUEST[]
+    std::array<uint8_t, 5U> const dataIdentifiersRequest
         = {ServiceId::READ_DATA_BY_IDENTIFIER,
            VALID_DATA_IDENTIFIER_1[0U],
            VALID_DATA_IDENTIFIER_1[1U],
            VALID_DATA_IDENTIFIER_1[0U],
            VALID_DATA_IDENTIFIER_1[1U]};
 
-    uint8_t const EXPECTED_RESPONSE[] = {
+    std::array<uint8_t, 11U> const expectedResponse = {
         0x62U, // Positive response to 0x22 (ReadDataByIdentifier)
         0xF1U, // ReadProductionDate dataIdentifier
         0x8BU, // ReadProductionDate dataIdentifier
@@ -859,7 +886,10 @@ TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_not_checked
             &MultipleReadDataByIdentifierTest::getDidLimit>(*this));
 
     TransportMessageWithBuffer pRequest(
-        SOURCE_ID, TARGET_ID, DATA_IDENTIFIERS_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
+        SOURCE_ID,
+        TARGET_ID,
+        ::etl::span<uint8_t const>(dataIdentifiersRequest.data(), dataIdentifiersRequest.size()),
+        AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
     fIncomingDiagConnection.requestMessage     = pRequest.get();
     fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
@@ -884,7 +914,7 @@ TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_not_checked
     EXPECT_EQ(
         DiagReturnCode::OK,
         fMyMultipleReadDataByIdentifier.execute(
-            fIncomingDiagConnection, DATA_IDENTIFIERS_REQUEST, sizeof(DATA_IDENTIFIERS_REQUEST)));
+            fIncomingDiagConnection, dataIdentifiersRequest.data(), dataIdentifiersRequest.size()));
     CONTEXT_EXECUTE;
 
     Mock::VerifyAndClearExpectations(&fDiagJob);
@@ -919,12 +949,12 @@ TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_not_checked
         fIncomingDiagConnection.responseMessage->getPayload(),
         fIncomingDiagConnection.responseMessage->getPayloadLength());
 
-    EXPECT_THAT(buffer, ElementsAreArray(EXPECTED_RESPONSE));
+    EXPECT_THAT(buffer, ElementsAreArray(expectedResponse));
 }
 
 TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_returns_ISO_INVALID_FORMAT)
 {
-    uint8_t const DATA_IDENTIFIERS_REQUEST[]
+    std::array<uint8_t, 5U> const dataIdentifiersRequest
         = {ServiceId::READ_DATA_BY_IDENTIFIER,
            VALID_DATA_IDENTIFIER_1[0U],
            VALID_DATA_IDENTIFIER_1[1U],
@@ -937,7 +967,10 @@ TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_returns_ISO
             &MultipleReadDataByIdentifierTest::getDidLimit>(*this));
 
     TransportMessageWithBuffer pRequest(
-        SOURCE_ID, TARGET_ID, DATA_IDENTIFIERS_REQUEST, AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
+        SOURCE_ID,
+        TARGET_ID,
+        ::etl::span<uint8_t const>(dataIdentifiersRequest.data(), dataIdentifiersRequest.size()),
+        AbstractDiagJob::VARIABLE_RESPONSE_LENGTH);
 
     fIncomingDiagConnection.requestMessage     = pRequest.get();
     fIncomingDiagConnection.messageSender      = &fUdsDispatcher;
@@ -953,7 +986,7 @@ TEST_F(MultipleReadDataByIdentifierTest, get_did_limit_is_called_and_returns_ISO
     EXPECT_EQ(
         DiagReturnCode::ISO_INVALID_FORMAT,
         fMyMultipleReadDataByIdentifier.execute(
-            fIncomingDiagConnection, DATA_IDENTIFIERS_REQUEST, sizeof(DATA_IDENTIFIERS_REQUEST)));
+            fIncomingDiagConnection, dataIdentifiersRequest.data(), dataIdentifiersRequest.size()));
     CONTEXT_EXECUTE;
 }
 

--- a/libs/bsw/uds/test/src/uds/services/readdtcinformation/ReadDTCInformationTest.cpp
+++ b/libs/bsw/uds/test/src/uds/services/readdtcinformation/ReadDTCInformationTest.cpp
@@ -14,7 +14,10 @@
 #include "uds/session/ApplicationDefaultSession.h"
 #include "uds/session/DiagSessionManagerMock.h"
 
+#include <etl/span.h>
 #include <transport/TransportMessageWithBuffer.h>
+
+#include <array>
 
 #include <gmock/gmock.h>
 
@@ -41,13 +44,14 @@ protected:
 
 TEST_F(ReadDTCInformationTest, execute_with_subfunction_0x02_and_valid_status_mask_should_return_OK)
 {
-    uint8_t request[] = {
+    std::array<uint8_t, 3U> request = {
         0x19U, // ReadDTCInformation SID
         0x02U, // reportDTCByStatusMask
         0xFFU  // DTCStatusMask
     };
 
-    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+    TransportMessageWithBuffer pRequest(
+        0xF1U, 0x10U, ::etl::span<uint8_t const>(request.data(), request.size()), 0U);
 
     fIncomingDiagConnection.requestMessage = pRequest.get();
 
@@ -59,19 +63,20 @@ TEST_F(ReadDTCInformationTest, execute_with_subfunction_0x02_and_valid_status_ma
 
     EXPECT_EQ(
         DiagReturnCode::OK,
-        fReadDTCInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+        fReadDTCInformation.execute(fIncomingDiagConnection, request.data(), request.size()));
 }
 
 TEST_F(
     ReadDTCInformationTest,
     execute_with_subfunction_0x02_without_status_mask_should_return_ISO_INVALID_FORMAT)
 {
-    uint8_t request[] = {
+    std::array<uint8_t, 2U> request = {
         0x19U, // ReadDTCInformation SID
         0x02U  // reportDTCByStatusMask (no DTCStatusMask)
     };
 
-    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+    TransportMessageWithBuffer pRequest(
+        0xF1U, 0x10U, ::etl::span<uint8_t const>(request.data(), request.size()), 0U);
 
     fIncomingDiagConnection.requestMessage = pRequest.get();
 
@@ -83,19 +88,42 @@ TEST_F(
 
     EXPECT_EQ(
         DiagReturnCode::ISO_INVALID_FORMAT,
-        fReadDTCInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+        fReadDTCInformation.execute(fIncomingDiagConnection, request.data(), request.size()));
+}
+
+TEST_F(ReadDTCInformationTest, execute_without_subfunction_should_return_ISO_INVALID_FORMAT)
+{
+    std::array<uint8_t, 1U> request = {
+        0x19U // ReadDTCInformation SID
+    };
+
+    TransportMessageWithBuffer pRequest(
+        0xF1U, 0x10U, ::etl::span<uint8_t const>(request.data(), request.size()), 0U);
+
+    fIncomingDiagConnection.requestMessage = pRequest.get();
+
+    EXPECT_CALL(fSessionManager, getActiveSession())
+        .WillRepeatedly(ReturnRef(DiagSession::APPLICATION_DEFAULT_SESSION()));
+
+    EXPECT_CALL(fSessionManager, acceptedJob(_, _, _, _))
+        .WillRepeatedly(Return(uds::DiagReturnCode::OK));
+
+    EXPECT_EQ(
+        DiagReturnCode::ISO_INVALID_FORMAT,
+        fReadDTCInformation.execute(fIncomingDiagConnection, request.data(), request.size()));
 }
 
 TEST_F(
     ReadDTCInformationTest,
     execute_with_subfunction_0x04_should_return_ISO_SUBFUNCTION_NOT_SUPPORTED)
 {
-    uint8_t request[]
+    std::array<uint8_t, 3U> request
         = {0x19U, // ReadDTCInformation SID
            0x04U, // reportDTCSnapshotRecordByDTCNumber
            0xFFU};
 
-    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+    TransportMessageWithBuffer pRequest(
+        0xF1U, 0x10U, ::etl::span<uint8_t const>(request.data(), request.size()), 0U);
 
     fIncomingDiagConnection.requestMessage = pRequest.get();
 
@@ -107,19 +135,20 @@ TEST_F(
 
     EXPECT_EQ(
         DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED,
-        fReadDTCInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+        fReadDTCInformation.execute(fIncomingDiagConnection, request.data(), request.size()));
 }
 
 TEST_F(
     ReadDTCInformationTest,
     execute_with_subfunction_0x06_should_return_ISO_SUBFUNCTION_NOT_SUPPORTED)
 {
-    uint8_t request[]
+    std::array<uint8_t, 3U> request
         = {0x19U, // ReadDTCInformation SID
            0x06U, // reportDTCExtendedDataRecordByDTCNumber
            0xFFU};
 
-    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+    TransportMessageWithBuffer pRequest(
+        0xF1U, 0x10U, ::etl::span<uint8_t const>(request.data(), request.size()), 0U);
 
     fIncomingDiagConnection.requestMessage = pRequest.get();
 
@@ -131,19 +160,20 @@ TEST_F(
 
     EXPECT_EQ(
         DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED,
-        fReadDTCInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+        fReadDTCInformation.execute(fIncomingDiagConnection, request.data(), request.size()));
 }
 
 TEST_F(
     ReadDTCInformationTest,
     execute_with_subfunction_0x0A_should_return_ISO_SUBFUNCTION_NOT_SUPPORTED)
 {
-    uint8_t request[]
+    std::array<uint8_t, 3U> request
         = {0x19U, // ReadDTCInformation SID
            0x0AU, // reportSupportedDTCs
            0xFFU};
 
-    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+    TransportMessageWithBuffer pRequest(
+        0xF1U, 0x10U, ::etl::span<uint8_t const>(request.data(), request.size()), 0U);
 
     fIncomingDiagConnection.requestMessage = pRequest.get();
 
@@ -155,19 +185,20 @@ TEST_F(
 
     EXPECT_EQ(
         DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED,
-        fReadDTCInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+        fReadDTCInformation.execute(fIncomingDiagConnection, request.data(), request.size()));
 }
 
 TEST_F(
     ReadDTCInformationTest,
     execute_with_unsupported_subfunction_should_return_ISO_SUBFUNCTION_NOT_SUPPORTED)
 {
-    uint8_t request[]
+    std::array<uint8_t, 3U> request
         = {0x19U, // ReadDTCInformation SID
            0x00U, // unsupported subfunction
            0xFFU};
 
-    TransportMessageWithBuffer pRequest(0xF1U, 0x10U, request, 0U);
+    TransportMessageWithBuffer pRequest(
+        0xF1U, 0x10U, ::etl::span<uint8_t const>(request.data(), request.size()), 0U);
 
     fIncomingDiagConnection.requestMessage = pRequest.get();
 
@@ -179,7 +210,7 @@ TEST_F(
 
     EXPECT_EQ(
         DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED,
-        fReadDTCInformation.execute(fIncomingDiagConnection, request, sizeof(request)));
+        fReadDTCInformation.execute(fIncomingDiagConnection, request.data(), request.size()));
 }
 
 } // anonymous namespace


### PR DESCRIPTION
## Purpose of this PR
- [x] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Other (Please specify)

**Description**
This PR fixes clang-tidy findings in the UDS module by replacing raw
request arrays and pointer arithmetic with ETL-backed views and
containers, tightening malformed-request validation in affected request
parsing paths, and making implemented-request storage safe during object
construction.

It also updates the related UDS regression tests.

Follow-up request API cleanup is tracked in #510.

**Related Issues**
#381
#510

**Breaking Changes**
- [ ] Yes
- [x] No

If there are breaking changes, please explain what they are and how they may impact existing
functionality.

**Test Plan**
- Build the changed area with the CI-matching POSIX/Freertos Clang configuration
- Build the same area locally with GCC
- Run clang-tidy on the related UDS translation units
- Run the focused `udsTest` coverage for the touched request parsing and bounds handling paths
- Build `tests-s32k1xx-release` to confirm the changes compile for the second CI target

**Regression Tests**
Have tests been added/updated? [x] Yes [ ] No