### PR TITLE
Migrate posix bsp drivers to Bazel

### DIFF
--- a/bazel_migration/README.md
+++ b/bazel_migration/README.md
@@ -85,7 +85,7 @@ OpenBSW Bazel migration
 │   │   ├── util ✅
 │   └── (remaining) 🔲
 ├── platforms/
-│   ├── posix/ ✅ (freeRtosPosix, threadx, bspInterruptsImpl, etlImpl, lwipSysArch)
+│   ├── posix/ ✅ (freeRtosPosix, threadx, bspInterruptsImpl, bspMcu, bspSystemTime, socketCanTransceiver, tapEthernetDriver, etlImpl, lwipSysArch)
 │   └── s32k1xx/ ✅ (freertos_cm4_sysTick, threadx, bspMcu, bspInterruptsImpl, etlImpl, lwipSysArch, bspCore, bspFtm, bspFtmPwm, hardFaultHandler, safeBspMcuWatchdog)
 ├── test/ Scope of Bazel support TBD
 └── tools/ Scope of Bazel support TBD

--- a/platforms/posix/bsp/bspMcu/BUILD.bazel
+++ b/platforms/posix/bsp/bspMcu/BUILD.bazel
@@ -1,0 +1,23 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_mcu",
+    srcs = ["src/reset/softwareSystemReset.cpp"],
+    hdrs = [
+        "include/mcu/mcu.h",
+        "include/reset/softwareSystemReset.h",
+    ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+)

--- a/platforms/posix/bsp/bspSystemTime/BUILD.bazel
+++ b/platforms/posix/bsp/bspSystemTime/BUILD.bazel
@@ -1,0 +1,23 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_system_time",
+    srcs = ["src/bsp/time/systemTimer.cpp"],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/bsw/asyncFreeRtos:async_core_configuration",
+        "//libs/bsw/bsp",
+        "//libs/bsw/platform",
+    ],
+)

--- a/platforms/posix/bsp/socketCanTransceiver/BUILD.bazel
+++ b/platforms/posix/bsp/socketCanTransceiver/BUILD.bazel
@@ -1,0 +1,24 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "socket_can_transceiver",
+    srcs = ["src/can/SocketCanTransceiver.cpp"],
+    hdrs = ["include/can/SocketCanTransceiver.h"],
+    strip_include_prefix = "include",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/bsw/cpp2can",
+        "//libs/bsw/io",
+    ],
+)

--- a/platforms/posix/bsp/tapEthernetDriver/BUILD.bazel
+++ b/platforms/posix/bsp/tapEthernetDriver/BUILD.bazel
@@ -1,0 +1,25 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "tap_ethernet_driver",
+    srcs = ["src/TapEthernetDriver.cpp"],
+    hdrs = ["include/TapEthernetDriver.h"],
+    strip_include_prefix = "include",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/bsw/async",
+        "//libs/bsw/lwipSocket:lwip_socket",
+        "//libs/bsw/util",
+    ],
+)


### PR DESCRIPTION
**Migrate posix bsp drivers to Bazel**

Add BUILD.bazel for Cmake targets:

- bspMcu
- socketCanTransceiver
- tapEthernetDriver,
- bspSystemTime

All targets are STATIC cc_library rules with target_compatible_with = linux, mirroring the existing POSIX platform target convention.
