### PR TITLE
Create proxy mock and adapt jinja files

### DIFF
--- a/libs/bsw/middleware/test/mock/CMakeLists.txt
+++ b/libs/bsw/middleware/test/mock/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(middlewareMock INTERFACE)
+target_include_directories(middlewareMock INTERFACE include)
+target_link_libraries(middlewareMock INTERFACE etl)

--- a/libs/bsw/middleware/test/mock/include/util/crtp_mock.h
+++ b/libs/bsw/middleware/test/mock/include/util/crtp_mock.h
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (c) 2026 BMW AG
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#pragma once
+
+#include <etl/error_handler.h>
+
+namespace middleware::util
+{
+/**
+ * \brief CRTP base class that wraps a GMock class
+ *
+ * The getMock() function provides access to the mock object and its mocked
+ * functions. Free mock functions can use this to redirect concrete
+ * implementations to the mock class T.
+ */
+template<typename T>
+class CrtpMock
+{
+public:
+    ~CrtpMock() { gInstance = nullptr; }
+
+    static bool isInstantiated() { return gInstance != nullptr; }
+
+    static auto* getMock()
+    {
+        ETL_ASSERT(gInstance != nullptr, ETL_ERROR_GENERIC("CrtpMock instance not set."));
+        return gInstance;
+    }
+
+private:
+    static inline T* gInstance;
+
+    CrtpMock() { gInstance = static_cast<T*>(this); }
+
+    // Explicitly disable copy/move to satisfy special member function guidelines
+    CrtpMock(CrtpMock const&)            = delete;
+    CrtpMock& operator=(CrtpMock const&) = delete;
+    CrtpMock(CrtpMock&&)                 = delete;
+    CrtpMock& operator=(CrtpMock&&)      = delete;
+
+    friend T;
+};
+
+} // namespace middleware::util

--- a/libs/bsw/middleware/tools/cpp_generator/README.md
+++ b/libs/bsw/middleware/tools/cpp_generator/README.md
@@ -45,7 +45,8 @@ python3 jinja2cpp.py \
   --output <output-base-dir> \
   --deployment-yaml <path-to-deployment.yaml> \
   [--clang-format-config <path-to-.clang-format>] \
-  [--no-clean]
+  [--no-clean] \
+  [--generation-mode {normal,mock}]
 ```
 
 ### Arguments
@@ -57,6 +58,7 @@ python3 jinja2cpp.py \
 | `--deployment-yaml` | Yes | Path to the deployment YAML file |
 | `--clang-format-config` | No | Path to a `.clang-format` config file; auto-detected from repo root if omitted |
 | `--no-clean` | No | Skip deleting the output directories before generation |
+| `--generation-mode` | No | Default generation mode: `normal` (full generation) or `mock` (interface-only for testing). Default: `normal` |
 
 ## Quick test with the bundled test deployment
 
@@ -85,6 +87,7 @@ include/generated_code/
   <namespace-path>/
     <service>_common.h        # one set per service
     <service>_proxy.h
+    <service>_proxy_mock.h    # mock header (skipped in normal mode)
     <service>_skeleton.h
 
 src/generated_code/
@@ -97,6 +100,18 @@ src/generated_code/
     <service>_proxy.cpp
     <service>_skeleton.cpp
 ```
+
+## Mock generation mode
+
+When `--generation-mode mock` is passed (or `generation_mode: mock` is set on a
+service in the deployment YAML), the generator produces only the interface files
+needed for unit-test mocking:
+
+- Global: only `cluster_id.h` and `shm/allocators_definitions.h`
+- Per-service: `*_common.h`, `*_proxy.h`, `*_proxy_mock.h`, and
+  `*_proxy_mock.cpp` (delegating to a GMock singleton via RAII auto-registration)
+
+Cluster, connection, skeleton, and COM templates are skipped in this mode.
 
 ## Input structure
 

--- a/libs/bsw/middleware/tools/cpp_generator/jinja2cpp.py
+++ b/libs/bsw/middleware/tools/cpp_generator/jinja2cpp.py
@@ -81,7 +81,9 @@ def load_yaml(yaml_path: Path) -> dict:
     with open(yaml_path, "r") as fh:
         data = yaml.safe_load(fh)
     if not isinstance(data, dict):
-        raise ValueError(f"Expected a YAML mapping at the top level, got {type(data).__name__}")
+        raise ValueError(
+            f"Expected a YAML mapping at the top level, got {type(data).__name__}"
+        )
     return _to_dot_dict(data)
 
 
@@ -98,7 +100,9 @@ def validate_data(data: dict, schema_path: Path) -> list[str]:
         validate(instance=dict(data), schema=schema)
         print(f" ✓ Schema validation passed: {schema_path.name}")
     except ValidationError as exc:
-        errors.append(f"{schema_path.name}: {exc.message} (path: {list(exc.absolute_path)})")
+        errors.append(
+            f"{schema_path.name}: {exc.message} (path: {list(exc.absolute_path)})"
+        )
     return errors
 
 
@@ -125,7 +129,9 @@ def load_input_data(input_base: Path, deployment_yaml: Path | None = None) -> di
         raise RuntimeError(f"Error loading deployment.yaml: {e}")
 
 
-def render_template_with_context(template_path: Path, context: dict, output_path: Path) -> None:
+def render_template_with_context(
+    template_path: Path, context: dict, output_path: Path
+) -> None:
     """Render a single template with the given context and write to output path."""
     env = Environment(
         loader=FileSystemLoader(searchpath=str(template_path.parent)),
@@ -150,15 +156,31 @@ def render_template_with_context(template_path: Path, context: dict, output_path
 # Template generation configuration
 TEMPLATE_CONFIG = {
     "global": [
-        ("allocator_selector_definitions.cpp.jinja", "AllocatorSelectorDefinitions.cpp", "src/generated_code"),
+        (
+            "allocator_selector_definitions.cpp.jinja",
+            "AllocatorSelectorDefinitions.cpp",
+            "src/generated_code",
+        ),
         ("cluster_id.h.jinja", "ClusterId.h", "include/generated_code/middleware"),
-        ("shm/allocators_definitions.h.jinja", "AllocatorsDefinitions.h", "include/generated_code/shm"),
+        (
+            "shm/allocators_definitions.h.jinja",
+            "AllocatorsDefinitions.h",
+            "include/generated_code/shm",
+        ),
         ("shm/config.h.jinja", "Config.h", "include/generated_code/middleware/shm"),
         ("shm/config.cpp.jinja", "Config.cpp", "src/generated_code/shm"),
-        ("shm/queue_definitions.h.jinja", "QueueDefinitions.h", "include/generated_code/shm"),
+        (
+            "shm/queue_definitions.h.jinja",
+            "QueueDefinitions.h",
+            "include/generated_code/shm",
+        ),
     ],
     "per_cluster": [
-        ("cluster_srcCluster.h.jinja", "Cluster{}.h", "include/generated_code/middleware"),
+        (
+            "cluster_srcCluster.h.jinja",
+            "Cluster{}.h",
+            "include/generated_code/middleware",
+        ),
         ("cluster_srcCluster.cpp.jinja", "Cluster{}.cpp", "src/generated_code"),
     ],
     "per_connection": [
@@ -171,12 +193,59 @@ TEMPLATE_CONFIG = {
     "per_service": [
         ("service_common.h.jinja", "{}Common.h", "include/generated_code/{}"),
         ("service_proxy.h.jinja", "{}Proxy.h", "include/generated_code/{}"),
+        (
+            "mock/service_proxy_mock.h.jinja",
+            "{}ProxyMock.h",
+            "include/generated_code/{}",
+        ),
         ("service_skeleton.h.jinja", "{}Skeleton.h", "include/generated_code/{}"),
         ("service_common.cpp.jinja", "{}Common.cpp", "src/generated_code/{}"),
         ("service_proxy.cpp.jinja", "{}Proxy.cpp", "src/generated_code/{}"),
         ("service_skeleton.cpp.jinja", "{}Skeleton.cpp", "src/generated_code/{}"),
     ],
 }
+
+
+# In mock generation mode a normal per-service template is replaced by its
+# `mock/<name>_mock` variant while keeping the same output filename. The variant
+# delegates the generated implementation to the mock singleton (the *.cpp
+# entries). Proxy attributes/events are concrete classes whose method bodies are
+# swapped at link time, so no header swap is required.
+MOCK_TEMPLATE_OVERRIDES = {
+    "service_common.h.jinja": "service_common.h.jinja",
+    "service_proxy.h.jinja": "service_proxy.h.jinja",
+    "mock/service_proxy_mock.h.jinja": "mock/service_proxy_mock.h.jinja",
+    "service_proxy.cpp.jinja": "mock/service_proxy_mock.cpp.jinja",
+    "service_skeleton.cpp.jinja": "mock/service_skeleton_mock.cpp.jinja",
+}
+
+# Global templates that are also generated in mock mode.
+MOCK_GLOBAL_TEMPLATES = {
+    "cluster_id.h.jinja",
+    "shm/allocators_definitions.h.jinja",
+}
+
+
+def _service_generation_mode(service) -> str:
+    """Return generation mode for a service.
+
+    Supported modes:
+    - normal: generate regular proxy + skeleton files
+    - mock: generate only templates under templates/jinja/mock
+    """
+    mode = str(getattr(service, "generation_mode", "")).strip().lower()
+    if mode in {"normal", "mock"}:
+        return mode
+
+    return "normal"
+
+
+def _has_mock_mode_service(input_data) -> bool:
+    """Return True if at least one service requests mock generation mode."""
+    return any(
+        _service_generation_mode(service) == "mock"
+        for service in getattr(input_data, "services", [])
+    )
 
 
 def build_context(input_data: dict, **additional) -> dict:
@@ -193,7 +262,12 @@ def build_context(input_data: dict, **additional) -> dict:
 
 
 def generate_files(
-    template_type: str, input_data: dict, input_base: Path, output_base: Path, items=None, item_key: str = None
+    template_type: str,
+    input_data: dict,
+    input_base: Path,
+    output_base: Path,
+    items=None,
+    item_key: str = None,
 ) -> None:
     """Unified file generation function for all template types."""
     print(f"Generating {template_type.replace('_', '-')} files...")
@@ -213,7 +287,27 @@ def generate_files(
                 print(f"  Processing {item_key}: {item.name}")
 
         for template_name, output_pattern, output_dir_pattern in mappings:
-            template_path = template_base / template_name
+            resolved_template_name = template_name
+
+            if template_type == "global" and _has_mock_mode_service(input_data):
+                if template_name not in MOCK_GLOBAL_TEMPLATES:
+                    continue
+
+            if template_type == "per_service":
+                service_mode = _service_generation_mode(item)
+
+                # normal: full regular service file set
+                # mock: generate only templates that live under templates/jinja/mock
+                if (
+                    service_mode == "normal"
+                    and template_name == "mock/service_proxy_mock.h.jinja"
+                ):
+                    continue
+                if service_mode == "mock":
+                    if template_name not in MOCK_TEMPLATE_OVERRIDES:
+                        continue
+                    resolved_template_name = MOCK_TEMPLATE_OVERRIDES[template_name]
+            template_path = template_base / resolved_template_name
 
             if not template_path.exists():
                 print(f"  Skipping template (not found): {template_name}")
@@ -233,15 +327,16 @@ def generate_files(
                 output_dir = output_base / output_dir_pattern
             elif template_type == "per_service":
                 service_name = getattr(item, "filename", item.name)
-                namespace_path = item.namespace.replace("::", "/").lower() if hasattr(item, "namespace") else ""
+                namespace_path = (
+                    item.namespace.replace("::", "/").lower()
+                    if hasattr(item, "namespace")
+                    else ""
+                )
                 output_filename = output_pattern.format(service_name)
                 output_dir = output_base / output_dir_pattern.format(namespace_path)
 
             output_path = output_dir / output_filename
             render_template_with_context(template_path, context, output_path)
-
-
-# These functions are now replaced by the unified generate_files() function above
 
 
 def clean_previous_generated_files(output_base: Path) -> None:
@@ -283,7 +378,10 @@ def format_cpp_files(output_base: Path, clang_format_config: Path = None) -> Non
         else:
             # Find the repository root (where .clang-format should be located)
             repo_root = Path(__file__).resolve()
-            while repo_root.parent != repo_root and not (repo_root / ".clang-format").exists():
+            while (
+                repo_root.parent != repo_root
+                and not (repo_root / ".clang-format").exists()
+            ):
                 repo_root = repo_root.parent
 
             clang_format_path = repo_root / ".clang-format"
@@ -300,7 +398,10 @@ def format_cpp_files(output_base: Path, clang_format_config: Path = None) -> Non
         if e.stderr:
             print(f"  Error output: {e.stderr.strip()}", file=sys.stderr)
     except FileNotFoundError:
-        print("Warning: clang-format not found in PATH, skipping formatting", file=sys.stderr)
+        print(
+            "Warning: clang-format not found in PATH, skipping formatting",
+            file=sys.stderr,
+        )
         print("  Install with: sudo apt install clang-format", file=sys.stderr)
         print("  Or ensure clang-format is available in your PATH", file=sys.stderr)
 
@@ -337,6 +438,12 @@ def parse_args(argv=None) -> argparse.Namespace:
         action="store_true",
         help="Preserve existing generated files and skip deleting include/generated_code and src/generated_code before generation.",
     )
+    parser.add_argument(
+        "--generation-mode",
+        choices=["normal", "mock"],
+        default="normal",
+        help="Default generation mode. Set to 'normal' for full service generation, or 'mock' to generate only templates from templates/jinja/mock (default: normal).",
+    )
     return parser.parse_args(argv)
 
 
@@ -362,6 +469,11 @@ def main(argv=None) -> int:
         print(f"error: {e}", file=sys.stderr)
         return 1
 
+    # Apply CLI generation-mode override to services that don't have explicit generation_mode set
+    for service in getattr(input_data, "services", []):
+        if not hasattr(service, "generation_mode") or not service.generation_mode:
+            service["generation_mode"] = args.generation_mode
+
     # Validate the input data against schema
     schema_path = input_base / "templates/schemas/deployment.yaml"
     if schema_path.exists():
@@ -376,20 +488,41 @@ def main(argv=None) -> int:
 
     # Generate all file types using the unified clusters.yaml data
     try:
+        has_mock_mode_service = _has_mock_mode_service(input_data)
+
         if args.no_clean:
             print("Skipping cleanup of previously generated files (--no-clean).")
         else:
             clean_previous_generated_files(output_base)
 
-        generate_files("global", input_data, input_base, output_base)
+        if has_mock_mode_service:
+            print("Mock generation mode detected: generating interface files only.")
+            generate_files("global", input_data, input_base, output_base)
+        else:
+            generate_files("global", input_data, input_base, output_base)
+            generate_files(
+                "per_cluster",
+                input_data,
+                input_base,
+                output_base,
+                items=input_data.clusters,
+                item_key="cluster",
+            )
+            generate_files(
+                "per_connection",
+                input_data,
+                input_base,
+                output_base,
+                items=input_data.connections,
+                item_key="connection",
+            )
         generate_files(
-            "per_cluster", input_data, input_base, output_base, items=input_data.clusters, item_key="cluster"
-        )
-        generate_files(
-            "per_connection", input_data, input_base, output_base, items=input_data.connections, item_key="connection"
-        )
-        generate_files(
-            "per_service", input_data, input_base, output_base, items=input_data.services, item_key="service"
+            "per_service",
+            input_data,
+            input_base,
+            output_base,
+            items=input_data.services,
+            item_key="service",
         )
 
         # Format all generated C++ files with clang-format

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/allocator_selector_definitions.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/allocator_selector_definitions.cpp.jinja
@@ -20,9 +20,10 @@
   *
   */
 #include <etl/type_traits.h>
-#include <middleware/memory/AllocatorSelector.h>
 
-#include "middleware/core/types.h"
+#include <middleware/memory/AllocatorSelector.h>
+#include <middleware/core/types.h>
+
 #include "shm/AllocatorsDefinitions.h"
 
 {% for service in services if service.allocator %}

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_connections_srcCluster_to_tgtCluster.h.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_connections_srcCluster_to_tgtCluster.h.jinja
@@ -27,13 +27,14 @@
 #include <etl/utility.h>
 #include <etl/vector.h>
 
+#include <middleware/core/ClusterConnection.h>
+#include <middleware/core/DatabaseManipulator.h>
+#include <middleware/core/IClusterConnectionConfigurationBase.h>
+#include <middleware/core/Message.h>
+#include <middleware/core/TransceiverContainer.h>
+#include <middleware/core/types.h>
+
 #include "middleware/ClusterId.h"
-#include "middleware/core/ClusterConnection.h"
-#include "middleware/core/DatabaseManipulator.h"
-#include "middleware/core/IClusterConnectionConfigurationBase.h"
-#include "middleware/core/Message.h"
-#include "middleware/core/TransceiverContainer.h"
-#include "middleware/core/types.h"
 #include "shm/QueueDefinitions.h"
 {% for proxy in connection.proxies %}
 #include "{{proxy.headers.common}}"

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.cpp.jinja
@@ -25,8 +25,9 @@
 #include <etl/alignment.h>
 #include <etl/type_traits.h>
 
+#include <middleware/core/LoggerApi.h>
+
 #include "middleware/ClusterId.h"
-#include "middleware/core/LoggerApi.h"
 #include "shm/QueueDefinitions.h"
 
 namespace middleware

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.h.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.h.jinja
@@ -24,10 +24,11 @@
 #include <etl/alignment.h>
 #include <etl/delegate.h>
 
+#include <middleware/core/ClusterConnection.h>
+
 {% for connection in connections if connection.source_cluster.name == cluster.name %}
 #include "middleware/ClusterConnections{{connection.source_cluster.name}}{{connection.target_cluster.name}}.h"
 {% endfor %}
-#include "middleware/core/ClusterConnection.h"
 
 namespace middleware
 {

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/mock/service_proxy_mock.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/mock/service_proxy_mock.cpp.jinja
@@ -1,0 +1,210 @@
+/********************************************************************************
+ * Copyright (c) 2026 BMW AG
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+/**
+  *
+  *  __  __ _     _     _ _
+  * |  \/  (_) __| | __| | | _____      ____ _ _ __ ___
+  * | |\/| | |/ _` |/ _` | |/ _ \ \ /\ / / _` | '__/ _ \
+  * | |  | | | (_| | (_| | |  __/\ V  V / (_| | | |  __/
+  * |_|  |_|_|\__,_|\__,_|_|\___| \_/\_/ \__,_|_|  \___|
+  *
+  * WARNING!
+  * This file is generated. Do not edit manually.
+  *
+  */
+#include "{{ service.headers.proxy }}"
+#include "{{ service.headers.proxy_mock | default(service.namespace.replace('::', '/') | lower + '/' + (service.filename | default(service.name | lower)) + '_proxy_mock.h') }}"
+
+#include <middleware/core/Message.h>
+#include <middleware/core/types.h>
+#include <middleware/os/TaskIdProvider.h>
+
+namespace {{ service.namespace }}::{{ service.name }}::proxy
+{
+
+// EVENTS
+{% for event in service.events if service.events %}
+{{ event.name }}Event::{{ event.name }}Event(::middleware::core::ProxyBase& proxy) : impl_(proxy)
+{
+}
+
+void {{ event.name }}Event::setReceiveHandler(const OnFieldChangedCallback callback)
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+    mock->{{ event.variable }}.setReceiveHandler(callback);
+}
+
+void {{ event.name }}Event::unsetReceiveHandler()
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+    mock->{{ event.variable }}.unsetReceiveHandler();
+}
+{% endfor %}
+
+// ATTRIBUTES
+{% for attribute in service.attributes if service.attributes %}
+{%- set has_subscription = not attribute.noSubscriptions %}
+{%- set has_setter = not attribute.readonly %}
+{%- set set_as_method = attribute.setAsMethod and not attribute.readonly %}
+{{ attribute.name }}Attribute::{{ attribute.name }}Attribute(::middleware::core::ProxyBase& proxy) : impl_(proxy)
+{
+}
+
+etl::expected<uint16_t, ::middleware::core::HRESULT> {{ attribute.name }}Attribute::get(const GetterCallback attrCb)
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+    return mock->{{ attribute.variable }}.get(attrCb);
+}
+
+::middleware::core::HRESULT {{ attribute.name }}Attribute::cancelGetterRequest(uint16_t requestId)
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+    return mock->{{ attribute.variable }}.cancelGetterRequest(requestId);
+}
+{%- if set_as_method %}
+
+etl::expected<uint16_t, ::middleware::core::HRESULT> {{ attribute.name }}Attribute::set(const AttributeType& payload,
+                                                                                       const SetterCallback cbk)
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+    return mock->{{ attribute.variable }}.set(payload, cbk);
+}
+
+::middleware::core::HRESULT {{ attribute.name }}Attribute::cancelSetterRequest(uint16_t requestId)
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+    return mock->{{ attribute.variable }}.cancelSetterRequest(requestId);
+}
+{%- elif has_setter %}
+
+etl::expected<uint16_t, ::middleware::core::HRESULT> {{ attribute.name }}Attribute::set(const AttributeType& payload)
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+    return mock->{{ attribute.variable }}.set(payload);
+}
+{%- endif %}
+{%- if has_subscription %}
+
+void {{ attribute.name }}Attribute::setReceiveHandler(const OnFieldChangedCallback callback)
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+    mock->{{ attribute.variable }}.setReceiveHandler(callback);
+}
+
+void {{ attribute.name }}Attribute::unsetReceiveHandler()
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+    mock->{{ attribute.variable }}.unsetReceiveHandler();
+}
+
+{% endif %}
+{% endfor %}
+
+{{ service.name }}Proxy::{{ service.name }}Proxy()
+    : Base(),
+      // ATTRIBUTES
+{% for attribute in service.attributes if service.attributes %}
+      {{ attribute.variable }}(*this),
+{% endfor %}
+      // EVENTS
+{% for event in service.events if service.events %}
+      {{ event.variable }}(*this),
+{% endfor %}
+      fProcessId(::middleware::core::INVALID_TASK_ID)
+{
+}
+
+{{ service.name }}Proxy::~{{ service.name }}Proxy()
+{
+    deInit();
+}
+
+middleware::core::HRESULT {{ service.name }}Proxy::init(const internal::InstanceId instanceId,
+                                                        ::middleware::core::ClusterId const sourceCluster)
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+    return mock->init(instanceId, sourceCluster);
+}
+
+void {{ service.name }}Proxy::deInit()
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+    mock->deInit();
+}
+
+uint16_t {{ service.name }}Proxy::getServiceId() const
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+    return mock->getServiceId();
+}
+
+// METHODS
+{% for method in service.methods if service.methods %}
+void {{ service.name }}Proxy::cancel{{ method.name }}Request(uint16_t requestId)
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+    mock->cancel{{ method.name }}Request(requestId);
+}
+{% endfor %}
+
+::middleware::core::HRESULT {{ service.name }}Proxy::onNewMessageReceived(::middleware::core::Message const&)
+{
+    return ::middleware::core::HRESULT::Ok;
+}
+
+void {{ service.name }}Proxy::futureDispatcherDeinitialization()
+{
+}
+
+void {{ service.name }}Proxy::updateTimeouts()
+{
+    doUpdateTimeouts();
+}
+
+void {{ service.name }}Proxy::doUpdateTimeouts()
+{
+}
+
+// METHODS
+{% for method in service.methods if service.methods %}
+etl::expected<uint16_t, middleware::core::HRESULT> {{ service.name }}Proxy::{{ method.variable }}(
+    {% if method.input_param %}const {{ method.input_param.type }}& {{ method.input_param.name }}, {% endif %}
+    const {{ method.name }}Callback& methodCb)
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+{% if method.input_param %}
+    return mock->{{ method.variable }}({{ method.input_param.name }}, methodCb);
+{% else %}
+    return mock->{{ method.variable }}(methodCb);
+{% endif %}
+}
+
+{% endfor %}
+
+// METHODS FIRE_AND_FORGET
+{% for method in service.methods_fire_and_forget if service.methods_fire_and_forget %}
+etl::expected<uint16_t, middleware::core::HRESULT> {{ service.name }}Proxy::{{ method.variable }}({% if method.input_param %}const {{ method.input_param.type }}& {{ method.input_param.name }}{% endif %})
+{
+    auto* mock = {{ service.name }}ProxyMock::getMock();
+{% if method.input_param %}
+    return mock->{{ method.variable }}({{ method.input_param.name }});
+{% else %}
+    return mock->{{ method.variable }}();
+{% endif %}
+}
+
+{% endfor %}
+
+::middleware::core::HRESULT {{ service.name }}Proxy::sendMessage(::middleware::core::Message&) const
+{
+    return ::middleware::core::HRESULT::NotRegistered;
+}
+
+}  // namespace {{ service.namespace }}::{{ service.name }}::proxy

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/mock/service_proxy_mock.h.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/mock/service_proxy_mock.h.jinja
@@ -1,0 +1,139 @@
+/********************************************************************************
+ * Copyright (c) 2026 BMW AG
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+/**
+  *
+  *  __  __ _     _     _ _
+  * |  \/  (_) __| | __| | | _____      ____ _ _ __ ___
+  * | |\/| | |/ _` |/ _` | |/ _ \ \ /\ / / _` | '__/ _ \
+  * | |  | | | (_| | (_| | |  __/\ V  V / (_| | | |  __/
+  * |_|  |_|_|\__,_|\__,_|_|\___| \_/\_/ \__,_|_|  \___|
+  *
+  * WARNING!
+  * This file is generated. Do not edit manually.
+  *
+  */
+#pragma once
+
+#include <etl/expected.h>
+#include <etl/functional.h>
+
+#include <gmock/gmock.h>
+
+#include <middleware/core/Future.h>
+#include <middleware/core/FutureDispatcher.h>
+#include <middleware/core/ProxyEventBase.h>
+
+#include "{{ service.headers.common }}"
+#include "{{ service.headers.proxy }}"
+#include "util/crtp_mock.h"
+
+namespace {{ service.namespace }}::{{ service.name }}::proxy
+{
+
+{% for event in service.events if service.events %}
+/// \brief GMock target for {{ event.name }}Event; the concrete proxy event forwards here.
+class {{ event.name }}EventMock
+{
+  public:
+    using EventType = {{ event.type }};
+    using OnFieldChangedCallback = middleware::core::EventCallbackTypeSelector<EventType>::Callback;
+
+    MOCK_METHOD(void, setReceiveHandler, (const OnFieldChangedCallback callback));
+    MOCK_METHOD(void, unsetReceiveHandler, ());
+};
+{% endfor %}
+
+{% for attribute in service.attributes if service.attributes %}
+{%- set has_subscription = not attribute.noSubscriptions %}
+{%- set has_setter = not attribute.readonly %}
+{%- set set_as_method = attribute.setAsMethod and not attribute.readonly %}
+/// \brief GMock target for {{ attribute.name }}Attribute; the concrete proxy attribute forwards here.
+class {{ attribute.name }}AttributeMock
+{
+  public:
+    using AttributeType = {{ attribute.name }}Attribute::AttributeType;
+    using GetterCallback = {{ attribute.name }}Attribute::GetterCallback;
+{%- if set_as_method %}
+    using SetterCallback = {{ attribute.name }}Attribute::SetterCallback;
+{%- endif %}
+{%- if has_subscription %}
+    using OnFieldChangedCallback = {{ attribute.name }}Attribute::OnFieldChangedCallback;
+{%- endif %}
+
+    MOCK_METHOD((etl::expected<uint16_t, middleware::core::HRESULT>), get, (const GetterCallback attrCb));
+    MOCK_METHOD(middleware::core::HRESULT, cancelGetterRequest, (uint16_t requestId));
+{%- if set_as_method %}
+    MOCK_METHOD((etl::expected<uint16_t, middleware::core::HRESULT>),
+                set,
+                (const AttributeType& payload, const SetterCallback cbk));
+    MOCK_METHOD(middleware::core::HRESULT, cancelSetterRequest, (uint16_t requestId));
+{%- elif has_setter %}
+    MOCK_METHOD((etl::expected<uint16_t, middleware::core::HRESULT>), set, (const AttributeType& payload));
+{%- endif %}
+{%- if has_subscription %}
+
+    MOCK_METHOD(void, setReceiveHandler, (const OnFieldChangedCallback callback));
+    MOCK_METHOD(void, unsetReceiveHandler, ());
+{%- endif %}
+};
+{% endfor %}
+
+class {{ service.name }}ProxyMock : public middleware::util::CrtpMock<{{ service.name }}ProxyMock>
+{
+  public:
+    {{ service.name }}ProxyMock() = default;
+    ~{{ service.name }}ProxyMock() = default;
+
+    MOCK_METHOD(middleware::core::HRESULT,
+                init,
+                (const internal::InstanceId instanceId, const middleware::core::ClusterId sourceCluster));
+    MOCK_METHOD(void, deInit, ());
+    MOCK_METHOD(uint16_t, getServiceId, (), (const));
+    MOCK_METHOD(bool, isInitialized, (), (const));
+
+    // METHODS
+{% for method in service.methods %}
+{% if method.input_param %}
+    MOCK_METHOD((etl::expected<uint16_t, middleware::core::HRESULT>),
+                {{ method.variable }},
+                (const {{ method.input_param.type }}& {{ method.input_param.name }},
+                 const {{ service.name }}Proxy::{{ method.name }}Callback& methodCb));
+{% else %}
+    MOCK_METHOD((etl::expected<uint16_t, middleware::core::HRESULT>),
+                {{ method.variable }},
+                (const {{ service.name }}Proxy::{{ method.name }}Callback& methodCb));
+{% endif %}
+    MOCK_METHOD(void, cancel{{ method.name }}Request, (uint16_t requestId));
+
+{% endfor %}
+
+    // METHODS FIRE_AND_FORGET
+{% for method in service.methods_fire_and_forget %}
+{% if method.input_param %}
+    MOCK_METHOD((etl::expected<uint16_t, middleware::core::HRESULT>),
+                {{ method.variable }},
+                (const {{ method.input_param.type }}& {{ method.input_param.name }}));
+{% else %}
+    MOCK_METHOD((etl::expected<uint16_t, middleware::core::HRESULT>), {{ method.variable }}, ());
+{% endif %}
+{% endfor %}
+
+    // EVENTS
+{% for event in service.events if service.events %}
+    ::testing::NiceMock<{{ event.name }}EventMock> {{ event.variable }};
+{% endfor %}
+
+    // ATTRIBUTES
+{% for attribute in service.attributes if service.attributes %}
+    ::testing::NiceMock<{{ attribute.name }}AttributeMock> {{ attribute.variable }};
+{% endfor %}
+};
+
+}  // namespace {{ service.namespace }}::{{ service.name }}::proxy

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_proxy.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_proxy.cpp.jinja
@@ -24,8 +24,8 @@
 #include <etl/delegate.h>
 #include <etl/expected.h>
 #include <etl/utility.h>
-#include <middleware/os/TaskIdProvider.h>
 
+#include <middleware/os/TaskIdProvider.h>
 #include "middleware/core/Message.h"
 #include "middleware/core/types.h"
 #include "middleware/rpc/ProxyFireAndForgetMethod.h"

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_skeleton.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_skeleton.cpp.jinja
@@ -23,12 +23,11 @@
 
 #include <middleware/logger/Logger.h>
 #include <middleware/os/TaskIdProvider.h>
-
-#include "middleware/core/LoggerApi.h"
-#include "middleware/core/Message.h"
-#include "middleware/core/MessagePayloadBuilder.h"
-#include "middleware/core/ResponseBufferBase.h"
-#include "middleware/core/types.h"
+#include <middleware/core/LoggerApi.h>
+#include <middleware/core/Message.h>
+#include <middleware/core/MessagePayloadBuilder.h>
+#include <middleware/core/ResponseBufferBase.h>
+#include <middleware/core/types.h>
 
 namespace {{ service.namespace }}::{{ service.name }}::skeleton
 {

--- a/libs/bsw/middleware/tools/cpp_generator/templates/schemas/deployment.yaml
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/schemas/deployment.yaml
@@ -310,13 +310,14 @@ definitions:
     required:
       - common
       - proxy
-      - skeleton
     properties:
       common:
         type: string
       proxy:
         type: string
       skeleton:
+        type: string
+      proxy_mock:
         type: string
 
   providers:
@@ -388,6 +389,13 @@ definitions:
       filename:
         type: string
         description: "Optional filename override for generated files"
+      generation_mode:
+        type: string
+        description: "Service interface generation mode"
+        enum:
+          - normal
+          - mock
+        default: normal
       id:
         type: integer
         description: "Unique service identifier"
@@ -447,6 +455,29 @@ definitions:
         $ref: "#/definitions/headers"
       deployment:
         $ref: "#/definitions/deployment"
+    allOf:
+      - if:
+          required:
+            - generation_mode
+          properties:
+            generation_mode:
+              const: normal
+        then:
+          properties:
+            headers:
+              required:
+                - skeleton
+      - if:
+          required:
+            - generation_mode
+          properties:
+            generation_mode:
+              const: mock
+        then:
+          properties:
+            headers:
+              required:
+                - proxy_mock
 
   connection_endpoint:
     type: object

--- a/libs/bsw/uds/test/src/uds/IntegrationTest.cpp
+++ b/libs/bsw/uds/test/src/uds/IntegrationTest.cpp
@@ -479,9 +479,7 @@ TEST_F(
     EXPECT_TRUE(_sendJobQueue.empty());
 }
 
-TEST_F(
-    UdsIntegration,
-    send_allows_existing_connection_response_if_isEnabled_return_false)
+TEST_F(UdsIntegration, send_allows_existing_connection_response_if_isEnabled_return_false)
 {
     uint8_t responseBuffer[] = {0x62U, 0x01U, 0x01U, 0x01U, 0x02U, 0x03U};
     TransportMessageWithBuffer pResponse(0x10U, 0xF1U, responseBuffer);


### PR DESCRIPTION
### Key changes

- Change ProxyAttribute and ProxyEvent class definitions from being an alias, to being a class that simply forwards work to an implementation object.
- Create mocks for Proxy classes.
- Create a different jinja template file for proxy class implementation (proxy.cpp files), that is used when the generator is called in mock mode.