### PR TITLE
Remove scratch buffers in shed

### DIFF
--- a/libs/bsw/shed/include/shed/ops_internal.h
+++ b/libs/bsw/shed/include/shed/ops_internal.h
@@ -351,6 +351,15 @@ void move_while_impl(
     ::etl::delegate<bool(size_t, size_t)> pred,
     ::etl::delegate<move_op(size_t)> csfr);
 
+template<typename TL>
+struct ordering_for;
+
+template<typename... Cmp>
+struct ordering_for<::etl::type_list<Cmp...>>
+{
+    using type = ::shed::ordering<Cmp...>;
+};
+
 template<typename R, typename... Args>
 struct SelectColumns
 {
@@ -400,19 +409,27 @@ struct SelectColumns
     template<typename Cmp, typename Table, typename Q, typename It>
     static void move_while(Table& table, Q& q, size_t const dst, It& it)
     {
-        using tr = type_list_recurse<Cmp>;
+        using tr     = type_list_recurse<Cmp>;
+        using OrdCol = typename ordering_for<Cmp>::type;
+
+        static_assert(
+            ::std::is_base_of<OrdCol, typename Table::column_data>::value,
+            "ordered operation requires the schema to declare a matching "
+            "shed::ordering<Cmp...> column, listing the comparators in the same order as the "
+            "ordered<Cmp...> operation");
 
         auto& ml  = static_cast<typename Table::state_data*>(&table.columns)->ml;
+        auto& ord = *static_cast<OrdCol*>(&table.columns);
+
         auto csfr = [&q, &table](size_t const i) -> move_op
         { return call_system_func_ret<::shed::move_op, Q, Table, size_t, Args...>(q, table, i); };
 
         auto pred = [&table](size_t const a, size_t const b) -> bool
         { return tr::less_than(table, a, b); };
 
-        auto const scratch = table.alloc_scratch();
-        auto const begin   = scratch._scratch.begin();
-        auto end           = begin;
-        auto f             = [&table, &end](size_t const i) -> bool
+        auto const begin = ord._scratch.begin();
+        auto end         = begin;
+        auto f           = [&table, &end](size_t const i) -> bool
         {
             if (tr::all_set(table, i))
             {
@@ -480,6 +497,10 @@ struct reset_row
     {
         v[idx].~T();
     }
+
+    template<typename... Cmp>
+    void operator()(::shed::ordering<Cmp...>&)
+    {}
 };
 
 struct init_row
@@ -498,6 +519,10 @@ struct init_row
 
     template<typename T>
     void operator()(::shed::internal::state_data<T>&)
+    {}
+
+    template<typename... Cmp>
+    void operator()(::shed::ordering<Cmp...>&)
     {}
 };
 

--- a/libs/bsw/shed/include/shed/table.h
+++ b/libs/bsw/shed/include/shed/table.h
@@ -12,15 +12,13 @@
 
 #include "shed/table_internal.h" // IWYU pragma: export
 
-#include <etl/error_handler.h>
-
 #include <cstddef>
 #include <cstdint>
 
 namespace shed
 {
 
-template<typename Schema, size_t stack_depth = 1U>
+template<typename Schema>
 struct table
 {
     using state_list  = typename Schema::states;
@@ -31,14 +29,9 @@ struct table
 
     static constexpr size_t memory_for(size_t const num)
     {
-        return internal::total_memory<column_data>::total(num)
-               + num * stack_depth * sizeof(internal::multi_list::idx_type)
-               + stack_depth * sizeof(::etl::span<internal::multi_list::idx_type>)
-               + internal::COLUMN_ALIGNMENT;
+        return internal::total_memory<column_data>::total(num) + internal::COLUMN_ALIGNMENT;
     }
 
-    ::etl::span<::etl::span<internal::multi_list::idx_type>> _scratch_arrays;
-    size_t pos;
     column_data columns;
     size_t n;
 
@@ -52,48 +45,13 @@ struct table
         {
             return false;
         }
-        auto const addr = reinterpret_cast<uintptr_t>(mem.data());
-        auto const pad  = (internal::COLUMN_ALIGNMENT - addr % internal::COLUMN_ALIGNMENT)
-                         % internal::COLUMN_ALIGNMENT;
-        mem.advance(pad);
-        pos = 0;
-        n   = size;
-        _scratch_arrays
-            = mem.reinterpret_as<::etl::span<internal::multi_list::idx_type>>().first(stack_depth);
-        mem.advance(stack_depth * sizeof(::etl::span<internal::multi_list::idx_type>));
-        for (auto& scratch_array : _scratch_arrays)
-        {
-            scratch_array = mem.reinterpret_as<internal::multi_list::idx_type>().first(n);
-            mem.advance(n * sizeof(internal::multi_list::idx_type));
-        }
+        n = size;
         ft_for_each(columns, internal::init_column{n, mem});
         return true;
     }
 
-    struct Scratch
-    {
-        Scratch(
-            ::etl::span<::etl::span<internal::multi_list::idx_type>> const scratch_arrays,
-            size_t& pos)
-        : _pos(pos)
-        {
-            ETL_ASSERT(
-                pos < scratch_arrays.size(), ETL_ERROR_GENERIC("shed: scratch space exhausted"));
-            _scratch = scratch_arrays[_pos];
-            ++_pos;
-        }
-
-        ~Scratch() { --_pos; }
-
-        ::etl::span<internal::multi_list::idx_type> _scratch;
-        size_t& _pos;
-    };
-
-    Scratch alloc_scratch() { return Scratch(_scratch_arrays, pos); }
-
     template<typename... Args>
-    explicit table(Args&&... args)
-    : _scratch_arrays(), pos(0), columns(state_data(), std::forward<Args>(args)...), n(0)
+    explicit table(Args&&... args) : columns(state_data(), std::forward<Args>(args)...), n(0)
     {}
 
     table(table const&)            = delete;
@@ -150,6 +108,25 @@ struct column
     }
 
     static constexpr size_t memory_for(size_t const n) { return n * sizeof(value_type); }
+};
+
+template<typename... Cmp>
+struct ordering
+{
+    using comparators = ::etl::type_list<Cmp...>;
+
+    ::etl::span<internal::multi_list::idx_type> _scratch;
+
+    void init(size_t const n, ::etl::span<uint8_t>& s)
+    {
+        _scratch = s.reinterpret_as<internal::multi_list::idx_type>().first(n);
+        s.advance(n * sizeof(internal::multi_list::idx_type));
+    }
+
+    static constexpr size_t memory_for(size_t const n)
+    {
+        return n * sizeof(internal::multi_list::idx_type);
+    }
 };
 
 } // namespace shed

--- a/libs/bsw/shed/include/shed/table_internal.h
+++ b/libs/bsw/shed/include/shed/table_internal.h
@@ -30,6 +30,9 @@ struct shared;
 template<typename T>
 struct column;
 
+template<typename... Cmp>
+struct ordering;
+
 namespace internal
 {
 static constexpr size_t COLUMN_ALIGNMENT = alignof(::std::max_align_t);

--- a/libs/bsw/shed/test/table_test.cpp
+++ b/libs/bsw/shed/test/table_test.cpp
@@ -12,7 +12,6 @@
 
 #include "shed/ops.h"
 
-#include <etl/exception.h>
 #include <etl/span.h>
 
 #include <cstring>
@@ -81,6 +80,23 @@ struct STATE_C
 struct STATE_D
 {};
 
+struct ByValue
+{
+    using value_type = ValueColumn;
+
+    bool operator()(ValueColumn const& a, ValueColumn const& b) const { return a.value < b.value; }
+};
+
+struct ByPointerColumn
+{
+    using value_type = PointerColumn;
+
+    bool operator()(PointerColumn const& a, PointerColumn const& b) const
+    {
+        return a.value < b.value;
+    }
+};
+
 struct Schema
 {
     using states  = ::shed::states<STATE_A, STATE_B, STATE_C, STATE_D>;
@@ -90,7 +106,14 @@ struct Schema
         shared<SharedConstPointer const*>,
         column<ValueColumn>,
         column<PointerColumn*>,
-        column<ConstPointerColumn const*>>;
+        column<ConstPointerColumn const*>,
+        ordering<ByValue>,
+        ordering<::shed::reverse<ByValue>>,
+        ordering<ByPointerColumn>,
+        ordering<ByValue, ByPointerColumn>,
+        ordering<ByPointerColumn, ByValue>,
+        ordering<ByPointerColumn, ::shed::reverse<ByValue>>,
+        ordering<::shed::reverse<ByPointerColumn>, ::shed::reverse<ByValue>>>;
 };
 
 using Table = table<Schema>;
@@ -146,6 +169,25 @@ TEST_F(TableTest, initialization_mem_too_small)
 {
     Table table;
     EXPECT_FALSE(table.init(mem, 50));
+}
+
+struct MinimalSchema
+{
+    using states  = ::shed::states<>;
+    using columns = ::shed::columns<>;
+};
+
+TEST(TableInitTest, initialization_size_too_large_for_index_type)
+{
+    using MinimalTable = table<MinimalSchema>;
+
+    // multi_list addresses rows and buckets with uint16_t, so (size + number of states) has to
+    // fit into that type. Memory is sufficient in both cases, only the size limit differs.
+    std::vector<uint8_t> mem(MinimalTable::memory_for(0xFFFFU));
+
+    MinimalTable table;
+    EXPECT_FALSE(table.init(mem, 0xFFFFU));
+    EXPECT_TRUE(table.init(mem, 0xFFFEU));
 }
 
 TEST_F(TableTest, initialization_with_constructor_arguments_forwarding)
@@ -564,13 +606,6 @@ TEST_F(TableTest, move)
     EXPECT_THAT(collect<Ids>(all(table)), UnorderedElementsAre(v1, v2, v3, v4, v5));
 }
 
-struct ByValue
-{
-    using value_type = ValueColumn;
-
-    bool operator()(ValueColumn const& a, ValueColumn const& b) const { return a.value < b.value; }
-};
-
 move_op neq_4(ValueColumn v) { return (v.value != 4) ? move_op::MOVE : move_op::SKIP_DONE; }
 
 move_op eq_4(ValueColumn v) { return (v.value != 4) ? move_op::SKIP : move_op::MOVE_DONE; }
@@ -612,34 +647,9 @@ TEST_F(TableTest, move_while_in_order)
 
 move_op tail(ValueColumn) { return move_op::SKIP_DONE; }
 
-TEST_F(TableTest, move_while_recursive_not_enough_scratch_space_assert)
-{
-    Table table;
-    auto const recurse = [&]()
-    {
-        ::shed::move_to<STATE_D>::from<STATE_C>::ordered<ByValue>(table, tail);
-        return move_op::MOVE;
-    };
-    ASSERT_TRUE(table.init(mem, 6));
-
-    (void)insert<STATE_A>(table, [](ValueColumn& v) { v.value = 5; });
-    (void)insert<STATE_A>(table, [](ValueColumn& v) { v.value = 1; });
-    (void)insert<STATE_A>(table, [](ValueColumn& v) { v.value = 4; });
-    (void)insert<STATE_A>(table, [](ValueColumn& v) { v.value = 3; });
-    (void)insert<STATE_A>(table, [](ValueColumn& v) { v.value = 2; });
-
-    (void)insert<STATE_C>(table, [](ValueColumn& v) { v.value = 6; });
-
-    ASSERT_THROW(
-        { ::shed::move_to<STATE_B>::from<STATE_A>::ordered<reverse<ByValue>>(table, recurse); },
-        ::etl::exception);
-}
-
 TEST_F(TableTest, move_while_in_order_recursive)
 {
-    // Provide a larger stack_depth for this particular test case
-    ::shed::table<Schema, 2> table;
-    uint8_t mem2[decltype(table)::memory_for(6)];
+    Table table;
 
     auto const recurse = [&](ValueColumn)
     {
@@ -647,7 +657,7 @@ TEST_F(TableTest, move_while_in_order_recursive)
         return move_op::MOVE;
     };
 
-    ASSERT_TRUE(table.init(mem2, 6));
+    ASSERT_TRUE(table.init(mem, 6));
 
     size_t const v5 = insert<STATE_A>(table, [](ValueColumn& v) { v.value = 5; });
     size_t const v1 = insert<STATE_A>(table, [](ValueColumn& v) { v.value = 1; });
@@ -671,16 +681,6 @@ TEST_F(TableTest, move_while_in_order_recursive)
     EXPECT_THAT(collect<Ids>(all<STATE_D>(table)), UnorderedElementsAre());
     EXPECT_THAT(collect<Ids>(all(table)), UnorderedElementsAre(v1, v2, v3, v4, v5, v6));
 }
-
-struct ByPointerColumn
-{
-    using value_type = PointerColumn;
-
-    bool operator()(PointerColumn const& a, PointerColumn const& b) const
-    {
-        return a.value < b.value;
-    }
-};
 
 TEST_F(TableTest, move_while_in_order_pointer_column)
 {


### PR DESCRIPTION
Remove scratch buffers in shed

These scratch buffers were used for ordered iteration, which had two problems:
1. The buffers were present even if no ordering was needed at all, wasting memory
2. If multiple orderings were needed and the iterations nested, the buffer
   access would conflict between the orderings

Now for each ordering we use a dedicated column to hold the data (binheap)
This also opens up future rework towards keeping a persistent heap instead
of the current on-demand make_heap.
