### PR TITLE
Fix unguarded ETH_1 reference in transportRouterSimple

### DIFF
--- a/executables/referenceApp/transportConfiguration/BUILD.bazel
+++ b/executables/referenceApp/transportConfiguration/BUILD.bazel
@@ -17,6 +17,7 @@ cc_library(
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
+        "//executables/referenceApp/configuration",
         "//libs/3rdparty/etl",
         "//libs/bsw/transport",
     ],

--- a/executables/referenceApp/transportConfiguration/CMakeLists.txt
+++ b/executables/referenceApp/transportConfiguration/CMakeLists.txt
@@ -2,4 +2,4 @@ add_library(transportConfiguration src/transport/TransportConfiguration.cpp)
 
 target_include_directories(transportConfiguration PUBLIC include)
 
-target_link_libraries(transportConfiguration PUBLIC transport etl)
+target_link_libraries(transportConfiguration PUBLIC transport etl configuration)

--- a/executables/referenceApp/transportConfiguration/include/transport/TransportConfiguration.h
+++ b/executables/referenceApp/transportConfiguration/include/transport/TransportConfiguration.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include "busid/BusId.h"
+
 #include <transport/LogicalAddress.h>
 #include <transport/TransportMessage.h>
 
@@ -88,6 +90,9 @@ public:
 
     static bool isTesterAddress(uint16_t address);
 
+    /// True if the bus uses 1-byte diagnostic addresses (i.e. not a DoIP bus).
+    static bool is1ByteDiagAddressBus(uint8_t busId);
+
     static uint16_t convert2ByteAddressTo1Byte(uint16_t address);
 
     static uint16_t convert1ByteAddressTo2Byte(uint16_t address);
@@ -103,6 +108,12 @@ public:
 inline bool TransportConfiguration::isFunctionalAddress(uint16_t const address)
 {
     return (FUNCTIONAL_ALL_ISO14229 == address);
+}
+
+inline bool TransportConfiguration::is1ByteDiagAddressBus(uint8_t const busId)
+{
+    // Only the Ethernet/DoIP buses use 2-byte diagnostic addresses.
+    return (busId != ::busid::ETH_0) && (busId != ::busid::ETH_1);
 }
 
 /**

--- a/executables/unitTest/transportConfiguration/CMakeLists.txt
+++ b/executables/unitTest/transportConfiguration/CMakeLists.txt
@@ -9,4 +9,4 @@ add_library(transportConfiguration src/transport/TransportConfiguration.cpp)
 
 target_include_directories(transportConfiguration PUBLIC include)
 
-target_link_libraries(transportConfiguration PUBLIC transport etl)
+target_link_libraries(transportConfiguration PUBLIC transport etl configuration)

--- a/executables/unitTest/transportConfiguration/include/transport/TransportConfiguration.h
+++ b/executables/unitTest/transportConfiguration/include/transport/TransportConfiguration.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include "busid/BusId.h"
+
 #include "transport/LogicalAddress.h"
 #include "transport/TransportMessage.h"
 
@@ -81,6 +83,9 @@ public:
 
     static bool isTesterAddress(uint16_t address);
 
+    /// True if the bus uses 1-byte diagnostic addresses (i.e. not a DoIP bus).
+    static bool is1ByteDiagAddressBus(uint8_t busId);
+
     static uint16_t convert2ByteAddressTo1Byte(uint16_t address);
 
     static uint16_t convert1ByteAddressTo2Byte(uint16_t address);
@@ -96,6 +101,12 @@ public:
 inline bool TransportConfiguration::isFunctionalAddress(uint16_t const address)
 {
     return (FUNCTIONAL_ALL_ISO14229 == address);
+}
+
+inline bool TransportConfiguration::is1ByteDiagAddressBus(uint8_t const busId)
+{
+    // Only the Ethernet/DoIP buses use 2-byte diagnostic addresses.
+    return (busId != ::busid::ETH_0) && (busId != ::busid::ETH_1);
 }
 
 /**

--- a/libs/bsw/transportRouterSimple/src/transport/routing/TransportRouterSimple.cpp
+++ b/libs/bsw/transportRouterSimple/src/transport/routing/TransportRouterSimple.cpp
@@ -23,14 +23,6 @@ namespace transport
 using ::util::logger::Logger;
 using ::util::logger::TPROUTER;
 
-namespace
-{
-bool is1ByteDiagAddressBus(uint8_t const busId)
-{
-    return (busId != ::busid::ETH_0) && (busId != ::busid::ETH_1);
-}
-} // namespace
-
 TransportRouterSimple::TransportRouterSimple() : _transportLayers()
 {
     for (uint8_t i = 0U; i < NUM_BUFFERS; i++)
@@ -67,7 +59,7 @@ ITransportMessageProvidingListener::ErrorCode TransportRouterSimple::getTranspor
 
     ::async::LockType const lockGuard;
     uint16_t const targetId2Byte
-        = is1ByteDiagAddressBus(srcBusId)
+        = TransportConfiguration::is1ByteDiagAddressBus(srcBusId)
               ? TransportConfiguration::convert1ByteAddressTo2Byte(targetId)
               : targetId;
 
@@ -135,7 +127,7 @@ ITransportMessageProvidingListener::ReceiveResult TransportRouterSimple::message
 {
     AbstractTransportLayer::ErrorCode result(AbstractTransportLayer::ErrorCode::TP_OK);
 
-    if (is1ByteDiagAddressBus(sourceBusId))
+    if (TransportConfiguration::is1ByteDiagAddressBus(sourceBusId))
     {
         transportMessage.setSourceAddress(
             TransportConfiguration::convert1ByteAddressTo2Byte(transportMessage.getSourceId()));
@@ -209,7 +201,7 @@ void TransportRouterSimple::forwardMessageToTransportLayer(
     ITransportMessageProcessedListener* const pNotificationListener,
     AbstractTransportLayer::ErrorCode& result)
 {
-    if (is1ByteDiagAddressBus(destBusId))
+    if (TransportConfiguration::is1ByteDiagAddressBus(destBusId))
     {
         transportMessage.setSourceAddress(
             TransportConfiguration::convert2ByteAddressTo1Byte(transportMessage.getSourceId()));


### PR DESCRIPTION
The generic transportRouterSimple hard coded busid::ETH_0 and busid::ETH_1 in is1ByteDiagAddressBus(), so integrations without ETH_1 failed to compile. This regressed [#349](https://github.com/eclipse-openbsw/openbsw/issues/349), which fixed the same for ETH_0.

Move the bus classification into the integration: add TransportConfiguration::is1ByteDiagAddressBus() and let the router
delegate to it. The generic router no longer names any Ethernet bus, so each integration decides which of its buses use 2-byte (DoIP) addresses.

Resolves:
[#507](https://github.com/eclipse-openbsw/openbsw/issues/507): transportRouterSimple references unguarded busid::ETH_1