### PR TITLE
Support void method responses in middleware response buffer and skeleton generator

### DIFF
--- a/libs/bsw/middleware/include/middleware/core/ResponseBuffer.h
+++ b/libs/bsw/middleware/include/middleware/core/ResponseBuffer.h
@@ -70,9 +70,7 @@ public:
      */
     template<typename T = ResponseType>
     ::etl::enable_if_t<!::etl::is_void<T>::value, HRESULT> respond(
-        SkeletonResponseInfo& response,
-        T const& result,
-        bool const handleResponseFailure = true)
+        SkeletonResponseInfo& response, T const& result, bool const handleResponseFailure = true)
     {
         auto ret = HRESULT::ResponseBufferFutureNotFound;
 

--- a/libs/bsw/middleware/include/middleware/core/ResponseBuffer.h
+++ b/libs/bsw/middleware/include/middleware/core/ResponseBuffer.h
@@ -68,9 +68,10 @@ public:
      * \param handleResponseFailure True to cancel the response on send failure
      * \return HRESULT Result code
      */
-    HRESULT respond(
+    template<typename T = ResponseType>
+    ::etl::enable_if_t<!::etl::is_void<T>::value, HRESULT> respond(
         SkeletonResponseInfo& response,
-        ResponseType const& result,
+        T const& result,
         bool const handleResponseFailure = true)
     {
         auto ret = HRESULT::ResponseBufferFutureNotFound;
@@ -83,6 +84,28 @@ public:
             {
                 ret = Base::sendResponse(msg, response, handleResponseFailure);
             }
+        }
+
+        return ret;
+    }
+
+    /**
+     * Sends a void response (header only) for a previously allocated response slot.
+     *
+     * \param response Response slot info
+     * \param handleResponseFailure True to cancel the response on send failure
+     * \return HRESULT Result code
+     */
+    template<typename T = ResponseType>
+    ::etl::enable_if_t<::etl::is_void<T>::value, HRESULT>
+    respond(SkeletonResponseInfo& response, bool const handleResponseFailure = true)
+    {
+        auto ret = HRESULT::ResponseBufferFutureNotFound;
+
+        if (Base::isResponseIteratorValid(&response))
+        {
+            Message msg = Base::generateResponseMessageHeader(response, Traits::METHOD_MEMBER_ID);
+            ret         = Base::sendResponse(msg, response, handleResponseFailure);
         }
 
         return ret;

--- a/libs/bsw/middleware/test/src/core/ResponseBufferTest.cpp
+++ b/libs/bsw/middleware/test/src/core/ResponseBufferTest.cpp
@@ -104,11 +104,6 @@ private:
     ResponseBuffer<Traits, RESPONSE_LIMIT> _responseBuffer;
 };
 
-constexpr uint16_t ResponseBufferTestSuite::RESPONSE_LIMIT;
-constexpr uint16_t ResponseBufferTestSuite::SKELETON_SERVICE_ID;
-constexpr uint16_t ResponseBufferTestSuite::SKELETON_INSTANCE_ID;
-constexpr uint8_t ResponseBufferTestSuite::TARGET_CLUSTER_ID;
-
 TEST_F(ResponseBufferTestSuite, TestCancelResponseWithValidSkeletonResponseInfo)
 {
     uint8_t const proxyAddress = 0U;
@@ -198,6 +193,101 @@ TEST_F(ResponseBufferTestSuite, TestGetAvailableResponseExhaustion)
     }
 
     EXPECT_EQ(this->doGetAvailableResponse(addressId, requestId), nullptr);
+}
+
+class ResponseBufferVoidTestSuite : public ::testing::Test
+{
+public:
+    using Traits                                   = ResponseTraits<void, 0U>;
+    static constexpr uint16_t RESPONSE_LIMIT       = 10U;
+    static constexpr uint16_t SKELETON_SERVICE_ID  = 4096U;
+    static constexpr uint16_t SKELETON_INSTANCE_ID = 1U;
+    static constexpr uint8_t TARGET_CLUSTER_ID     = 2U;
+
+    ResponseBufferVoidTestSuite() : _skeletonMock(), _responseBuffer(_skeletonMock) {}
+
+    void SetUp() final
+    {
+        ON_CALL(_skeletonMock, getServiceId).WillByDefault(::testing::Return(SKELETON_SERVICE_ID));
+        _skeletonMock.init(SKELETON_INSTANCE_ID);
+    }
+
+    HRESULT doRespond(
+        ResponseBufferBase::SkeletonResponseInfo& response, bool const handleResponseFailure = true)
+    {
+        return _responseBuffer.respond(response, handleResponseFailure);
+    }
+
+    bool doIsResponseIteratorValid(ResponseBufferBase::SkeletonResponseInfo* const iterator)
+    {
+        return _responseBuffer.isResponseIteratorValid(iterator);
+    }
+
+    ResponseBufferBase::SkeletonResponseInfo*
+    doGetAvailableResponse(uint8_t const addressId, uint16_t const requestId)
+    {
+        return _responseBuffer.getAvailableResponse(addressId, TARGET_CLUSTER_ID, requestId);
+    }
+
+    void checkMessageHeader(
+        Message const& msg, uint8_t const expectedAddressId, uint16_t const expectedRequestId)
+    {
+        EXPECT_EQ(msg.getHeader().serviceId, SKELETON_SERVICE_ID);
+        EXPECT_EQ(msg.getHeader().serviceInstanceId, SKELETON_INSTANCE_ID);
+        EXPECT_EQ(msg.getHeader().memberId, Traits::METHOD_MEMBER_ID);
+        EXPECT_EQ(msg.isResponse(), true);
+        EXPECT_EQ(msg.isEvent(), false);
+        EXPECT_EQ(msg.getPayloadSize(), 0U);
+        EXPECT_EQ(msg.hasExternalPayload(), false);
+        EXPECT_EQ(msg.getHeader().tgtClusterId, TARGET_CLUSTER_ID);
+        EXPECT_EQ(msg.getHeader().srcClusterId, _skeletonMock.getSourceClusterId());
+        EXPECT_EQ(msg.getHeader().addressId, expectedAddressId);
+        EXPECT_EQ(msg.getHeader().requestId, expectedRequestId);
+    }
+
+protected:
+    ::testing::NiceMock<SkeletonResponseMock> _skeletonMock;
+
+private:
+    ResponseBuffer<Traits, RESPONSE_LIMIT> _responseBuffer;
+};
+
+TEST_F(ResponseBufferVoidTestSuite, TestRespondWithValidVoidResponse)
+{
+    uint8_t const proxyAddress = 0U;
+    uint16_t const requestId   = 1U;
+
+    ResponseBufferBase::SkeletonResponseInfo* response
+        = this->doGetAvailableResponse(proxyAddress, requestId);
+
+    EXPECT_CALL(this->_skeletonMock, sendMessage)
+        .WillRepeatedly(
+            [this](Message& msg) -> HRESULT
+            {
+                this->checkMessageHeader(msg, 0U, 1U);
+                return HRESULT::Ok;
+            });
+    EXPECT_EQ(this->doRespond(*response), HRESULT::Ok);
+}
+
+TEST_F(ResponseBufferVoidTestSuite, TestRespondWithInvalidVoidResponse)
+{
+    ResponseBufferBase::SkeletonResponseInfo response{};
+    EXPECT_CALL(this->_skeletonMock, sendMessage).Times(0U);
+    EXPECT_EQ(this->doRespond(response), HRESULT::ResponseBufferFutureNotFound);
+}
+
+TEST_F(ResponseBufferVoidTestSuite, TestRespondWithInvalidVoidSendResponseResult)
+{
+    uint8_t const proxyAddress = 0U;
+    uint16_t const requestId   = 1U;
+
+    ResponseBufferBase::SkeletonResponseInfo* response
+        = this->doGetAvailableResponse(proxyAddress, requestId);
+
+    ON_CALL(this->_skeletonMock, sendMessage).WillByDefault(testing::Return(HRESULT::QueueFull));
+    EXPECT_EQ(this->doRespond(*response, false), HRESULT::QueueFull);
+    EXPECT_EQ(this->doIsResponseIteratorValid(response), true);
 }
 
 } // namespace middleware::core::test

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_skeleton.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_skeleton.cpp.jinja
@@ -230,11 +230,19 @@ middleware::core::HRESULT {{service.name}}Skeleton::onNewMessageReceived(middlew
 
 // METHODS
 {% for method in service.methods if service.methods %}
+{% if method.output_param %}
 middleware::core::HRESULT {{service.name}}Skeleton::respond(middleware::core::ResponseBufferBase::SkeletonResponseInfo& response,
-                                               {% if method.output_param %}const {{  method.output_param.type }}& {{  method.output_param.name }}, {% endif %}const bool handleResponseFailure)
+                                                const {{  method.output_param.type }}& {{  method.output_param.name }}, const bool handleResponseFailure)
 {
-    return f{{method.variable}}ResponseBuffer.respond(response, {{  method.output_param.name | default('0U') }}, handleResponseFailure);
+    return f{{method.variable}}ResponseBuffer.respond(response, {{ method.output_param.name }}, handleResponseFailure);
 }
+{% else %}
+middleware::core::HRESULT {{service.name}}Skeleton::respond(middleware::core::ResponseBufferBase::SkeletonResponseInfo& response,
+                                                const bool handleResponseFailure)
+{
+    return f{{method.variable}}ResponseBuffer.respond(response, handleResponseFailure);
+}
+{% endif %}
 {% endfor %}
 
 // ATTRIBUTES

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_skeleton.h.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_skeleton.h.jinja
@@ -56,7 +56,7 @@ class {{service.name}}Skeleton : public ::middleware::core::SkeletonBase
     // METHODS
     {% for method in service.methods %}
     using {{ method.variable }}Response =
-      ::middleware::core::ResponseBuffer<::middleware::core::ResponseTraits<{{ method.output_param.type | default('uint8_t') }}, internal::{{ method.variable }}_id>, {{ method.provider_request_limit }}U>;
+      ::middleware::core::ResponseBuffer<::middleware::core::ResponseTraits<{{ method.output_param.type | default('void') }}, internal::{{ method.variable }}_id>, {{ method.provider_request_limit }}U>;
     {% endfor %}
 
     {{service.name}}Skeleton();


### PR DESCRIPTION
# Overview
This PR adds support for `void` method responses in middleware response handling and updates generated skeleton code accordingly.

# What Changed
- Added a `void`-specific `respond(...)` overload in `ResponseBuffer` while keeping the existing payload-based path for non-void responses.
- Updated service skeleton templates to generate `void` response buffer types and `respond(...)` signatures without payload parameters for methods that have no output parameter.
- Added unit tests that validate `void` response behavior for success, invalid response handles, and send failure scenarios.

# Changed Files
- [ResponseBuffer implementation](libs/bsw/middleware/include/middleware/core/ResponseBuffer.h)
- [ResponseBuffer unit tests](libs/bsw/middleware/test/src/core/ResponseBufferTest.cpp)
- [Service skeleton source template](libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_skeleton.cpp.jinja)
- [Service skeleton header template](libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_skeleton.h.jinja)

# Impact
- Enables methods without output payloads to send valid header-only responses.
- Keeps generated APIs aligned with both payload and `void` method signatures.
- Improves confidence via dedicated test coverage for `void` response flows.

