### PR TITLE
Fix static init order UB in generated cluster connection code

### DIFF
--- a/libs/bsw/middleware/include/middleware/core/TransceiverContainer.h
+++ b/libs/bsw/middleware/include/middleware/core/TransceiverContainer.h
@@ -91,9 +91,9 @@ struct TransceiverContainer
     TransceiverContainer& operator=(TransceiverContainer&&)      = delete;
 
     /** Pointer to the vector holding transceiver pointers. */
-    ::etl::ivector<TransceiverBase*>* const _container{};
+    ::etl::ivector<TransceiverBase*>* _container{};
     /** The service ID associated with this container. */
-    uint16_t const _serviceId;
+    uint16_t _serviceId;
     /** The current/next available address ID for proxies. */
     uint16_t _actualAddress;
 };

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.cpp.jinja
@@ -51,7 +51,7 @@ void process{{cluster.name}}Cluster(size_t messages, const bool updateTimeouts)
         {
 {% for connection in connections if connection.source_cluster.name == cluster.name %}
             case core::ClusterId::{{connection.target_cluster.name}}: {
-                ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}->processMessage(msg);
+                ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}.processMessage(msg);
                 break;
             }
 {% endfor %}
@@ -73,22 +73,23 @@ void process{{cluster.name}}Cluster(size_t messages, const bool updateTimeouts)
 void update{{cluster.name}}ClusterTimeouts()
 {
 {% for connection in connections if connection.source_cluster.name == cluster.name and connection.has_timeouts %}
-    ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}->updateTimeouts();
+    ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}.updateTimeouts();
 {% endfor %}
 }
 
 // ***************************** {{cluster.name}} *****************************
 {% for connection in connections if connection.source_cluster.name == cluster.name %}
-::etl::typed_storage<meta::ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Meta> ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config;
-::etl::typed_storage<core::ClusterConnectionTypeSelector<meta::ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Meta>::type> ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}};
+meta::ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Meta ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config;
+core::ClusterConnectionTypeSelector<meta::ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Meta>::type ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}(ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config);
 {% endfor %}
 
 void initialize{{cluster.name}}ClusterConnection()
 {
 {% for connection in connections if connection.source_cluster.name == cluster.name %}
-    ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config.create();
-    ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}.create(
-        *ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config);
+    ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config
+        .~ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Meta();
+    ::new (&ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config)
+        meta::ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Meta{};
 {% endfor %}
 }
 

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.h.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.h.jinja
@@ -34,7 +34,7 @@ namespace middleware
 {
 
 {% for connection in connections if connection.source_cluster.name == cluster.name %}
-extern ::etl::typed_storage<core::ClusterConnectionTypeSelector<meta::ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}}Meta>::type> ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}};
+extern core::ClusterConnectionTypeSelector<meta::ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}}Meta>::type ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}};
 {% endfor %}
 
 void initialize{{cluster.name}}ClusterConnection();

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_common.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_common.cpp.jinja
@@ -75,12 +75,10 @@ class InstancesDatabase_Merged : public ::middleware::core::IInstanceDatabase
     ::etl::span<::middleware::core::IClusterConnection* const> getSkeletonConnectionsRange() const override
     {
         {% if all_skeleton_connections %}
-        // Function-local static: initialised on first call, which is always after
-        // initializeXClusterConnection() has called typed_storage::create().
-        static ::etl::array<::middleware::core::IClusterConnection* const, {{all_skeleton_connections | length}}U> connections = {
+        static constexpr ::etl::array<::middleware::core::IClusterConnection* const, {{all_skeleton_connections | length}}U> connections = {
             {
             {%- for connection in all_skeleton_connections %}
-            ::middleware::ClusterConnection{{ connection.source_cluster.name }}To{{ connection.target_cluster.name }}.operator->(){{ "," if not loop.last }}
+            &::middleware::ClusterConnection{{ connection.source_cluster.name }}To{{ connection.target_cluster.name }}{{ "," if not loop.last }}
             {%- endfor %}
             }
         };
@@ -93,10 +91,10 @@ class InstancesDatabase_Merged : public ::middleware::core::IInstanceDatabase
     ::etl::span<::middleware::core::IClusterConnection* const> getProxyConnectionsRange() const override
     {
         {% if all_proxy_connections %}
-        static ::etl::array<::middleware::core::IClusterConnection* const, {{all_proxy_connections | length}}U> connections = {
+        static constexpr ::etl::array<::middleware::core::IClusterConnection* const, {{all_proxy_connections | length}}U> connections = {
             {
             {%- for connection in all_proxy_connections %}
-            ::middleware::ClusterConnection{{ connection.source_cluster.name }}To{{ connection.target_cluster.name }}.operator->(){{ "," if not loop.last }}
+            &::middleware::ClusterConnection{{ connection.source_cluster.name }}To{{ connection.target_cluster.name }}{{ "," if not loop.last }}
             {%- endfor %}
             }
         };


### PR DESCRIPTION
Replace typed_storage<T> + create() with direct globals constructed via the single-argument constructor, and update initializeXClusterConnection() to reset only the Config object (explicit destructor + placement-new).

The original UB was calling placement-new on the Connection object which holds a reference member (_configuration), violating [basic.life]/8. The fix eliminates placement-new on the Connection entirely:

- Config and Connection are direct globals; Config is constructed first (same TU, declaration order), Connection's reference binds to it at startup.

- initializeXClusterConnection() now only reconstructs the Config (destructor + placement-new) to clear registered transceivers. The Connection's reference stays valid because Config is at the same address.

- service_common.cpp.jinja: replace function-local statics with static constexpr arrays using & (valid since vtable is always set at startup by the constructor).