### PR TITLE
Update formatting guidelines for pragma once and copyright header

### DIFF
--- a/doc/dev/guidelines/formatting/automatic.rst
+++ b/doc/dev/guidelines/formatting/automatic.rst
@@ -130,45 +130,8 @@ Running ``treefmt`` will automatically fix copyright headers alongside code form
 
     treefmt
 
-Header Guard Generation
------------------------
+Include Guard
+-------------
 
-You can create a header guard manually or use one of the following tools.
-
-VS Code Include Guard Extension
-+++++++++++++++++++++++++++++++
-
-Install the "C/C++ Include Guard" extension.
-
-Aside from the built-in extension browser, you can also find it here:
-https://marketplace.visualstudio.com/items?itemName=akiramiyakoda.cppincludeguard
-or here: https://github.com/AkiraMiyakoda/cppIncludeGuard
-
-Next, configure the extension in your settings menu (search @ext:akiramiyakoda.cppincludeguard)
-and set the prefix to "GUARD\_".
-
-Vim UUID Generation Plugin
-++++++++++++++++++++++++++
-
-Install a UUID generation plugin (here's one): https://github.com/kburdett/vim-nuuid
-
-Create a new custom function to use the UUID generator, and insert the appropriate preprocessor
-statements:
-
-.. code-block:: vim
-
-    function! GenIncludeGuard()
-        let guard  = join(["GUARD", substitute(NuuidNewUuid(), '-', '_', 'g')], "_")
-        let ifndef = join(["#ifndef",   guard], " ")
-        let define = join(["#define",   guard], " ")
-        let endif  = join(["#endif //", guard], " ")
-        " Extra empty strings included here to insert another newline before the endif
-        return join([ifndef, define, "", "", "", endif], "\n")
-    endfunction
-
-Lastly, map this function (along with ancillary operations) to your favorite keystroke combination.
-Here's an example mapping:
-
-.. code-block:: vim
-
-    nnoremap <leader>u i<C-R>=GenIncludeGuard()<CR><Esc>
+Use ``#pragma once`` at the top of every header file.
+See :ref:`cf_include_guard` for the required format.

--- a/doc/dev/guidelines/formatting/for_c++/additional.rst
+++ b/doc/dev/guidelines/formatting/for_c++/additional.rst
@@ -19,53 +19,52 @@ Additional Rules
 Include Guard
 -------------
 
-| Include guards shall prevent code from being processed multiple times which
-  would cause compilation errors.
-| The following format shall be used:
-
-.. code-block:: cpp
-
-    #ifndef GUARD_<UUID>
-    #define GUARD_<UUID>
-    // ...
-    #endif // GUARD_<UUID>
-
-The ``<UUID>`` shall be:
-
-.. code-block:: none
-
-    <8 hex digits>_<4 hex digits>_<4 hex digits>_<4 hex digits>_<12 hex digits>
-
-The hex digits shall be uppercase.
+Use ``#pragma once`` at the top of every header file to prevent multiple inclusion.
+This is simpler and less error-prone than UUID-based ``#ifndef`` guards.
 
 .. code-block:: cpp
     :caption: good example
+
+    #pragma once
+
+.. code-block:: cpp
+    :caption: bad examples
 
     #ifndef GUARD_C73C2C69_6A11_4490_93AA_73A40D5F62F9
     #define GUARD_C73C2C69_6A11_4490_93AA_73A40D5F62F9
     // ...
     #endif // GUARD_C73C2C69_6A11_4490_93AA_73A40D5F62F9
 
-.. code-block:: cpp
-    :caption: bad examples
-
     #ifndef CANTRANSCEIVER_H_
     #define CANTRANSCEIVER_H_
     // ...
     #endif /* CANTRANSCEIVER_H_ */
 
-    #ifndef HE793FCD8_FC04_45D3_A438_533341BBA7B1
-    #define HE793FCD8_FC04_45D3_A438_533341BBA7B1
-    // ...
-    #endif
 
 .. _cf_copyright_disclaimer:
 
 Copyright Disclaimer
 --------------------
 
-Every source file should have a copyright disclaimer in the first line:
+Every source file must contain an Apache-2.0 copyright header with SPDX identifier at the
+**top of the file**. For ``.cpp``, ``.hpp``, ``.h``, and ``.c`` files the exact format is:
 
 .. code-block:: cpp
 
-    // Copyright <year> <company>.
+    /********************************************************************************
+     * Copyright (c) <year> <author>
+     *
+     * This program and the accompanying materials are made available under the
+     * terms of the Apache License Version 2.0 which is available at
+     * https://www.apache.org/licenses/LICENSE-2.0
+     *
+     * SPDX-License-Identifier: Apache-2.0
+     ********************************************************************************/
+
+- The year must be a 4-digit year (a range such as ``2024-2026`` is also acceptable).
+- The author/company name must be present.
+- The SPDX identifier ``Apache-2.0`` must be included.
+- Old-style single-line headers (e.g. ``// Copyright 2024 Accenture.``) are **no longer valid**.
+
+The ``cr_checker.py`` tool can automatically verify and fix copyright headers.
+See :ref:`automatic_formatting` → *Copyright Header Check* for details.


### PR DESCRIPTION
Update formatting guidelines for pragma once and copyright header

Replace UUID-based include guard documentation with #pragma once,
which is the style used throughout the codebase. Add bad examples
to illustrate what to avoid.

Update the copyright disclaimer section to reflect the current
Apache-2.0 block header format. The old single-line format
(// Copyright <year> <company>.) is no longer valid. Add a
reference to cr_checker.py for automatic verification.

Remove the now-obsolete header guard generation tooling section
from automatic.rst and replace it with a short reference to
the pragma once guideline.
