### PR TITLE
Fix No-IPv6 cases in tests, introduce PLATFORM_SUPPORT_IPV6

### DIFF
--- a/executables/referenceApp/platforms/posix/Options.cmake
+++ b/executables/referenceApp/platforms/posix/Options.cmake
@@ -32,6 +32,9 @@ set(PLATFORM_SUPPORT_ROM_CHECK
 set(PLATFORM_SUPPORT_ETHERNET
     ON
     CACHE BOOL "Turn ethernet support on or off" FORCE)
+set(PLATFORM_SUPPORT_IPV6
+    OFF
+    CACHE BOOL "Turn IPv6 support on or off" FORCE)
 set(PLATFORM_SUPPORT_STORAGE
     ON
     CACHE BOOL "Turn persistent storage on or off" FORCE)

--- a/executables/referenceApp/platforms/s32k148evb/Options.cmake
+++ b/executables/referenceApp/platforms/s32k148evb/Options.cmake
@@ -19,6 +19,9 @@ set(PLATFORM_SUPPORT_CAN
 set(PLATFORM_SUPPORT_ETHERNET
     ON
     CACHE BOOL "Turn ethernet support on or off" FORCE)
+set(PLATFORM_SUPPORT_IPV6
+    OFF
+    CACHE BOOL "Turn IPv6 support on or off" FORCE)
 set(PLATFORM_SUPPORT_TRANSPORT
     ON
     CACHE BOOL "Turn TRANSPORT support on or off" FORCE)

--- a/libs/bsw/cpp2ethernet/include/ip/IPAddress.h
+++ b/libs/bsw/cpp2ethernet/include/ip/IPAddress.h
@@ -369,7 +369,7 @@ isNetworkLocal(IPAddress const& ipAddr1, IPAddress const& ipAddr2, uint8_t const
     return ((ipAddr1.raw[netMaskFullBytes] & mask) == (ipAddr2.raw[netMaskFullBytes] & mask));
 }
 
-inline IPAddress::Family addressFamilyOf(IPAddress const& ipAddr)
+inline IPAddress::Family addressFamilyOf([[maybe_unused]] IPAddress const& ipAddr)
 {
 #ifdef PLATFORM_SUPPORT_IPV6
     uint32_t const IP4_PREFIX[] = {0U, 0U, 0xFFFFU};

--- a/libs/bsw/cpp2ethernet/include/ip/IPAddress.h
+++ b/libs/bsw/cpp2ethernet/include/ip/IPAddress.h
@@ -32,7 +32,7 @@ struct IPAddress
     static constexpr uint8_t IP4LENGTH = 4U;
     static constexpr uint8_t IP6LENGTH = 16U;
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
     static constexpr size_t MAX_IP_LENGTH = IP6LENGTH;
 #else
     static constexpr size_t MAX_IP_LENGTH = IP4LENGTH;
@@ -55,7 +55,7 @@ constexpr IPAddress make_ip4(uint32_t ip4addr);
 
 IPAddress make_ip4(::etl::span<uint8_t const> const& ip4addr);
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 constexpr IPAddress make_ip6(uint32_t addr0, uint32_t addr1, uint32_t addr2, uint32_t addr3);
 
 constexpr IPAddress make_ip6(uint32_t const ip6addr[IPAddress::IP6LENGTH / sizeof(uint32_t)]);
@@ -70,7 +70,7 @@ constexpr IPAddress make_ip4(uint8_t byte0, uint8_t byte1, uint8_t byte2, uint8_
 
 uint32_t ip4_to_u32(IPAddress const& ipAddr);
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 uint32_t ip6_to_u32(IPAddress const& ipAddr, size_t offset);
 #endif
 
@@ -112,7 +112,7 @@ inline constexpr IPAddress make_ip4(uint32_t const ip4addr)
 {
     // clang-format off
     return {{
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
         0x00U, 0x00U, 0x00U, 0x00U,
         0x00U, 0x00U, 0x00U, 0x00U,
         0x00U, 0x00U, 0xFFU, 0xFFU,
@@ -129,7 +129,7 @@ make_ip4(uint8_t const byte0, uint8_t const byte1, uint8_t const byte2, uint8_t 
 {
     // clang-format off
     return {{
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
         0x00U, 0x00U, 0x00U, 0x00U,
         0x00U, 0x00U, 0x00U, 0x00U,
         0x00U, 0x00U, 0xFFU, 0xFFU,
@@ -146,7 +146,7 @@ inline IPAddress make_ip4(::etl::span<uint8_t const> const& ip4addr)
 
     // clang-format off
     IPAddress const newAddr = {{
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
         0x00U, 0x00U, 0x00U, 0x00U,
         0x00U, 0x00U, 0x00U, 0x00U,
         0x00U, 0x00U, 0xFFU, 0xFFU,
@@ -158,7 +158,7 @@ inline IPAddress make_ip4(::etl::span<uint8_t const> const& ip4addr)
     return newAddr;
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 inline constexpr IPAddress
 make_ip6(uint32_t const addr0, uint32_t const addr1, uint32_t const addr2, uint32_t const addr3)
 {
@@ -239,7 +239,7 @@ inline uint32_t ip4_to_u32(IPAddress const& ipAddr)
     return ipAddr.be_uint32_at(internal::IP4_IDX);
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 inline uint32_t ip6_to_u32(IPAddress const& ipAddr, size_t const offset)
 {
     ETL_ASSERT(offset <= 3U, ETL_ERROR_GENERIC("offset must be smaller than 3"));
@@ -371,7 +371,7 @@ isNetworkLocal(IPAddress const& ipAddr1, IPAddress const& ipAddr2, uint8_t const
 
 inline IPAddress::Family addressFamilyOf(IPAddress const& ipAddr)
 {
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
     uint32_t const IP4_PREFIX[] = {0U, 0U, 0xFFFFU};
 
     bool const isIp4MappedIp6 = (IP4_PREFIX[0U] == ipAddr.be_uint32_at(0U))
@@ -386,7 +386,7 @@ inline IPAddress::Family addressFamilyOf(IPAddress const& ipAddr)
 
 inline bool operator==(IPAddress const& ip1, IPAddress const& ip2)
 {
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
     return (
         (ip1.be_uint32_at(3) == ip2.be_uint32_at(3)) && (ip1.be_uint32_at(2) == ip2.be_uint32_at(2))
         && (ip1.be_uint32_at(1) == ip2.be_uint32_at(1))

--- a/libs/bsw/cpp2ethernet/src/ip/NetworkInterfaceConfig.cpp
+++ b/libs/bsw/cpp2ethernet/src/ip/NetworkInterfaceConfig.cpp
@@ -45,7 +45,7 @@ IPAddress NetworkInterfaceConfig::ipAddress() const
     {
         return make_ip4(_config[IPADDRESS_INDEX]);
     }
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
     if (_family == IPAddress::IPV6)
     {
         return make_ip6(&_config[0U]);

--- a/libs/bsw/cpp2ethernet/src/ip/to_str.cpp
+++ b/libs/bsw/cpp2ethernet/src/ip/to_str.cpp
@@ -34,6 +34,7 @@ namespace ip
             ipAddr.raw[internal::RAW_IP4_IDX + 2U],
             ipAddr.raw[internal::RAW_IP4_IDX + 3U]);
     }
+#ifdef PLATFORM_SUPPORT_IPV6
     else if ((IPAddress::IPV6 == family) && (bufferSize >= IP6_MAX_STRING_LENGTH))
     {
         printfResult = ::std::snprintf(
@@ -57,6 +58,7 @@ namespace ip
             ipAddr.raw[14U],
             ipAddr.raw[15U]);
     }
+#endif
     else
     {
         return {};
@@ -87,6 +89,7 @@ namespace ip
             ipAddr.raw[internal::RAW_IP4_IDX + 3U],
             endp.getPort());
     }
+#ifdef PLATFORM_SUPPORT_IPV6
     else if ((IPAddress::IPV6 == family) && (bufferSize >= IP6_ENDPOINT_MAX_STRING_LENGTH))
     {
         printfResult = ::std::snprintf(
@@ -111,6 +114,7 @@ namespace ip
             ipAddr.raw[15U],
             endp.getPort());
     }
+#endif
     else
     {
         return {};

--- a/libs/bsw/cpp2ethernet/test/src/ip/IPAddressTest.cpp
+++ b/libs/bsw/cpp2ethernet/test/src/ip/IPAddressTest.cpp
@@ -15,7 +15,7 @@
 using namespace ::testing;
 using namespace ::ip;
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, defaults_to_ipv6)
 {
     IPAddress ip = {{0}};
@@ -32,7 +32,7 @@ TEST(IPAddressTest, zero_ip_address_ip4)
     EXPECT_TRUE(isUnspecified(ip));
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, zero_ip_address_ip6)
 {
     constexpr uint32_t addr[] = {0U, 0U, 0U, 0U};
@@ -82,7 +82,7 @@ TEST(IPAddressTest, factory_make_ip4_slice)
     EXPECT_THROW({ make_ip4(bytes_wrong_length); }, ::etl::exception);
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, factory_make_ip6_array)
 {
     constexpr uint32_t addr[] = {0x11223344, 0x55667788, 0x99AABBCC, 0xDDEEFF00};
@@ -96,7 +96,7 @@ TEST(IPAddressTest, factory_make_ip6_array)
 }
 #endif
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, factory_make_ip6_integers)
 {
     constexpr IPAddress ip = make_ip6(0x11223344U, 0x55667788U, 0x99AABBCCU, 0xDDEEFF00U);
@@ -109,7 +109,7 @@ TEST(IPAddressTest, factory_make_ip6_integers)
 }
 #endif
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, factory_make_ip6_slice)
 {
     // clang-format off
@@ -154,7 +154,7 @@ TEST(IPAddressTest, ip4_as_bytes)
     EXPECT_EQ(0x01, ip_bytes[3]);
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, ip6_as_bytes)
 {
     uint32_t const addr[] = {0x11223344, 0x55667788, 0x99AABBCC, 0xDDEEFF00};
@@ -195,7 +195,7 @@ TEST(IPAddressTest, ip4_packed)
     EXPECT_EQ(0x01, ip_bytes[3]);
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, ip6_packed)
 {
     uint32_t const addr[] = {0x11223344, 0x55667788, 0x99AABBCC, 0xDDEEFF00};
@@ -223,7 +223,7 @@ TEST(IPAddressTest, ip6_packed)
 }
 #endif
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, ip_address_type)
 {
     constexpr uint32_t addr4   = 0xABCDEF01;
@@ -246,7 +246,7 @@ TEST(IPAddressTest, ip4_to_u32)
     EXPECT_EQ(addr, ip4_to_u32(ip));
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, ip6_to_u32)
 {
     uint32_t const addr[] = {0x11223344, 0x55667788, 0x99AABBCC, 0xDDEEFF00};
@@ -277,7 +277,7 @@ TEST(IPAddressTest, equality)
     EXPECT_NE(ip1, ip4);
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, inequality_ip4_ip6)
 {
     uint32_t const ip6_addr[] = {0x11223344, 0x55667788, 0x99AABBCC, 0xDDEEFF00};
@@ -301,7 +301,7 @@ TEST(IPAddressTest, isMulticastAddress_ip4)
     EXPECT_TRUE(isMulticastAddress(ip2));
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, isMulticastAddress_ip6)
 {
     uint32_t const addr[] = {0x11223344, 0x55667788, 0x99AABBCC, 0xDDEEFF00};
@@ -324,7 +324,7 @@ TEST(IPAddressTest, isLinkLocalAddress_ip4)
     EXPECT_TRUE(isLinkLocalAddress(make_ip4(addr)));
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, isLinkLocalAddress_ip6)
 {
     // clang-format off
@@ -360,7 +360,7 @@ TEST(IPAddressTest, isLoopbackAddress_ip4)
     }
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, isLoopbackAddress_ip6)
 {
     IPAddress ip6        = {};
@@ -403,7 +403,7 @@ TEST(IPAddressTest, isNetworkLocal_ip4)
     EXPECT_FALSE(isNetworkLocal(ip41, ip43, 24));
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, isNetworkLocal_ip6)
 {
     IPAddress emptyIp = {};
@@ -439,7 +439,7 @@ TEST(IPAddressTest, isNetworkLocal_ip6)
 }
 #endif
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, isNetworkLocal_mixed)
 {
     IPAddress ip41 = make_ip4(0x01020304);
@@ -470,7 +470,7 @@ TEST(IPAddressDefaultCompareTest, compare_ip4)
     EXPECT_FALSE(compare(ip2, ip1));
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressDefaultCompareTest, compare_ip6)
 {
     IPAddressCompareLess const compare;
@@ -487,7 +487,7 @@ TEST(IPAddressDefaultCompareTest, compare_ip6)
 }
 #endif
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(IPAddressTest, OrderIPv4IPv6)
 {
     IPAddressCompareLess const compare;

--- a/libs/bsw/cpp2ethernet/test/src/ip/NetworkInterfaceConfigTest.cpp
+++ b/libs/bsw/cpp2ethernet/test/src/ip/NetworkInterfaceConfigTest.cpp
@@ -18,7 +18,7 @@ using namespace ip;
 
 namespace
 {
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 static uint32_t nonConstIp6Address[]   = {2348U, 234U, 232U, 345743U};
 static uint32_t const ip6Address1[]    = {0x123U, 0x1232U, 0x23839U, 0x23492U};
 static uint32_t const ip6Address2[]    = {0x12433U, 0x133232U, 0x2383439U, 0x2492342U};
@@ -81,7 +81,7 @@ cut = *&cut;
     EXPECT_EQ(make_ip4(0x33229U), assign.defaultGateway());
     EXPECT_EQ(make_ip4(0xc0afffffU), assign.broadcastAddress());
 }
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 {
     // IPv6 config
     NetworkInterfaceConfig cut(ip6Address1);
@@ -128,7 +128,7 @@ TEST(NetworkInterfaceConfigTest, Compare)
         // operator==
         EXPECT_TRUE(NetworkInterfaceConfig() == NetworkInterfaceConfig());
         EXPECT_FALSE(NetworkInterfaceConfig() == NetworkInterfaceConfig(0U, 0U, 0U));
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
         EXPECT_FALSE(NetworkInterfaceConfig() == NetworkInterfaceConfig(ip6AddressNull));
 #endif
         EXPECT_TRUE(
@@ -143,7 +143,7 @@ TEST(NetworkInterfaceConfigTest, Compare)
         EXPECT_FALSE(
             NetworkInterfaceConfig(0x2347U, 0x23748U, 0x4434U)
             == NetworkInterfaceConfig(0x2347U, 0x23748U, 0x454U));
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
         EXPECT_TRUE(
             NetworkInterfaceConfig(ip6AddressNull) == NetworkInterfaceConfig(ip6AddressNull));
         EXPECT_FALSE(NetworkInterfaceConfig(ip6AddressNull) == NetworkInterfaceConfig(ip6Address1));
@@ -155,7 +155,7 @@ TEST(NetworkInterfaceConfigTest, Compare)
         // operator!=
         EXPECT_FALSE(NetworkInterfaceConfig() != NetworkInterfaceConfig());
         EXPECT_TRUE(NetworkInterfaceConfig() != NetworkInterfaceConfig(0U, 0U, 0U));
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
         EXPECT_TRUE(NetworkInterfaceConfig() != NetworkInterfaceConfig(ip6AddressNull));
 #endif
         EXPECT_FALSE(
@@ -170,7 +170,7 @@ TEST(NetworkInterfaceConfigTest, Compare)
         EXPECT_TRUE(
             NetworkInterfaceConfig(0x2347U, 0x23748U, 0x4434U)
             != NetworkInterfaceConfig(0x2347U, 0x23748U, 0x454U));
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
         EXPECT_FALSE(
             NetworkInterfaceConfig(ip6AddressNull) != NetworkInterfaceConfig(ip6AddressNull));
         EXPECT_TRUE(NetworkInterfaceConfig(ip6AddressNull) != NetworkInterfaceConfig(ip6Address1));

--- a/libs/bsw/cpp2ethernet/test/src/ip/to_strTest.cpp
+++ b/libs/bsw/cpp2ethernet/test/src/ip/to_strTest.cpp
@@ -26,7 +26,7 @@ TEST(StringConversion, to_str_ip4)
     EXPECT_EQ(0U, to_str(ip, smallBuffer).size());
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(StringConversion, to_str_ip6)
 {
     // clang-format off
@@ -62,7 +62,7 @@ TEST(StringConversion, to_str_ip4_endpoint)
     EXPECT_EQ(0U, to_str(endpoint, smallBuffer).size());
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(StringConversion, to_str_ip6_endpoint)
 {
     // clang-format off

--- a/libs/bsw/doip/test/src/doip/server/DoIpServerVehicleIdentificationSocketHandlerTest.cpp
+++ b/libs/bsw/doip/test/src/doip/server/DoIpServerVehicleIdentificationSocketHandlerTest.cpp
@@ -204,6 +204,7 @@ TEST_F(
     testContext.expireAndExecute();
 }
 
+#ifndef OPENBSW_NO_IPV6
 TEST_F(DoIpServerVehicleIdentificationSocketHandlerTest, JoinMulticastGroupIfIPv6Configured)
 {
     EXPECT_CALL(fVehicleIdentificationCallbackMock, getVin(_))
@@ -249,6 +250,7 @@ TEST_F(DoIpServerVehicleIdentificationSocketHandlerTest, JoinMulticastGroupIfIPv
 
     testContext.expireAndExecute();
 }
+#endif
 
 TEST_F(DoIpServerVehicleIdentificationSocketHandlerTest, IgnoreUnknownNetworkConfig)
 {

--- a/libs/bsw/doip/test/src/doip/server/DoIpServerVehicleIdentificationSocketHandlerTest.cpp
+++ b/libs/bsw/doip/test/src/doip/server/DoIpServerVehicleIdentificationSocketHandlerTest.cpp
@@ -204,7 +204,7 @@ TEST_F(
     testContext.expireAndExecute();
 }
 
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST_F(DoIpServerVehicleIdentificationSocketHandlerTest, JoinMulticastGroupIfIPv6Configured)
 {
     EXPECT_CALL(fVehicleIdentificationCallbackMock, getVin(_))

--- a/libs/bsw/routing/src/routing/PduTransportConfig.cpp
+++ b/libs/bsw/routing/src/routing/PduTransportConfig.cpp
@@ -62,7 +62,7 @@ bool load(::etl::span<uint8_t const> mem, PduTransportConfig& config)
     }
     auto const ipVersion = static_cast<::ip::IPAddress::Family>(ipVersionValue);
     bool const isIpV4    = ipVersion == ::ip::IPAddress::Family::IPV4;
-#ifdef OPENBSW_NO_IPV6
+#ifndef PLATFORM_SUPPORT_IPV6
     if (!isIpV4 || (mem.size() < ::ip::IPAddress::IP4LENGTH))
     {
         return false;

--- a/libs/bsw/routing/src/routing/PduTransportConfig.cpp
+++ b/libs/bsw/routing/src/routing/PduTransportConfig.cpp
@@ -62,7 +62,7 @@ bool load(::etl::span<uint8_t const> mem, PduTransportConfig& config)
     }
     auto const ipVersion = static_cast<::ip::IPAddress::Family>(ipVersionValue);
     bool const isIpV4    = ipVersion == ::ip::IPAddress::Family::IPV4;
-#ifdef ESR_NO_IPV6
+#ifdef OPENBSW_NO_IPV6
     if (!isIpV4 || (mem.size() < ::ip::IPAddress::IP4LENGTH))
     {
         return false;

--- a/libs/bsw/routing/test/src/routing/PduTransportConfigTest.cpp
+++ b/libs/bsw/routing/test/src/routing/PduTransportConfigTest.cpp
@@ -78,6 +78,7 @@ TEST(PduTransportConfigTest, pdu_transport_config)
 /**
  * \desc: Loading PDU transport config with address family IPv6 gives the correct values.
  */
+#ifndef OPENBSW_NO_IPV6
 TEST(PduTransportConfigTest, ipv6_pdu_transport_config)
 {
     constexpr ip::IPAddress IP_ADDRESS               = ip::make_ip6(0x0, 0x0, 0x0, 0xEFC0FFFD);
@@ -112,6 +113,7 @@ TEST(PduTransportConfigTest, ipv6_pdu_transport_config)
     EXPECT_EQ(TRANSMISSION_TIMEOUT, pduTransportConfig.transmissionTimeout);
     EXPECT_THAT(pduTransportConfig.remoteIpAddresses, ElementsAreArray(REMOTE_IP_ADDRESSES));
 }
+#endif
 
 /**
  * \desc: Loading from a corrupted config returns a default-constructed config.

--- a/libs/bsw/routing/test/src/routing/PduTransportConfigTest.cpp
+++ b/libs/bsw/routing/test/src/routing/PduTransportConfigTest.cpp
@@ -78,7 +78,7 @@ TEST(PduTransportConfigTest, pdu_transport_config)
 /**
  * \desc: Loading PDU transport config with address family IPv6 gives the correct values.
  */
-#ifndef OPENBSW_NO_IPV6
+#ifdef PLATFORM_SUPPORT_IPV6
 TEST(PduTransportConfigTest, ipv6_pdu_transport_config)
 {
     constexpr ip::IPAddress IP_ADDRESS               = ip::make_ip6(0x0, 0x0, 0x0, 0xEFC0FFFD);


### PR DESCRIPTION
When activating OPENBSW_NO_IPV6, some tests are failing. Adding respective guards to compile and run respective tests selectively. Also, replace ESR_NO_IPV6 with OPENBSW_NO_IPV6 to make the flag consistent.

Further, replace OPENBSW_NO_IPV6 (positive logic) with PLATFORM_SUPPORT_IPV6 (positive logic), default: off.