### PR TITLE
Add Bazel build for libs/bsw examples and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,44 @@ options and build the generated project.
 > when for example loading a generated elf into a debugger or following symlinks created within the
 > container.
 
+### Building with CMake
 ```
 host> DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose run --build development
 docker> cmake --preset posix
 docker> cmake --build --preset posix
 ```
+
+### Building with Bazel
+From inside the same container:
+
+Build all targets for host platform
+
+```
+docker> bazel build //...
+```
+
+Build all targets for s32k148 platform
+
+```
+docker> bazel build --config=s32k148 //...
+```
+
+To run all tests for host platform and s32k148
+
+```
+docker> bazel test //...
+docker> bazel test --config=s32k148 //...
+```
+
+> [!NOTE]
+>
+> The above builds every target for the host and for the S32K148 target respectively.
+> To build or test a single target, use its Bazel label, e.g.:
+>
+> ```
+> docker> bazel build //libs/bsw/util:util
+> docker> bazel build --config=s32k148 //libs/bsw/util:util
+> ```
 
 ## Feature Overview
 

--- a/bazel_migration/README.md
+++ b/bazel_migration/README.md
@@ -34,7 +34,7 @@ Open:
 OpenBSW Bazel migration
 ├── bazel/ ✅ (toolchain + s32k148 platform/constraints + rtos config)
 ├── cmake/ ⬛
-├── doc/ ⬛
+├── doc/ ✅ (Bazel guidelines/module.rst + formatting/bazel.rst)
 ├── docker/ ⬛
 ├── executables/
 │   ├── referenceApp/ 🔲
@@ -44,8 +44,8 @@ OpenBSW Bazel migration
 │   │   ├── configuration ✅
 │   │   ├── lwipConfiguration ✅
 │   │   └── platforms/
-│   │       ├── posix/ ✅ (freeRtosCoreConfiguration, osHooks)
-│   │       └── s32k148evb/ ✅ (freeRtosCoreConfiguration, osHooks)
+│   │       ├── posix/ ✅ (freeRtosCoreConfiguration, threadXCoreConfiguration, osHooks)
+│   │       └── s32k148evb/ ✅ (freeRtosCoreConfiguration, threadXCoreConfiguration, osHooks)
 │   └── unitTest/ 🔲
 │       └── configuration ✅
 ├── libs/
@@ -55,13 +55,14 @@ OpenBSW Bazel migration
 │   │   ├── freeRtos ✅
 │   │   ├── lwip ✅
 │   │   └── printf ✅
-│   │   └── printf ✅
+│   │   └── threadx ✅
 │   ├── bsp/
 │   │   └── bspInterrupts ✅
 │   ├── bsw/
 │   │   ├── async ✅
 │   │   ├── asyncConsole ✅
 │   │   ├── asyncFreeRtos ✅
+│   │   ├── asyncThreadX ✅
 │   │   ├── asyncImpl ✅
 │   │   ├── cpp2can ✅
 │   │   ├── cpp2ethernet ✅
@@ -84,8 +85,8 @@ OpenBSW Bazel migration
 │   │   ├── util ✅
 │   └── (remaining) 🔲
 ├── platforms/
-│   ├── posix/ ✅ (freeRtosPosix, bspInterruptsImpl, etlImpl, lwipSysArch)
-│   └── s32k1xx/ ✅ (freertos_cm4_sysTick, bspMcu, bspInterruptsImpl, etlImpl, lwipSysArch)
+│   ├── posix/ ✅ (freeRtosPosix, threadx, bspInterruptsImpl, etlImpl, lwipSysArch)
+│   └── s32k1xx/ ✅ (freertos_cm4_sysTick, threadx, bspMcu, bspInterruptsImpl, etlImpl, lwipSysArch)
 ├── test/ Scope of Bazel support TBD
 └── tools/ Scope of Bazel support TBD
 

--- a/doc/dev/guidelines/formatting/bazel.rst
+++ b/doc/dev/guidelines/formatting/bazel.rst
@@ -1,0 +1,35 @@
+..
+   *******************************************************************************
+   Copyright (c) 2026 Accenture
+
+   This program and the accompanying materials are made available under the
+   terms of the Apache License Version 2.0 which is available at
+   https://www.apache.org/licenses/LICENSE-2.0
+
+   SPDX-License-Identifier: Apache-2.0
+   *******************************************************************************
+
+
+Bazel
+=====
+
+We use `buildifier <https://github.com/bazelbuild/buildtools/tree/main/buildifier>`_ to format Bazel files.
+
+Usage
+-----
+
+Formatting a file:
+
+.. code-block:: bash
+
+    bazel run //:format_check //module_path/BUILD.bazel
+
+    bazel run //:format_fix //module_path/BUILD.bazel
+
+Formatting all the files at once:
+
+.. code-block:: bash
+
+    bazel run //:format_check //...
+
+    bazel run //:format_fix //...

--- a/doc/dev/guidelines/formatting/index.rst
+++ b/doc/dev/guidelines/formatting/index.rst
@@ -27,3 +27,4 @@ improves readability and comprehensibility, which in turn reduces bugs and saves
    for_c++/index
    cmake
    automatic
+   bazel

--- a/doc/dev/guidelines/module.rst
+++ b/doc/dev/guidelines/module.rst
@@ -156,3 +156,40 @@ Use only standard CMake commands. The typical structure is as follows:
         add_library(<module>Mock src/...)
         target_include_directories(<module>Mock PUBLIC include)
         target_link_libraries(<module>Mock PUBLIC gmock ... PRIVATE ...)
+
+.. _build_bazel:
+
+BUILD.bazel
+-----------
+
+Use only standard Bazel build rules. The typical structure is as follows:
+
+<module>
+++++++++
+
+  .. code-block:: python
+
+        cc_library(
+            name = "<module>",
+            srcs = [
+                "src/<module>/foo.cpp",
+                "src/<module>/bar.cpp",
+            ],
+            hdrs = [
+                "include/<module>/foo.h",
+                "include/<module>/bar.h",
+            ],
+            strip_include_prefix = "include",
+            deps = ["//<module>:target_name",],
+            visibility = ["//visibility:public"],
+        )
+
+        # If a module has more than 10 source or header files, use glob() instead:
+        cc_library(
+            name = "<module>",
+            srcs = glob(["src/<module>/*.cpp"]),
+            hdrs = glob(["include/<module>/*.h"]),
+            strip_include_prefix = "include",
+            deps = ["//<module>:target_name",],
+            visibility = ["//visibility:public"],
+        )

--- a/libs/bsw/asyncImpl/examples/BUILD.bazel
+++ b/libs/bsw/asyncImpl/examples/BUILD.bazel
@@ -1,0 +1,26 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "async_impl_example",
+    srcs = ["src/example.cpp"],
+    hdrs = [
+        "include/async/Types.h",
+        "include/example.h",
+    ],
+    implementation_deps = [
+        "//libs/3rdparty/etl",
+        "//libs/bsw/async",
+        "//libs/bsw/asyncImpl:async_impl",
+    ],
+    strip_include_prefix = "include",
+)

--- a/libs/bsw/io/examples/BUILD.bazel
+++ b/libs/bsw/io/examples/BUILD.bazel
@@ -1,0 +1,19 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "io_examples",
+    #TODO: Complete the deps and srcs here once libs/3rdparty/googletest is migrated to bazel
+    implementation_deps = [
+        "//libs/bsw/io",
+    ],
+)

--- a/libs/bsw/lifecycle/examples/BUILD.bazel
+++ b/libs/bsw/lifecycle/examples/BUILD.bazel
@@ -1,0 +1,22 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "lifecycle_examples",
+    srcs = ["src/examples.cpp"],
+    hdrs = ["include/example.h"],
+    implementation_deps = [
+        "//libs/bsw/lifecycle",
+        # TODO: migrate asyncMock unit test to Bazel, then add the dependency here.
+    ],
+    strip_include_prefix = "include",
+)


### PR DESCRIPTION

Add Bazel build support for the following example targets:
- //libs/bsw/asyncImpl:async_impl_example
- //libs/bsw/io:io_examples
- //libs/bsw/lifecycle:lifecycle_examples

Documentation:
- Getting started (in README.md)
- Developer guide for writing Bazel files
- Formatting Bazel files (in doc/dev/guidelines/formatting/bazel.rst)