### PR TITLE
Skip test_middleware tests when target is s32k148

### DIFF
--- a/test/pyTest/conftest.py
+++ b/test/pyTest/conftest.py
@@ -268,9 +268,13 @@ def pytest_runtest_setup(item):
     skip_marker = item.get_closest_marker("skip_if")
     if skip_marker:
         condition = skip_marker.args[0]
+        reason = skip_marker.args[1] if len(skip_marker.args) > 1 else None
         target = item.config.getoption("target")
         app = item.config.getoption("app")
 
         context = {"target": target, "app": app}
         if eval(condition, {}, context):
-            pytest.skip(f"Skipped because condition '{condition}' matched")
+            if reason:
+                pytest.skip(reason)
+            else:
+                pytest.skip(f"Skipped because condition '{condition}' matched")

--- a/test/pyTest/middleware/test_middleware.py
+++ b/test/pyTest/middleware/test_middleware.py
@@ -46,7 +46,7 @@ def _extract_foo_value(line: bytes) -> int | None:
 # Tests
 # ---------------------------------------------------------------------------
 
-
+@pytest.mark.skip_if("target==['s32k148']", "Middleware Foo test not supported on s32k148")
 def test_foo_broadcast_sent(target_session):
     """Cluster0 FooSkeleton sends at least one Foo broadcast after boot."""
     capserial = target_session.capserial()
@@ -58,7 +58,7 @@ def test_foo_broadcast_sent(target_session):
     )
     assert success, "Timed out waiting for Foo broadcast"
 
-
+@pytest.mark.skip_if("target==['s32k148']", "Middleware Foo test not supported on s32k148")
 def test_foo_attribute_notification(target_session):
     """Cluster1 FooProxy receives a change notification right after a broadcast."""
     capserial = target_session.capserial()
@@ -75,7 +75,7 @@ def test_foo_attribute_notification(target_session):
     )
     assert success, "Proxy did not receive attribute change notification after broadcast"
 
-
+@pytest.mark.skip_if("target==['s32k148']", "Middleware Foo test not supported on s32k148")
 def test_foo_getter_response(target_session):
     """Cluster1 FooProxy getter round-trip returns a response within expected time."""
     capserial = target_session.capserial()
@@ -87,7 +87,7 @@ def test_foo_getter_response(target_session):
     )
     assert success, "Timed out waiting for Foo getter response"
 
-
+@pytest.mark.skip_if("target==['s32k148']", "Middleware Foo test not supported on s32k148")
 def test_foo_value_increments(target_session):
     """fooValue is strictly incremented across two consecutive broadcasts."""
     capserial = target_session.capserial()
@@ -111,7 +111,7 @@ def test_foo_value_increments(target_session):
         f"fooValue did not increment: first={values[0]}, second={values[1]}"
     )
 
-
+@pytest.mark.skip_if("target==['s32k148']", "Middleware Foo test not supported on s32k148")
 def test_foo_broadcast_and_getter_values_match(target_session):
     """The fooValue in a getter response matches the most recent broadcast value."""
     capserial = target_session.capserial()


### PR DESCRIPTION
Skip test_middleware tests when target is s32k148

- test_middleware.py tests are currently failing when run on s32k148 target
- The expected messages in tests are not observed and need to be analyzed before enabling tests on hardware
