### PR TITLE
Migrate BSP core platform targets

### DIFF
--- a/bazel_migration/README.md
+++ b/bazel_migration/README.md
@@ -86,7 +86,7 @@ OpenBSW Bazel migration
 │   └── (remaining) 🔲
 ├── platforms/
 │   ├── posix/ ✅ (freeRtosPosix, threadx, bspInterruptsImpl, etlImpl, lwipSysArch)
-│   └── s32k1xx/ ✅ (freertos_cm4_sysTick, threadx, bspMcu, bspInterruptsImpl, etlImpl, lwipSysArch)
+│   └── s32k1xx/ ✅ (freertos_cm4_sysTick, threadx, bspMcu, bspInterruptsImpl, etlImpl, lwipSysArch, bspCore, bspFtm, bspFtmPwm, hardFaultHandler, safeBspMcuWatchdog)
 ├── test/ Scope of Bazel support TBD
 └── tools/ Scope of Bazel support TBD
 

--- a/platforms/s32k1xx/bsp/bspCore/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspCore/BUILD.bazel
@@ -1,0 +1,21 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_core",
+    srcs = ["src/cache/cache.cpp"],
+    hdrs = ["include/cache/cache.h"],
+    implementation_deps = ["//platforms/s32k1xx/bsp/bspMcu:bsp_mcu"],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+)

--- a/platforms/s32k1xx/bsp/bspFtm/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspFtm/BUILD.bazel
@@ -1,0 +1,19 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_ftm",
+    hdrs = ["include/ftm/Ftm.h"],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+)

--- a/platforms/s32k1xx/bsp/bspFtmPwm/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspFtmPwm/BUILD.bazel
@@ -1,0 +1,26 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_ftm_pwm",
+    hdrs = [
+        "include/ftmPwm/FtmCPwm.h",
+        "include/ftmPwm/FtmCentralAlignedCombinePwm.h",
+        "include/ftmPwm/FtmCombinePwm.h",
+        "include/ftmPwm/FtmECombinePwm.h",
+        "include/ftmPwm/FtmEPwm.h",
+        "include/ftmPwm/FtmModCombinePwm.h",
+    ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+)

--- a/platforms/s32k1xx/hardFaultHandler/BUILD.bazel
+++ b/platforms/s32k1xx/hardFaultHandler/BUILD.bazel
@@ -1,0 +1,18 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "hard_fault_handler",
+    srcs = ["src/hardFaultHandler.s"],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+)

--- a/platforms/s32k1xx/safety/safeBspMcuWatchdog/BUILD.bazel
+++ b/platforms/s32k1xx/safety/safeBspMcuWatchdog/BUILD.bazel
@@ -1,0 +1,26 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "safe_bsp_mcu_watchdog",
+    srcs = ["src/watchdog/Watchdog.cpp"],
+    hdrs = ["include/watchdog/Watchdog.h"],
+    implementation_deps = [
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//libs/bsw/bsp",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+    ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = ["//libs/bsw/platform"],
+)


### PR DESCRIPTION
Migrate BSP core platform targets

Migrate bspCore, bspFtm, bspFtmPwm, hardFaultHandler, and
safeBspMcuWatchdog to Bazel.
All targets are constrained to `s32k148`
