### PR TITLE
Add Bazel build support for platforms and libs/bsp

### DIFF
--- a/doc/dev/guidelines/formatting/bazel.rst
+++ b/doc/dev/guidelines/formatting/bazel.rst
@@ -18,15 +18,7 @@ We use `buildifier <https://github.com/bazelbuild/buildtools/tree/main/buildifie
 Usage
 -----
 
-Formatting a file:
-
-.. code-block:: bash
-
-    bazel run //:format_check //module_path/BUILD.bazel
-
-    bazel run //:format_fix //module_path/BUILD.bazel
-
-Formatting all the files at once:
+Formatting bazel files globally:
 
 .. code-block:: bash
 

--- a/executables/referenceApp/platforms/posix/bspConfiguration/BUILD.bazel
+++ b/executables/referenceApp/platforms/posix/bspConfiguration/BUILD.bazel
@@ -1,0 +1,21 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_configuration_headers",
+    hdrs = [
+        "include/bsp/EepromConfiguration.h",
+        "include/bsp/uart/UartConfig.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)

--- a/executables/referenceApp/platforms/s32k148evb/bspConfiguration/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/bspConfiguration/BUILD.bazel
@@ -1,0 +1,46 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_configuration_headers",
+    hdrs = glob([
+        "include/bsp/**/*.h",
+        "include/bsp/**/*.hpp",
+    ]),
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "bsp_configuration",
+    srcs = [
+        "src/bsp/SystemTimer/SystemTimer.cpp",
+        "src/bsp/adc/AnalogInput.cpp",
+        "src/bsp/io/outputPwm/PwmSupport.cpp",
+        "src/bsp/stdIo/stdIo.cpp",
+        "src/bsp/uart/UartConfig.cpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bsp_configuration_headers",
+        "//libs/bsp/bspCharInputOutput:bsp_char_input_output",
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//libs/bsp/bspOutputPwm:bsp_output_pwm",
+        "//platforms/s32k1xx/bsp/bspAdc:bsp_adc",
+        "//platforms/s32k1xx/bsp/bspEepromDriver:bsp_eeprom_driver",
+        "//platforms/s32k1xx/bsp/bspEthernet:bsp_ethernet",
+        "//platforms/s32k1xx/bsp/bspFtm:bsp_ftm",
+        "//platforms/s32k1xx/bsp/bspFtmPwm:bsp_ftm_pwm",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+        "//platforms/s32k1xx/bsp/bspUart:bsp_uart",
+    ],
+)

--- a/libs/bsp/bspCharInputOutput/BUILD.bazel
+++ b/libs/bsp/bspCharInputOutput/BUILD.bazel
@@ -1,0 +1,71 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_char_input_output",
+    srcs = [
+        "src/charInputOutput/bspIo.cpp",
+        "src/charInputOutput/charIo.cpp",
+        "src/charInputOutput/charIoSerial.cpp",
+    ],
+    hdrs = [
+        "include/charInputOutput/CharIOSerialCfg.h",
+        "include/charInputOutput/bspIoStd.h",
+        "include/charInputOutput/charIo.h",
+        "include/charInputOutput/charIoSerial.h",
+        "include/charInputOutput/printfPragma.hpp",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bsp_configuration",
+        ":bsp_uart",
+        "//libs/3rdparty/printf",
+        "//libs/bsw/bsp",
+    ],
+)
+
+alias(
+    name = "bsp_configuration_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints/soc:s32k148": "//executables/referenceApp/platforms/s32k148evb/bspConfiguration:bsp_configuration_headers",
+            "@platforms//os:linux": "//executables/referenceApp/platforms/posix/bspConfiguration:bsp_configuration_headers",
+        },
+        no_match_error = "No bsp_configuration for this platform. Override --//<path>:bsp_configuration with your own implementation.",
+    ),
+    visibility = ["//visibility:public"],
+)
+
+label_flag(
+    name = "bsp_configuration",
+    build_setting_default = ":bsp_configuration_default",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "bsp_uart_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints/soc:s32k148": "//platforms/s32k1xx/bsp/bspUart:bsp_uart",
+            "@platforms//os:linux": "//platforms/posix/bsp/bspUart:bsp_uart",
+        },
+        no_match_error = "No bsp_uart for this platform. Override --//<path>:bsp_uart with your own implementation.",
+    ),
+    visibility = ["//visibility:public"],
+)
+
+label_flag(
+    name = "bsp_uart",
+    build_setting_default = ":bsp_uart_default",
+    visibility = ["//visibility:public"],
+)

--- a/libs/bsp/bspDynamicClient/BUILD.bazel
+++ b/libs/bsp/bspDynamicClient/BUILD.bazel
@@ -1,0 +1,22 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_dynamic_client",
+    hdrs = ["include/io/DynamicClientCfg.h"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/bsw/bsp",
+        "//libs/bsw/platform",
+    ],
+)

--- a/libs/bsp/bspOutputManager/BUILD.bazel
+++ b/libs/bsp/bspOutputManager/BUILD.bazel
@@ -1,0 +1,51 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_output_manager",
+    srcs = [
+        "src/outputManager/Output.cpp",
+        "src/outputManager/OutputTester.cpp",
+    ],
+    hdrs = [
+        "include/outputManager/Output.h",
+        "include/outputManager/OutputTester.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bsp_configuration",
+        "//libs/3rdparty/etl",
+        "//libs/bsp/bspDynamicClient:bsp_dynamic_client",
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//libs/bsw/util",
+        "//platforms/s32k1xx/bsp/bspIo:bsp_io",
+    ],
+)
+
+alias(
+    name = "bsp_configuration_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints/soc:s32k148": "//executables/referenceApp/platforms/s32k148evb/bspConfiguration:bsp_configuration_headers",
+            "@platforms//os:linux": "//executables/referenceApp/platforms/posix/bspConfiguration:bsp_configuration_headers",
+        },
+        no_match_error = "No bsp_configuration for this platform. Override --//<path>:bsp_configuration with your own implementation.",
+    ),
+    visibility = ["//visibility:public"],
+)
+
+label_flag(
+    name = "bsp_configuration",
+    build_setting_default = ":bsp_configuration_default",
+    visibility = ["//visibility:public"],
+)

--- a/libs/bsp/bspOutputPwm/BUILD.bazel
+++ b/libs/bsp/bspOutputPwm/BUILD.bazel
@@ -1,0 +1,32 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_output_pwm",
+    srcs = [
+        "src/outputPwm/OutputPwm.cpp",
+        "src/outputPwm/OutputPwmTester.cpp",
+    ],
+    hdrs = [
+        "include/outputPwm/OutputPwm.h",
+        "include/outputPwm/OutputPwmTester.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/etl",
+        "//libs/bsp/bspDynamicClient:bsp_dynamic_client",
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//libs/bsw/util",
+        "//platforms/s32k1xx/bsp/bspIo:bsp_io",
+    ],
+)

--- a/platforms/posix/bsp/bspUart/BUILD.bazel
+++ b/platforms/posix/bsp/bspUart/BUILD.bazel
@@ -1,0 +1,47 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_uart",
+    srcs = [
+        "src/bsp/Uart.cpp",
+    ],
+    hdrs = [
+        "include/bsp/Uart.h",
+    ],
+    implementation_deps = [
+        ":bsp_configuration",
+        "//libs/bsw/bsp",
+        "//libs/bsw/platform",
+    ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "bsp_configuration_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints/soc:s32k148": "//executables/referenceApp/platforms/s32k148evb/bspConfiguration:bsp_configuration_headers",
+            "@platforms//os:linux": "//executables/referenceApp/platforms/posix/bspConfiguration:bsp_configuration_headers",
+        },
+        no_match_error = "No bsp_configuration for this platform. Override --//<path>:bsp_configuration with your own implementation.",
+    ),
+    visibility = ["//visibility:public"],
+)
+
+label_flag(
+    name = "bsp_configuration",
+    build_setting_default = ":bsp_configuration_default",
+    visibility = ["//visibility:public"],
+)

--- a/platforms/s32k1xx/bsp/bspAdc/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspAdc/BUILD.bazel
@@ -1,0 +1,57 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_adc",
+    srcs = ["src/tester/AnalogTester.cpp"],
+    hdrs = [
+        "include/adc/Adc.h",
+        "include/adc/AnalogInputScaleImplementation.h",
+        "include/adc/AnalogInputScaleImplementation.hpp",
+        "include/adc/adcPhysicalName.h",
+        "include/adc/adcResolution.h",
+        "include/adc/adcScale.h",
+        "include/tester/AnalogTester.h",
+    ],
+    implementation_deps = [
+        ":bsp_configuration",
+        "//libs/bsw/util",
+    ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        # NOTE: bsp:bsp and bspMcu:bsp_mcu are not present in CMake's
+        # target_link_libraries(bspAdc ...) list, but Adc.h transitively includes
+        # bsp/Bsp.h and mcu/mcu.h.
+        "//libs/bsw/bsp",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+    ],
+)
+
+alias(
+    name = "bsp_configuration_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints/soc:s32k148": "//executables/referenceApp/platforms/s32k148evb/bspConfiguration:bsp_configuration_headers",
+            "@platforms//os:linux": "//executables/referenceApp/platforms/posix/bspConfiguration:bsp_configuration_headers",
+        },
+        no_match_error = "No bsp_configuration for this platform. Override --//<path>:bsp_configuration with your own implementation.",
+    ),
+    visibility = ["//visibility:public"],
+)
+
+label_flag(
+    name = "bsp_configuration",
+    build_setting_default = ":bsp_configuration_default",
+    visibility = ["//visibility:public"],
+)

--- a/platforms/s32k1xx/bsp/bspEepromDriver/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspEepromDriver/BUILD.bazel
@@ -1,0 +1,28 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_eeprom_driver",
+    srcs = ["src/eeprom/EepromDriver.cpp"],
+    hdrs = ["include/eeprom/EepromDriver.h"],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/etl",
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//libs/bsw/bsp",
+        "//libs/bsw/util",
+        "//platforms/s32k1xx/bsp/bspCore:bsp_core",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+    ],
+)

--- a/platforms/s32k1xx/bsp/bspEthernet/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspEthernet/BUILD.bazel
@@ -1,0 +1,39 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_ethernet",
+    srcs = [
+        "src/ethernet/EnetDriver.cpp",
+        "src/ethernet/RxBuffers.cpp",
+        "src/ethernet/TxBuffers.cpp",
+    ],
+    hdrs = [
+        "include/ethernet/EnetDevice.h",
+        "include/ethernet/EnetDriver.h",
+        "include/ethernet/RawEthernet.h",
+        "include/ethernet/RxBuffers.h",
+        "include/ethernet/TxBuffers.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/lwip:lwip_core",
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//libs/bsw/bsp",
+        "//libs/bsw/cpp2ethernet",
+        "//libs/bsw/lwipSocket:lwip_socket",
+        "//libs/bsw/util",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+        "//platforms/s32k1xx/bsp/bspTja1101:bsp_tja1101",
+    ],
+)

--- a/platforms/s32k1xx/bsp/bspIo/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspIo/BUILD.bazel
@@ -1,0 +1,48 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_io",
+    srcs = ["src/io/Io.cpp"],
+    hdrs = [
+        "include/io/Io.h",
+        "include/io/ioPorts.h",
+    ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bsp_configuration",
+        "//libs/3rdparty/etl",
+        "//libs/bsw/bsp",
+        "//libs/bsw/platform",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+    ],
+)
+
+alias(
+    name = "bsp_configuration_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints/soc:s32k148": "//executables/referenceApp/platforms/s32k148evb/bspConfiguration:bsp_configuration_headers",
+            "@platforms//os:linux": "//executables/referenceApp/platforms/posix/bspConfiguration:bsp_configuration_headers",
+        },
+        no_match_error = "No bsp_configuration for this platform. Override --//<path>:bsp_configuration with your own implementation.",
+    ),
+    visibility = ["//visibility:public"],
+)
+
+label_flag(
+    name = "bsp_configuration",
+    build_setting_default = ":bsp_configuration_default",
+    visibility = ["//visibility:public"],
+)

--- a/platforms/s32k1xx/bsp/bspTja1101/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspTja1101/BUILD.bazel
@@ -1,0 +1,52 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_tja1101",
+    srcs = [
+        "src/mdio/MdioTja1101.cpp",
+        "src/phy/Tja1101.cpp",
+        "src/phy/Tja1101Tester.cpp",
+    ],
+    hdrs = [
+        "include/mdio/MdioTja1101.h",
+        "include/phy/Tja1101.h",
+        "include/phy/Tja1101Tester.h",
+    ],
+    implementation_deps = ["//libs/bsw/cpp2ethernet"],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bsp_configuration",
+        "//libs/bsp/bspOutputManager:bsp_output_manager",
+        "//platforms/s32k1xx/bsp/bspIo:bsp_io",
+    ],
+)
+
+alias(
+    name = "bsp_configuration_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints/soc:s32k148": "//executables/referenceApp/platforms/s32k148evb/bspConfiguration:bsp_configuration_headers",
+            "@platforms//os:linux": "//executables/referenceApp/platforms/posix/bspConfiguration:bsp_configuration_headers",
+        },
+        no_match_error = "No bsp_configuration for this platform. Override --//<path>:bsp_configuration with your own implementation.",
+    ),
+    visibility = ["//visibility:public"],
+)
+
+label_flag(
+    name = "bsp_configuration",
+    build_setting_default = ":bsp_configuration_default",
+    visibility = ["//visibility:public"],
+)

--- a/platforms/s32k1xx/bsp/bspUart/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspUart/BUILD.bazel
@@ -1,0 +1,48 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_uart",
+    srcs = ["src/Uart.cpp"],
+    hdrs = [
+        "include/bsp/Uart.h",
+        "include/bsp/UartPrivate.h",
+    ],
+    implementation_deps = [":bsp_configuration"],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/etl",
+        "//libs/bsw/bsp",
+        "//platforms/s32k1xx/bsp/bspIo:bsp_io",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+    ],
+)
+
+alias(
+    name = "bsp_configuration_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints/soc:s32k148": "//executables/referenceApp/platforms/s32k148evb/bspConfiguration:bsp_configuration_headers",
+            "@platforms//os:linux": "//executables/referenceApp/platforms/posix/bspConfiguration:bsp_configuration_headers",
+        },
+        no_match_error = "No bsp_configuration for this platform. Override --//<path>:bsp_configuration with your own implementation.",
+    ),
+    visibility = ["//visibility:public"],
+)
+
+label_flag(
+    name = "bsp_configuration",
+    build_setting_default = ":bsp_configuration_default",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Add Bazel build support for platforms and libs/bsp

//platforms/posix/bspConfiguration:bsp_configuration_headers
//platforms/s32k148evb/bspConfiguration:bsp_configuration
//libs/bsp/bspCharInputOutput:bsp_char_input_output
//libs/bsp/bspDynamicClient:bsp_dynamic_client
//libs/bsp/bspOutputManager:bsp_output_manager
//libs/bsp/bspOutputPwm:bsp_output_pwm
//platforms/posix/bsp/bspUart:bsp_uart
//platforms/s32k1xx/bsp/bspAdc:bsp_adc
//platforms/s32k1xx/bsp/bspEepromDriver:bsp_eeprom_driver
//platforms/s32k1xx/bsp/bspEthernet:bsp_ethernet
//platforms/s32k1xx/bsp/bspIo:bsp_io
//platforms/s32k1xx/bsp/bspTja1101:bsp_tja1101
//platforms/s32k1xx/bsp/bspUart:bsp_uart
