### PR TITLE
Fix removed SystemTimer calls in STM32 ETL clock implementation

### DIFF
--- a/platforms/stm32/etlImpl/src/clocks.cpp
+++ b/platforms/stm32/etlImpl/src/clocks.cpp
@@ -20,11 +20,11 @@ etl::chrono::high_resolution_clock::rep etl_get_high_resolution_clock()
 
 etl::chrono::system_clock::rep etl_get_system_clock()
 {
-    return etl::chrono::system_clock::rep(static_cast<int64_t>(getSystemTimeUs()));
+    return etl::chrono::system_clock::rep(static_cast<int64_t>(getSystemTimeUs64Bit()));
 }
 
 etl::chrono::steady_clock::rep etl_get_steady_clock()
 {
-    return etl::chrono::steady_clock::rep(static_cast<int64_t>(getSystemTimeMs() / 1000));
+    return etl::chrono::steady_clock::rep(static_cast<int64_t>(getSystemTimeMs64Bit() / 1000));
 }
 }


### PR DESCRIPTION
### Problem

`platforms/stm32/etlImpl/src/clocks.cpp` no longer compiles on `main`: commit 9d3e89a28 ("Add TimestampProvider") renamed `getSystemTimeUs()`/`getSystemTimeMs()` to `getSystemTimeUs64Bit()`/`getSystemTimeMs64Bit()`, and the STM32 ETL clock implementation (merged via #414, written before the rename) still references the old names:

```
clocks.cpp:23: error: 'getSystemTimeUs' was not declared in this scope
clocks.cpp:28: error: 'getSystemTimeMs' was not declared in this scope
```

No CI configuration cross-compiles `platforms/stm32/etlImpl` yet, so the breakage is silent on `main`.

### Fix

Use the renamed 64-bit accessors, matching `platforms/s32k1xx/etlImpl/src/clocks.cpp`.

Verified with `arm-none-eabi-g++ -std=c++17 -fsyntax-only -Ilibs/bsw/bsp/include -Ilibs/3rdparty/etl/include`: fails on `main`, passes with this change.