### PR TITLE
Fix multi_list two-bucket exclusion scan

### DIFF
--- a/libs/bsw/shed/src/multi_list.cpp
+++ b/libs/bsw/shed/src/multi_list.cpp
@@ -78,18 +78,24 @@ void multi_list::NotInBuckets::iter(::etl::delegate<bool(size_t)> const f) const
     size_t const n              = self->_n;
     idx_type const* const items = self->items();
     size_t pos[2]               = {items[n + buckets[0]], items[n + buckets[1]]};
-    size_t i                    = 0;
 
-    do
+    for (size_t i = n; i > 0;)
     {
-        ++i;
-        while (((n - i) == pos[0]) || ((n - i) == pos[1]))
+        --i;
+        bool excluded = false;
+        for (auto& bucket_pos : pos)
         {
-            ++i;
-            auto const j = ((pos[0] < pos[1]) && (pos[1] < n)) ? 1U : 0U;
-            pos[j]       = items[pos[j]];
+            if (i == bucket_pos)
+            {
+                bucket_pos = items[bucket_pos];
+                excluded   = true;
+            }
         }
-    } while ((i < n + 1) && f(n - i));
+        if (!excluded && !f(i))
+        {
+            break;
+        }
+    }
 }
 } // namespace internal
 } // namespace shed

--- a/libs/bsw/shed/test/multi_list_test.cpp
+++ b/libs/bsw/shed/test/multi_list_test.cpp
@@ -74,6 +74,19 @@ TEST(A_multi_list, can_conditionally_transfer_indices_between_buckets)
         ::shed::collect<Ids>(ms.not_in_bucket(2)), UnorderedElementsAre(0, 1, 3, 5, 6, 7, 9));
 }
 
+TEST(A_multi_list, can_iterate_when_first_excluded_bucket_is_empty_or_exhausted)
+{
+    ::etl::span<uint8_t> mem         = ::etl::span{ml_mem};
+    ::shed::internal::multi_list& ms = *::shed::internal::multi_list::make(10, 3, mem);
+
+    ms.move_if(0, 1, [](size_t) { return ::shed::move_op::MOVE; });
+    EXPECT_THAT(::shed::collect<Ids>(ms.not_in_buckets(0, 1)), IsEmpty());
+
+    ms.move_idx(0, 2);
+    ms.move_idx(9, 0);
+    EXPECT_THAT(::shed::collect<Ids>(ms.not_in_buckets(0, 1)), ElementsAre(0));
+}
+
 TEST(A_multi_list, can_iterate_items_that_are_not_in_a_bucket)
 {
     ::etl::span<uint8_t> mem         = ::etl::span{ml_mem};


### PR DESCRIPTION
Fix multi_list two-bucket exclusion scan

Advance each excluded bucket cursor independently so empty or exhausted buckets do not produce incorrect results. Add regression coverage for both states.
