### PR TITLE
Add STM32 unit-test builds to CI

### DIFF
--- a/.ci/build.py
+++ b/.ci/build.py
@@ -47,6 +47,22 @@ commands = {
         platforms=["linux"],
         build_dir="build/tests/s32k1xx/Release",
     ),
+    "tests-stm32-debug": BuildOpTpl(
+        config_cmd="cmake --preset tests-stm32-debug",
+        build_cmd="cmake --build --preset tests-stm32-debug",
+        test_cmd="ctest --preset tests-stm32-debug --output-on-failure",
+        configs=["Debug"],
+        platforms=["linux"],
+        build_dir="build/tests/stm32/Debug",
+    ),
+    "tests-stm32-release": BuildOpTpl(
+        config_cmd="cmake --preset tests-stm32-release",
+        build_cmd="cmake --build --preset tests-stm32-release",
+        test_cmd="ctest --preset tests-stm32-release --output-on-failure",
+        configs=["Release"],
+        platforms=["linux"],
+        build_dir="build/tests/stm32/Release",
+    ),
     "posix-freertos": BuildOpTpl(
         config_cmd="cmake --preset posix-freertos",
         build_cmd="cmake --build --preset posix-freertos",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-name: Build S32k and posix platform
+name: Build S32k, STM32 and posix platform
 
 on: [workflow_call, push, pull_request]
 
@@ -18,7 +18,7 @@ jobs:
     strategy:
     #   max-parallel: 1
       matrix:
-        preset: [ "tests-posix-debug", "tests-posix-release", "tests-s32k1xx-debug", "tests-s32k1xx-release", "posix-freertos", "posix-threadx", "posix-freertos-with-tracing", "posix-rust", "s32k148-freertos-gcc", "s32k148-threadx-gcc", "s32k148-freertos-clang", "s32k148-threadx-clang", "s32k148-rust-gcc" ]
+        preset: [ "tests-posix-debug", "tests-posix-release", "tests-s32k1xx-debug", "tests-s32k1xx-release", "tests-stm32-debug", "tests-stm32-release", "posix-freertos", "posix-threadx", "posix-freertos-with-tracing", "posix-rust", "s32k148-freertos-gcc", "s32k148-threadx-gcc", "s32k148-freertos-clang", "s32k148-threadx-clang", "s32k148-rust-gcc" ]
         platform: [ "arm", "linux" ]
         config: [ "Debug", "Release", "RelWithDebInfo" ]
         cxxid: ["gcc", "clang"]
@@ -49,6 +49,34 @@ jobs:
             config: "Debug"
           - preset: "tests-s32k1xx-release"
             config: "RelWithDebInfo"
+
+          # STM32 unit-test builds: minimal initial set (linux, gcc, C++17) -
+          # one Debug and one Release variant. Follow-up: extend to clang and
+          # C++20/23 to match the grid run by the posix and s32k1xx presets.
+          - preset: "tests-stm32-debug"
+            platform: "arm"
+          - preset: "tests-stm32-debug"
+            config: "Release"
+          - preset: "tests-stm32-debug"
+            config: "RelWithDebInfo"
+          - preset: "tests-stm32-debug"
+            cxxid: "clang"
+          - preset: "tests-stm32-debug"
+            cxxstd: 20
+          - preset: "tests-stm32-debug"
+            cxxstd: 23
+          - preset: "tests-stm32-release"
+            platform: "arm"
+          - preset: "tests-stm32-release"
+            config: "Debug"
+          - preset: "tests-stm32-release"
+            config: "RelWithDebInfo"
+          - preset: "tests-stm32-release"
+            cxxid: "clang"
+          - preset: "tests-stm32-release"
+            cxxstd: 20
+          - preset: "tests-stm32-release"
+            cxxstd: 23
 
           - preset: "posix-freertos"
             platform: "arm"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Build Status 🚀
 
-[![Build S32k and posix platform](https://github.com/eclipse-openbsw/openbsw/actions/workflows/build.yml/badge.svg?branch=main&event=push)](https://github.com/eclipse-openbsw/openbsw/actions/workflows/build.yml)
+[![Build S32k, STM32 and posix platform](https://github.com/eclipse-openbsw/openbsw/actions/workflows/build.yml/badge.svg?branch=main&event=push)](https://github.com/eclipse-openbsw/openbsw/actions/workflows/build.yml)
 
 ## Code Coverage 
 


### PR DESCRIPTION
Follow-up promised in #519: adds the STM32 unit-test builds to the CI checks.

### What

- `tests-stm32-debug` and `tests-stm32-release` presets added to the `build.yml` matrix and to `.ci/build.py`'s per-preset build templates (configure/build/ctest via the existing CMake presets).
- Minimal initial grid: linux, gcc, C++17 — one Debug and one Release variant (matrix excludes are documented in `build.yml`). A follow-up can extend this to clang and C++20/23 to match the posix/s32k1xx grid.
- README build-status line updated accordingly.

### Validation

Both new jobs ran green on this exact branch on my fork: [run 29574728435](https://github.com/nhuvaoanh123/openbsw/actions/runs/29574728435). The suites exercised are the STM32 CAN driver unit tests from #415/#518.

Note: this covers the host-built unit tests. Target cross-compile jobs (like the s32k148 ones) will follow with the board bring-up PRs, which add the board executables.