### PR TITLE
Fix IPv4 comparison when IPv6 disabled.

### DIFF
--- a/libs/bsw/cpp2ethernet/include/ip/IPAddress.h
+++ b/libs/bsw/cpp2ethernet/include/ip/IPAddress.h
@@ -392,7 +392,7 @@ inline bool operator==(IPAddress const& ip1, IPAddress const& ip2)
         && (ip1.be_uint32_at(1) == ip2.be_uint32_at(1))
         && (ip1.be_uint32_at(0) == ip2.be_uint32_at(0)));
 #else
-    return (ip1.raw[0] == ip2.raw[0]);
+    return (ip1.be_uint32_at(0) == ip2.be_uint32_at(0));
 #endif
 }
 

--- a/libs/bsw/cpp2ethernet/test/src/ip/IPAddressTest.cpp
+++ b/libs/bsw/cpp2ethernet/test/src/ip/IPAddressTest.cpp
@@ -272,6 +272,9 @@ TEST(IPAddressTest, equality)
 
     IPAddress ip3 = make_ip4(++addr);
     EXPECT_NE(ip1, ip3);
+
+    IPAddress ip4 = make_ip4(0xABCDFF01);
+    EXPECT_NE(ip1, ip4);
 }
 
 #ifndef OPENBSW_NO_IPV6


### PR DESCRIPTION
Hello,

We had a problem at Technica related to this; IP comparison doesn't look right when IPV6 is disabled.
I think this should be the fix, please let me know if I missed something.

Thanks,
Andreu 