### PR TITLE
Fix common depending on configuration in CMake targets

### DIFF
--- a/doc/dev/guidelines/module.rst
+++ b/doc/dev/guidelines/module.rst
@@ -157,6 +157,50 @@ Use only standard CMake commands. The typical structure is as follows:
         target_include_directories(<module>Mock PUBLIC include)
         target_link_libraries(<module>Mock PUBLIC gmock ... PRIVATE ...)
 
+.. _module_impl_pattern:
+
+The module + moduleImpl pattern
+-------------------------------
+
+Some modules only declare an interface (pure header/``INTERFACE`` CMake target) that is meant to be
+reused by many other modules, while a concrete implementation of that interface is only available,
+or only makes sense, in a more specific context (e.g. it depends on platform- or application-specific
+data). Providing that implementation from within the interface module itself would force the
+generic, widely used ``<module>`` target to depend on that specific context - inverting the intended
+dependency direction and dragging an application-specific dependency into every consumer of
+``<module>``.
+
+To avoid this, split the module into two CMake targets:
+
+- ``<module>``: the interface only (declarations, generic types, ``INTERFACE`` library). This target
+  must **never** depend on anything application- or platform-specific.
+- ``<module>Impl``: a regular (non-``INTERFACE``) library providing the actual implementation of
+  ``<module>``'s interface. Only ``<module>Impl`` may depend on whatever context-specific data or
+  libraries it needs to realize the interface (e.g. ``PRIVATE`` linking an application's
+  ``configuration`` library).
+
+  .. code-block:: cmake
+
+        add_library(<module> INTERFACE)
+        target_include_directories(<module> INTERFACE include)
+        target_link_libraries(<module> INTERFACE <module>Impl ...)
+
+        add_library(<module>Impl src/...)
+        target_link_libraries(<module>Impl PRIVATE ...)
+
+Rules of thumb:
+
+- If a module is purely header-only with no implementation-specific dependencies, a single
+  ``INTERFACE`` library named ``<module>`` is sufficient - do not introduce a ``<module>Impl`` target
+  that isn't needed.
+- Never let the generic ``<module>`` interface link back to an application- or executable-specific
+  library directly. If an implementation genuinely needs such a dependency, hide it behind
+  ``<module>Impl`` (or push the dependency down to the concrete component that calls into the
+  interface, e.g. a ``PUBLIC`` link on the library that actually invokes the function, so that only
+  its consumers - not every user of the generic interface - pull in the concrete implementation).
+- Watch out for dependency cycles: ``<module>Impl`` depending on something that (transitively)
+  depends on ``<module>`` again reintroduces the same layering problem the pattern is meant to avoid.
+
 .. _build_bazel:
 
 BUILD.bazel

--- a/executables/referenceApp/configuration/CMakeLists.txt
+++ b/executables/referenceApp/configuration/CMakeLists.txt
@@ -2,13 +2,7 @@ add_library(configuration common/src/busid/BusId.cpp)
 
 target_include_directories(configuration PUBLIC include)
 
-target_link_libraries(configuration PUBLIC commonHeaders async)
-
-target_link_libraries(configuration INTERFACE common etl)
-
-add_library(commonImpl common/src/busid/BusId.cpp)
-
-target_link_libraries(commonImpl PRIVATE configuration async)
+target_link_libraries(configuration PUBLIC common async)
 
 # python -m blob binary -i routing.jsonl -c blob.routing.table | python -m blob
 # header data -n CONFIGURATION_BLOB > include/blob/configuration.h

--- a/executables/unitTest/configuration/CMakeLists.txt
+++ b/executables/unitTest/configuration/CMakeLists.txt
@@ -2,4 +2,4 @@ add_library(configuration common/src/busid/BusId.cpp)
 
 target_include_directories(configuration PUBLIC common/include)
 
-target_link_libraries(configuration PUBLIC commonHeaders async)
+target_link_libraries(configuration PUBLIC common async)

--- a/libs/bsw/common/CMakeLists.txt
+++ b/libs/bsw/common/CMakeLists.txt
@@ -1,9 +1,5 @@
-add_library(commonHeaders INTERFACE)
-
-target_include_directories(commonHeaders INTERFACE include)
-
-target_link_libraries(commonHeaders INTERFACE etl platform)
-
 add_library(common INTERFACE)
 
-target_link_libraries(common INTERFACE commonHeaders configuration)
+target_include_directories(common INTERFACE include)
+
+target_link_libraries(common INTERFACE etl platform)

--- a/libs/bsw/transport/CMakeLists.txt
+++ b/libs/bsw/transport/CMakeLists.txt
@@ -3,7 +3,13 @@ add_library(transport src/AbstractTransportLayer.cpp src/LogicalAddress.cpp
 
 target_include_directories(transport PUBLIC include)
 
-target_link_libraries(transport PUBLIC common etl util async)
+target_link_libraries(
+    transport
+    PUBLIC common
+           etl
+           util
+           async
+           configuration)
 
 if (BUILD_EXECUTABLE STREQUAL "unitTest")
     add_library(transportMock

--- a/libs/bsw/uds/CMakeLists.txt
+++ b/libs/bsw/uds/CMakeLists.txt
@@ -53,10 +53,10 @@ target_link_libraries(
     uds
     PUBLIC async
            bsp
-           configuration
            transport
            transportConfiguration
-           udsConfiguration)
+           udsConfiguration
+           configuration)
 
 if (BUILD_EXECUTABLE STREQUAL "unitTest")
 

--- a/platforms/s32k1xx/bsp/canflex2Transceiver/CMakeLists.txt
+++ b/platforms/s32k1xx/bsp/canflex2Transceiver/CMakeLists.txt
@@ -13,9 +13,11 @@ if (BUILD_EXECUTABLE STREQUAL "unitTest")
                etl
                bspIo
                lifecycle
-               gmock)
+               gmock
+               configuration)
 else ()
     target_include_directories(canflex2Transceiver PUBLIC include)
 
-    target_link_libraries(canflex2Transceiver PUBLIC async bspFlexCan lifecycle)
+    target_link_libraries(canflex2Transceiver PUBLIC async bspFlexCan lifecycle
+                                                     configuration)
 endif ()


### PR DESCRIPTION
Fix common depending on configuration in CMake targets

"common" is a foundational, header-only interface used by dozens of
libraries, while "configuration" is executable-specific. "common"
had ended up linking "configuration" directly, inverting the
intended dependency direction and forcing every consumer of
"common" to transitively depend on an application's configuration.

- Remove the leftover duplicate "commonImpl" target from
  executables/referenceApp/configuration/CMakeLists.txt; its source
  file was already compiled into "configuration" and nothing linked
  against it.
- Restore libs/bsw/common as a pure INTERFACE library (include dirs,
  etl, platform) with no reference to "configuration".
- Have "configuration" (referenceApp and unitTest variants) link
  PUBLIC "common", the correct direction.
- common::busid::BusIdTraits::getName() is declared in "common" but
  implemented in each executable's "configuration" library.
  libs/bsw/transport and platforms/s32k1xx/bsp/canflex2Transceiver
  call it directly, so link "configuration" PUBLIC from those
  targets themselves, matching the existing precedent in
  libs/bsw/uds. Reorder link lists so "configuration" appears after
  "transport", since static libraries are resolved left to right.

Add a "module + moduleImpl" section to
doc/dev/guidelines/module.rst describing this pattern: keep the
generic interface target free of implementation-specific
dependencies, and put those in a separate impl target instead.
