### PR TITLE
Fix middleware undefined behaviour

### DIFF
--- a/libs/bsw/middleware/include/middleware/queue/Queue.h
+++ b/libs/bsw/middleware/include/middleware/queue/Queue.h
@@ -193,14 +193,13 @@ public:
         bool write(QueueItem const& value)
         {
             LockStrategy const lock(_queue._mutex.get());
-            ::etl::optional<size_t> index = _queue.writeNext();
-            bool res                      = index.has_value();
-            if (res)
+            ::etl::optional<WriteToken> const token = _queue.reserveSlot();
+            if (token.has_value())
             {
-                _queue._buffer[index.value()] = value;
+                _queue._buffer[token->slotIndex] = value;
+                _queue.publishSlot(*token);
             }
-
-            return res;
+            return token.has_value();
         }
 
     private:
@@ -287,14 +286,13 @@ public:
         /** Appends \p value to the queue, returns true on success. */
         bool write(QueueItem const& value)
         {
-            ::etl::optional<size_t> index = _queue.writeNext();
-            bool const res                = index.has_value();
-            if (res)
+            ::etl::optional<WriteToken> const token = _queue.reserveSlot();
+            if (token.has_value())
             {
-                _queue._buffer[index.value()] = value;
+                _queue._buffer[token->slotIndex] = value;
+                _queue.publishSlot(*token);
             }
-
-            return res;
+            return token.has_value();
         }
 
     private:

--- a/libs/bsw/middleware/include/middleware/queue/QueueBase.h
+++ b/libs/bsw/middleware/include/middleware/queue/QueueBase.h
@@ -66,28 +66,23 @@ public:
     /** Returns the current number of elements in the queue. */
     uint32_t size() const
     {
-        // Volatile is needed to to make sure the read is not optimized away when new elements have
-        // been added to the queue by the other core.
-        uint32_t const txPos = static_cast<uint32_t const volatile&>(_sent);
+        // _sent is volatile; read is not optimised away when the other core writes it.
+        uint32_t const txPos = _sent;
         return (txPos >= _received) ? (txPos - _received) : (txPos + (2U * _maxSize)) - _received;
     }
 
     /** Returns true if the queue is full, false otherwise. */
     bool isFull() const
     {
-        // Volatile is needed to make sure the read is not optimized away when isFull() is called
-        // in a loop like `while(sender.isFull()){}`.
-        return (
-            _sent
-            == ((static_cast<uint32_t const volatile&>(_received) + _maxSize) % (2U * _maxSize)));
+        // _received is volatile; read is not optimised away when called in a busy-wait loop.
+        return _sent == ((_received + _maxSize) % (2U * _maxSize));
     }
 
     /** Returns true if the queue is empty, false otherwise. */
     bool isEmpty() const
     {
-        // Volatile is needed to prevent `isEmpty()` from returning `true` when in fact new elements
-        // have been added to the queue by the other core.
-        return static_cast<uint32_t const volatile&>(_sent) == _received;
+        // _sent is volatile; read is not optimised away when the other core adds elements.
+        return _sent == _received;
     }
 
     /**
@@ -175,8 +170,8 @@ protected:
 
 private:
     uint32_t _maxSize;
-    uint32_t _sent;
-    uint32_t _received;
+    uint32_t volatile _sent;
+    uint32_t volatile _received;
     QueueStats _stats;
 };
 

--- a/libs/bsw/middleware/include/middleware/queue/QueueBase.h
+++ b/libs/bsw/middleware/include/middleware/queue/QueueBase.h
@@ -69,7 +69,9 @@ public:
     {
         // Snapshot both cursors once to avoid a race between the comparison
         // and the subtraction in the ternary expression below.
-        uint32_t const txPos = _sent.load(::etl::memory_order_relaxed);
+        // acquire on _sent synchronises with the release in publishSlot() so that
+        // the payload written before publishSlot() is visible before peek().
+        uint32_t const txPos = _sent.load(::etl::memory_order_acquire);
         uint32_t const rxPos = _received.load(::etl::memory_order_relaxed);
         return (txPos >= rxPos) ? (txPos - rxPos) : (txPos + (2U * _maxSize)) - rxPos;
     }
@@ -84,7 +86,8 @@ public:
     /** Returns true if the queue is empty, false otherwise. */
     bool isEmpty() const
     {
-        return _sent.load(::etl::memory_order_relaxed)
+        // acquire on _sent: see size() comment.
+        return _sent.load(::etl::memory_order_acquire)
                == _received.load(::etl::memory_order_relaxed);
     }
 
@@ -144,33 +147,57 @@ protected:
     }
 
     /**
-     * Updates the writing cursor to the next element in the buffer.
-     *
-     * \return ::etl::optional<size_t>
+     * Token returned by reserveSlot() carrying the slot index and the
+     * next-sent value to pass to publishSlot() after writing the payload.
      */
-    ::etl::optional<size_t> writeNext()
+    struct WriteToken
     {
-        ::etl::optional<size_t> writableIndex{};
+        size_t slotIndex;
+        uint32_t nextSent;
+    };
+
+    /**
+     * Reserves the next writable slot without publishing the cursor.
+     * The caller must write the payload into _buffer[token.slotIndex] and then
+     * call publishSlot() to make the slot visible to the consumer.
+     *
+     * \return A WriteToken on success, or an empty optional if the queue is full.
+     */
+    ::etl::optional<WriteToken> reserveSlot()
+    {
+        ::etl::optional<WriteToken> token{};
         if (isFull())
         {
             ++_stats.lostMessages;
         }
         else
         {
-            uint32_t const sentVal = _sent.load(::etl::memory_order_relaxed);
-            writableIndex.emplace(sentVal % _maxSize);
-            _sent.store((sentVal + 1U) % (2U * _maxSize), ::etl::memory_order_relaxed);
-            if (size() > _stats.maxLoad)
-            {
-                _stats.maxLoad = static_cast<uint8_t>(size());
-            }
+            uint32_t const sentVal  = _sent.load(::etl::memory_order_relaxed);
+            uint32_t const nextSent = (sentVal + 1U) % (2U * _maxSize);
             if (0U == _received.load(::etl::memory_order_relaxed))
             {
                 ++_stats.startupLoad;
             }
+            token.emplace(WriteToken{sentVal % _maxSize, nextSent});
         }
+        return token;
+    }
 
-        return writableIndex;
+    /**
+     * Publishes the slot reserved by reserveSlot(), making it visible to
+     * the consumer. Must be called after the payload has been written.
+     * Uses memory_order_release so the payload write is visible before
+     * the consumer sees the updated cursor via size()/isEmpty()/peek().
+     *
+     * \param token  The WriteToken returned by the matching reserveSlot() call.
+     */
+    void publishSlot(WriteToken const& token)
+    {
+        _sent.store(token.nextSent, ::etl::memory_order_release);
+        if (size() > _stats.maxLoad)
+        {
+            _stats.maxLoad = static_cast<uint8_t>(size());
+        }
     }
 
 private:

--- a/libs/bsw/middleware/include/middleware/queue/QueueBase.h
+++ b/libs/bsw/middleware/include/middleware/queue/QueueBase.h
@@ -164,7 +164,7 @@ protected:
             {
                 _stats.maxLoad = static_cast<uint8_t>(size());
             }
-            if (0U == _stats.processedMessages)
+            if (0U == _received.load(::etl::memory_order_relaxed))
             {
                 ++_stats.startupLoad;
             }

--- a/libs/bsw/middleware/include/middleware/queue/QueueBase.h
+++ b/libs/bsw/middleware/include/middleware/queue/QueueBase.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <etl/atomic.h>
 #include <etl/optional.h>
 
 #include <cstdint>
@@ -66,23 +67,25 @@ public:
     /** Returns the current number of elements in the queue. */
     uint32_t size() const
     {
-        // _sent is volatile; read is not optimised away when the other core writes it.
-        uint32_t const txPos = _sent;
-        return (txPos >= _received) ? (txPos - _received) : (txPos + (2U * _maxSize)) - _received;
+        // Snapshot both cursors once to avoid a race between the comparison
+        // and the subtraction in the ternary expression below.
+        uint32_t const txPos = _sent.load(::etl::memory_order_relaxed);
+        uint32_t const rxPos = _received.load(::etl::memory_order_relaxed);
+        return (txPos >= rxPos) ? (txPos - rxPos) : (txPos + (2U * _maxSize)) - rxPos;
     }
 
     /** Returns true if the queue is full, false otherwise. */
     bool isFull() const
     {
-        // _received is volatile; read is not optimised away when called in a busy-wait loop.
-        return _sent == ((_received + _maxSize) % (2U * _maxSize));
+        uint32_t const rxPos = _received.load(::etl::memory_order_relaxed);
+        return _sent.load(::etl::memory_order_relaxed) == ((rxPos + _maxSize) % (2U * _maxSize));
     }
 
     /** Returns true if the queue is empty, false otherwise. */
     bool isEmpty() const
     {
-        // _sent is volatile; read is not optimised away when the other core adds elements.
-        return _sent == _received;
+        return _sent.load(::etl::memory_order_relaxed)
+               == _received.load(::etl::memory_order_relaxed);
     }
 
     /**
@@ -127,15 +130,16 @@ protected:
     {}
 
     /** Returns the value of the reading cursor. */
-    uint32_t getReceived() const { return _received; }
+    uint32_t getReceived() const { return _received.load(::etl::memory_order_relaxed); }
 
     /** Returns the value of the writing cursor. */
-    uint32_t getSent() const { return _sent; }
+    uint32_t getSent() const { return _sent.load(::etl::memory_order_relaxed); }
 
     /** Advances the reading cursor. */
     void advanceReceived()
     {
-        _received = (_received + 1U) % (2U * _maxSize);
+        uint32_t const next = (_received.load(::etl::memory_order_relaxed) + 1U) % (2U * _maxSize);
+        _received.store(next, ::etl::memory_order_relaxed);
         ++_stats.processedMessages;
     }
 
@@ -153,8 +157,9 @@ protected:
         }
         else
         {
-            writableIndex.emplace(_sent % _maxSize);
-            _sent = (_sent + 1U) % (2U * _maxSize);
+            uint32_t const sentVal = _sent.load(::etl::memory_order_relaxed);
+            writableIndex.emplace(sentVal % _maxSize);
+            _sent.store((sentVal + 1U) % (2U * _maxSize), ::etl::memory_order_relaxed);
             if (size() > _stats.maxLoad)
             {
                 _stats.maxLoad = static_cast<uint8_t>(size());
@@ -170,8 +175,8 @@ protected:
 
 private:
     uint32_t _maxSize;
-    uint32_t volatile _sent;
-    uint32_t volatile _received;
+    ::etl::atomic<uint32_t> _sent;
+    ::etl::atomic<uint32_t> _received;
     QueueStats _stats;
 };
 

--- a/libs/bsw/middleware/include/middleware/queue/QueueBase.h
+++ b/libs/bsw/middleware/include/middleware/queue/QueueBase.h
@@ -194,9 +194,10 @@ protected:
     void publishSlot(WriteToken const& token)
     {
         _sent.store(token.nextSent, ::etl::memory_order_release);
-        if (size() > _stats.maxLoad)
+        uint32_t const currentSize = size();
+        if (currentSize > _stats.maxLoad)
         {
-            _stats.maxLoad = static_cast<uint8_t>(size());
+            _stats.maxLoad = static_cast<uint8_t>(currentSize);
         }
     }
 

--- a/libs/bsw/middleware/src/middleware/memory/PoolBase.cpp
+++ b/libs/bsw/middleware/src/middleware/memory/PoolBase.cpp
@@ -51,12 +51,14 @@ void PoolBase::initialize()
     {
         uint8_t* const tempNext = offsetAddress(tempBuff, _elementAlignedSize);
         // Write the address of tempNext into the bytes pointed to by tempBuff
-        ::etl::mem_copy(reinterpret_cast<uint8_t const*>(&tempNext), sizeof(uint8_t*), tempBuff);
+        ::etl::mem_copy(
+            reinterpret_cast<uint8_t const*>(&tempNext), sizeof(uint8_t*), tempBuff); // NOLINT
         tempBuff = tempNext;
     }
     // Last chunk: next pointer is nullptr
     uint8_t* const null_ptr = nullptr;
-    ::etl::mem_copy(reinterpret_cast<uint8_t const*>(&null_ptr), sizeof(uint8_t*), tempBuff);
+    ::etl::mem_copy(
+        reinterpret_cast<uint8_t const*>(&null_ptr), sizeof(uint8_t*), tempBuff); // NOLINT
     _nextChunk = _buffer;
     _available = _elementCount;
 }
@@ -68,7 +70,7 @@ uint8_t* PoolBase::allocate(size_t const size)
     if ((size <= _elementSize) && (!isFull()))
     {
         ret = _nextChunk;
-        ::etl::mem_copy(ret, sizeof(uint8_t*), reinterpret_cast<uint8_t*>(&_nextChunk));
+        ::etl::mem_copy(ret, sizeof(uint8_t*), reinterpret_cast<uint8_t*>(&_nextChunk)); // NOLINT
         --_available;
         _stats.internalFragmentation += static_cast<uint32_t>(_elementSize - size);
         ++_stats.successfulAllocations;
@@ -93,7 +95,8 @@ bool PoolBase::deallocate(void* const ptr)
         // This relies on the null pointer being represented as all-zero bytes, which holds
         // on every supported target (ARM Cortex-M, x86/x86-64 POSIX) but is
         // implementation-defined by the C++ standard.
-        ::etl::mem_copy(reinterpret_cast<uint8_t const*>(&_nextChunk), sizeof(uint8_t*), ptrObject);
+        ::etl::mem_copy(
+            reinterpret_cast<uint8_t const*>(&_nextChunk), sizeof(uint8_t*), ptrObject); // NOLINT
 
         ptrdiff_t const distance = ::etl::distance(_buffer, ptrObject);
         size_t const ptrPosition = static_cast<size_t>(distance) / _elementAlignedSize;

--- a/libs/bsw/middleware/src/middleware/memory/PoolBase.cpp
+++ b/libs/bsw/middleware/src/middleware/memory/PoolBase.cpp
@@ -11,6 +11,7 @@
 #include "middleware/memory/PoolBase.h"
 
 #include <etl/algorithm.h>
+#include <etl/bit.h>
 #include <etl/iterator.h>
 #include <etl/memory.h>
 #include <etl/tuple.h>
@@ -48,15 +49,16 @@ void PoolBase::initialize()
     uint8_t* tempBuff = _buffer;
     for (size_t i = 0U; i < (_elementCount - 1U); ++i)
     {
-        uint8_t* const tempNext                = offsetAddress(tempBuff, _elementAlignedSize);
-        // Write the address of tempNext in the memory pointed to by tempBuff
-        *reinterpret_cast<uint8_t**>(tempBuff) = tempNext; // NOLINT
-        tempBuff                               = tempNext;
+        uint8_t* const tempNext = offsetAddress(tempBuff, _elementAlignedSize);
+        // Write the address of tempNext into the bytes pointed to by tempBuff
+        ::etl::mem_copy(reinterpret_cast<uint8_t const*>(&tempNext), sizeof(uint8_t*), tempBuff);
+        tempBuff = tempNext;
     }
     // Last chunk: next pointer is nullptr
-    *reinterpret_cast<uint8_t**>(tempBuff) = nullptr; // NOLINT
-    _nextChunk                             = _buffer;
-    _available                             = _elementCount;
+    uint8_t* const null_ptr = nullptr;
+    ::etl::mem_copy(reinterpret_cast<uint8_t const*>(&null_ptr), sizeof(uint8_t*), tempBuff);
+    _nextChunk = _buffer;
+    _available = _elementCount;
 }
 
 uint8_t* PoolBase::allocate(size_t const size)
@@ -65,8 +67,8 @@ uint8_t* PoolBase::allocate(size_t const size)
 
     if ((size <= _elementSize) && (!isFull()))
     {
-        ret        = _nextChunk;
-        _nextChunk = *reinterpret_cast<uint8_t**>(_nextChunk); // NOLINT
+        ret = _nextChunk;
+        ::etl::mem_copy(ret, sizeof(uint8_t*), reinterpret_cast<uint8_t*>(&_nextChunk));
         --_available;
         _stats.internalFragmentation += static_cast<uint32_t>(_elementSize - size);
         ++_stats.successfulAllocations;
@@ -87,8 +89,7 @@ bool PoolBase::deallocate(void* const ptr)
     auto* const ptrObject = static_cast<uint8_t*>(ptr);
     if (isValidPointer(ptrObject))
     {
-        *reinterpret_cast<uintptr_t*>(ptrObject)                                    // NOLINT
-            = _nextChunk != nullptr ? reinterpret_cast<uintptr_t>(_nextChunk) : 0U; // NOLINT
+        ::etl::mem_copy(reinterpret_cast<uint8_t const*>(&_nextChunk), sizeof(uint8_t*), ptrObject);
 
         ptrdiff_t const distance = ::etl::distance(_buffer, ptrObject);
         size_t const ptrPosition = static_cast<size_t>(distance) / _elementAlignedSize;

--- a/libs/bsw/middleware/src/middleware/memory/PoolBase.cpp
+++ b/libs/bsw/middleware/src/middleware/memory/PoolBase.cpp
@@ -153,8 +153,10 @@ void PoolBase::updatePtrFlag(size_t const position, bool const ptrBusy)
     }
     else
     {
-        uint32_t const mask = ~(static_cast<size_t>(1U) << indexRemainder);
-        *(offsetAddress(_flags, index)) &= static_cast<uint8_t>(mask);
+        // Keep the mask at uint8_t width: 1U << indexRemainder is at most 128 (indexRemainder
+        // is in [0, CHAR_BIT-1]), so the cast is lossless on any platform.
+        uint8_t const mask = static_cast<uint8_t>(~(1U << indexRemainder));
+        *(offsetAddress(_flags, index)) &= mask;
     }
 }
 

--- a/libs/bsw/middleware/src/middleware/memory/PoolBase.cpp
+++ b/libs/bsw/middleware/src/middleware/memory/PoolBase.cpp
@@ -89,6 +89,10 @@ bool PoolBase::deallocate(void* const ptr)
     auto* const ptrObject = static_cast<uint8_t*>(ptr);
     if (isValidPointer(ptrObject))
     {
+        // Copies the raw bytes of _nextChunk (which may be nullptr) into the freed slot.
+        // This relies on the null pointer being represented as all-zero bytes, which holds
+        // on every supported target (ARM Cortex-M, x86/x86-64 POSIX) but is
+        // implementation-defined by the C++ standard.
         ::etl::mem_copy(reinterpret_cast<uint8_t const*>(&_nextChunk), sizeof(uint8_t*), ptrObject);
 
         ptrdiff_t const distance = ::etl::distance(_buffer, ptrObject);

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.cpp.jinja
@@ -50,7 +50,7 @@ void process{{cluster.name}}Cluster(size_t messages, const bool updateTimeouts)
         {
 {% for connection in connections if connection.source_cluster.name == cluster.name %}
             case core::ClusterId::{{connection.target_cluster.name}}: {
-                (*ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}).processMessage(msg);
+                ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}->processMessage(msg);
                 break;
             }
 {% endfor %}
@@ -72,7 +72,7 @@ void process{{cluster.name}}Cluster(size_t messages, const bool updateTimeouts)
 void update{{cluster.name}}ClusterTimeouts()
 {
 {% for connection in connections if connection.source_cluster.name == cluster.name and connection.has_timeouts %}
-    (*ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}).updateTimeouts();
+    ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}->updateTimeouts();
 {% endfor %}
 }
 

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.cpp.jinja
@@ -22,6 +22,7 @@
 #include "middleware/Cluster{{cluster.name}}.h"
 
 #include <etl/algorithm.h>
+#include <etl/alignment.h>
 #include <etl/type_traits.h>
 
 #include "middleware/ClusterId.h"
@@ -49,7 +50,7 @@ void process{{cluster.name}}Cluster(size_t messages, const bool updateTimeouts)
         {
 {% for connection in connections if connection.source_cluster.name == cluster.name %}
             case core::ClusterId::{{connection.target_cluster.name}}: {
-                ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}.processMessage(msg);
+                (*ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}).processMessage(msg);
                 break;
             }
 {% endfor %}
@@ -71,24 +72,22 @@ void process{{cluster.name}}Cluster(size_t messages, const bool updateTimeouts)
 void update{{cluster.name}}ClusterTimeouts()
 {
 {% for connection in connections if connection.source_cluster.name == cluster.name and connection.has_timeouts %}
-    ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}.updateTimeouts();
+    (*ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}).updateTimeouts();
 {% endfor %}
 }
 
 // ***************************** {{cluster.name}} *****************************
 {% for connection in connections if connection.source_cluster.name == cluster.name %}
-meta::ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Meta ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config;
-core::ClusterConnectionTypeSelector<meta::ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Meta>::type ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}(
-    ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config);
+::etl::typed_storage<meta::ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Meta> ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config;
+::etl::typed_storage<core::ClusterConnectionTypeSelector<meta::ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Meta>::type> ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}};
 {% endfor %}
 
 void initialize{{cluster.name}}ClusterConnection()
 {
 {% for connection in connections if connection.source_cluster.name == cluster.name %}
-    static_cast<void>(new (&ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config) decltype(ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config)());
-    static_cast<void>(new (&ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}})
-        decltype(ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}})(
-            ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config));
+    ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config.create();
+    ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}.create(
+        *ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config);
 {% endfor %}
 }
 

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.h.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.h.jinja
@@ -21,6 +21,7 @@
   */
 #pragma once
 
+#include <etl/alignment.h>
 #include <etl/delegate.h>
 
 {% for connection in connections if connection.source_cluster.name == cluster.name %}
@@ -32,7 +33,7 @@ namespace middleware
 {
 
 {% for connection in connections if connection.source_cluster.name == cluster.name %}
-extern core::ClusterConnectionTypeSelector<meta::ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}}Meta>::type ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}};
+extern ::etl::typed_storage<core::ClusterConnectionTypeSelector<meta::ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}}Meta>::type> ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}};
 {% endfor %}
 
 void initialize{{cluster.name}}ClusterConnection();

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_common.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_common.cpp.jinja
@@ -98,20 +98,20 @@ class InstancesDatabase_Merged : public ::middleware::core::IInstanceDatabase
   private:
     static constexpr ::etl::array<const uint16_t, {{all_instance_ids | length}}U> fInstanceIds = {% if all_instance_ids -%}{ {{all_instance_ids | join('U, ')}}U }{%- else -%}{  }{%- endif %};
     {% if all_proxy_connections %}
-    static constexpr ::etl::array<::middleware::core::IClusterConnection* const, {{all_proxy_connections | length}}U> fProxyConnections = {
+    inline static ::etl::array<::middleware::core::IClusterConnection* const, {{all_proxy_connections | length}}U> fProxyConnections = {
         {
         {%- for connection in all_proxy_connections %}
-        &::middleware::ClusterConnection{{ connection.source_cluster.name }}To{{ connection.target_cluster.name }}{{ "," if not loop.last }}
+        ::middleware::ClusterConnection{{ connection.source_cluster.name }}To{{ connection.target_cluster.name }}.operator->(){{ "," if not loop.last }}
 
         {%- endfor %}
         }
         };
     {% endif %}
     {% if all_skeleton_connections %}
-    static constexpr ::etl::array<::middleware::core::IClusterConnection* const, {{all_skeleton_connections | length}}U> fSkeletonConnections = {
+    inline static ::etl::array<::middleware::core::IClusterConnection* const, {{all_skeleton_connections | length}}U> fSkeletonConnections = {
         {
         {%- for connection in all_skeleton_connections %}
-        &::middleware::ClusterConnection{{ connection.source_cluster.name }}To{{ connection.target_cluster.name }}{{ "," if not loop.last }}
+        ::middleware::ClusterConnection{{ connection.source_cluster.name }}To{{ connection.target_cluster.name }}.operator->(){{ "," if not loop.last }}
 
         {%- endfor %}
         }
@@ -119,12 +119,6 @@ class InstancesDatabase_Merged : public ::middleware::core::IInstanceDatabase
     {% endif %}
 };
 
-{% if all_proxy_connections %}
-constexpr ::etl::array<::middleware::core::IClusterConnection* const, {{all_proxy_connections | length}}U> InstancesDatabase_Merged::fProxyConnections;
-{% endif %}
-{% if all_skeleton_connections %}
-constexpr ::etl::array<::middleware::core::IClusterConnection* const, {{all_skeleton_connections | length}}U> InstancesDatabase_Merged::fSkeletonConnections;
-{% endif %}
 constexpr ::etl::array<const uint16_t, {{all_instance_ids | length}}U> InstancesDatabase_Merged::fInstanceIds;
 
 constexpr InstancesDatabase_Merged _InstancesDatabase_Merged;

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_common.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_common.cpp.jinja
@@ -75,7 +75,16 @@ class InstancesDatabase_Merged : public ::middleware::core::IInstanceDatabase
     ::etl::span<::middleware::core::IClusterConnection* const> getSkeletonConnectionsRange() const override
     {
         {% if all_skeleton_connections %}
-        return ::etl::make_span(fSkeletonConnections);
+        // Function-local static: initialised on first call, which is always after
+        // initializeXClusterConnection() has called typed_storage::create().
+        static ::etl::array<::middleware::core::IClusterConnection* const, {{all_skeleton_connections | length}}U> connections = {
+            {
+            {%- for connection in all_skeleton_connections %}
+            ::middleware::ClusterConnection{{ connection.source_cluster.name }}To{{ connection.target_cluster.name }}.operator->(){{ "," if not loop.last }}
+            {%- endfor %}
+            }
+        };
+        return ::etl::make_span(connections);
         {% else %}
         return ::etl::span<::middleware::core::IClusterConnection* const>();
         {% endif %}
@@ -84,7 +93,14 @@ class InstancesDatabase_Merged : public ::middleware::core::IInstanceDatabase
     ::etl::span<::middleware::core::IClusterConnection* const> getProxyConnectionsRange() const override
     {
         {% if all_proxy_connections %}
-        return ::etl::make_span(fProxyConnections);
+        static ::etl::array<::middleware::core::IClusterConnection* const, {{all_proxy_connections | length}}U> connections = {
+            {
+            {%- for connection in all_proxy_connections %}
+            ::middleware::ClusterConnection{{ connection.source_cluster.name }}To{{ connection.target_cluster.name }}.operator->(){{ "," if not loop.last }}
+            {%- endfor %}
+            }
+        };
+        return ::etl::make_span(connections);
         {% else %}
         return ::etl::span<::middleware::core::IClusterConnection* const>();
         {% endif %}
@@ -97,26 +113,6 @@ class InstancesDatabase_Merged : public ::middleware::core::IInstanceDatabase
 
   private:
     static constexpr ::etl::array<const uint16_t, {{all_instance_ids | length}}U> fInstanceIds = {% if all_instance_ids -%}{ {{all_instance_ids | join('U, ')}}U }{%- else -%}{  }{%- endif %};
-    {% if all_proxy_connections %}
-    inline static ::etl::array<::middleware::core::IClusterConnection* const, {{all_proxy_connections | length}}U> fProxyConnections = {
-        {
-        {%- for connection in all_proxy_connections %}
-        ::middleware::ClusterConnection{{ connection.source_cluster.name }}To{{ connection.target_cluster.name }}.operator->(){{ "," if not loop.last }}
-
-        {%- endfor %}
-        }
-        };
-    {% endif %}
-    {% if all_skeleton_connections %}
-    inline static ::etl::array<::middleware::core::IClusterConnection* const, {{all_skeleton_connections | length}}U> fSkeletonConnections = {
-        {
-        {%- for connection in all_skeleton_connections %}
-        ::middleware::ClusterConnection{{ connection.source_cluster.name }}To{{ connection.target_cluster.name }}.operator->(){{ "," if not loop.last }}
-
-        {%- endfor %}
-        }
-        };
-    {% endif %}
 };
 
 constexpr ::etl::array<const uint16_t, {{all_instance_ids | length}}U> InstancesDatabase_Merged::fInstanceIds;


### PR DESCRIPTION
**Pool memory (`PoolBase.cpp`)**

- Fix implicit integer-conversion UB in `updatePtrFlag`: the clear-bit mask was computed in `size_t` and implicitly narrowed to `uint32_t`. Now computed directly at `uint8_t` width via an explicit cast that is provably lossless (`indexRemainder ∈ [0, CHAR_BIT-1]`).

**Pool free-list (`PoolBase.cpp`)**

- Fix strict-aliasing UB in the free-list initialisation: raw byte copies through `reinterpret_cast` now go via `etl::mem_copy` to satisfy the aliasing rules.

**Queue (`QueueBase.h`, `Queue.h`)**

- Replace `volatile` cursors with `etl::atomic` throughout `QueueBase` to give correct acquire/release semantics.
- Fix producer/consumer race on the startup counter read path.
- Split the write operation into `reserveSlot()` / `publishSlot()` to eliminate the cursor-before-payload race where the consumer could observe the updated sent cursor before the payload was written.
- Cache `size()` in `publishSlot()` to avoid two inconsistent atomic loads when updating `maxLoad`.

**Generated cluster/service code (jinja templates)**

- Fix typed_storage initialisation-order UB: `ClusterConnection` objects and their config were direct-initialised as global variables, causing static init-order issues. Replace with `::etl::typed_storage<>` and explicit `create()` calls in `initializeXClusterConnection()`.
- Fix the `getSkeletonConnectionsRange()` / `getProxyConnectionsRange()` static constexpr arrays: `static constexpr` members holding pointers to typed_storage objects were invalid before construction. Replace with function-local statics initialised on first call (guaranteed after `initializeXClusterConnection()`).