### PR TITLE
Update rule FILE-000 to use <> for standard headers only

### DIFF
--- a/doc/dev/guidelines/conventions/files.rst
+++ b/doc/dev/guidelines/conventions/files.rst
@@ -19,12 +19,10 @@ Files
 Including Header Files
 ----------------------
 
-:rule:`FILE-000` The style used to specify an include shall reflect the locality of the included
-header file.
+:rule:`FILE-000` The style used to specify an include shall reflect if it's a system include or user defined file.
 
-- All includes which are part of the same module shall use quotes ``""``.
-- All includes which are not part of the same module (including system headers) shall use angle
-  brackets ``<>``.
+- All C and C++ standard library headers as well as all etl headers shall use angle brackets ``<>``.
+- All other includes shall use quotes ``""``.
 
 Standard Headers
 ----------------


### PR DESCRIPTION
Update rule FILE-000 to use <> for standard headers only

This is a simplification and conforms much more witch
other coding guidelines. Our previous rule to only
use "" for includes within the same module is hard to
explain, review and maintain.
