### PR TITLE
Migrate remaining BSP targets and socBsp aggregators

### DIFF
--- a/bazel/config/bsp/BUILD.bazel
+++ b/bazel/config/bsp/BUILD.bazel
@@ -1,0 +1,32 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# BSP configuration contract: the board-specific bspConfiguration headers the
+# generic BSP drivers compile against. Shared seam for all BSP driver targets so
+# the whole board configuration is selected/overridden in one place.
+#   Default:  select based on the target platform (s32k148 / posix)
+#   Override: --//bazel/config/bsp:bsp_configuration=//path/to:your_bsp_configuration
+alias(
+    name = "bsp_configuration_default",
+    actual = select(
+        {
+            "//bazel/platform/constraints/soc:s32k148": "//executables/referenceApp/platforms/s32k148evb/bspConfiguration:bsp_configuration_headers",
+            "@platforms//os:linux": "//executables/referenceApp/platforms/posix/bspConfiguration:bsp_configuration_headers",
+        },
+        no_match_error = "No bsp_configuration for this platform. Override --//bazel/config/bsp:bsp_configuration with your own implementation.",
+    ),
+    visibility = ["//visibility:public"],
+)
+
+label_flag(
+    name = "bsp_configuration",
+    build_setting_default = ":bsp_configuration_default",
+    visibility = ["//visibility:public"],
+)

--- a/bazel_migration/README.md
+++ b/bazel_migration/README.md
@@ -57,7 +57,8 @@ OpenBSW Bazel migration
 │   │   └── printf ✅
 │   │   └── threadx ✅
 │   ├── bsp/
-│   │   └── bspInterrupts ✅
+│   │   ├── bspInterrupts ✅
+│   │   └── bspInputManager ✅
 │   ├── bsw/
 │   │   ├── async ✅
 │   │   ├── asyncConsole ✅
@@ -85,8 +86,8 @@ OpenBSW Bazel migration
 │   │   ├── util ✅
 │   └── (remaining) 🔲
 ├── platforms/
-│   ├── posix/ ✅ (freeRtosPosix, threadx, bspInterruptsImpl, bspMcu, bspSystemTime, socketCanTransceiver, tapEthernetDriver, etlImpl, lwipSysArch)
-│   └── s32k1xx/ ✅ (freertos_cm4_sysTick, threadx, bspMcu, bspInterruptsImpl, etlImpl, lwipSysArch, bspCore, bspFtm, bspFtmPwm, hardFaultHandler, safeBspMcuWatchdog)
+│   ├── posix/ ✅ (freeRtosPosix, threadx, bspInterruptsImpl, bspMcu, bspSystemTime, socketCanTransceiver, tapEthernetDriver, etlImpl, lwipSysArch, bspEepromDriver, bspStdio, soc_bsp)
+│   └── s32k1xx/ ✅ (freertos_cm4_sysTick, threadx, bspMcu, bspInterruptsImpl, etlImpl, lwipSysArch, bspCore, bspFtm, bspFtmPwm, hardFaultHandler, safeBspMcuWatchdog, bspClock, bspFlexCan, canflex2Transceiver, soc_bsp)
 ├── test/ Scope of Bazel support TBD
 └── tools/ Scope of Bazel support TBD
 
@@ -117,6 +118,7 @@ Implemented config points:
 | [`etl_profile`](../libs/3rdparty/etl/BUILD.bazel) | Injects the ETL profile header. Vendored default is `:no_profile`; OpenBSW's own build overrides it in [`.bazelrc`](../.bazelrc) to [`//bazel/config/etl:etl_profile`](../bazel/config/etl/BUILD.bazel), an `executable_config` select (mirrors CMake `BUILD_EXECUTABLE`). Downstream integrators inherit `:no_profile` and must inject their own. | `--//libs/3rdparty/etl:etl_profile` | `label_flag` | any `cc_library` label | vendored: `:no_profile`. OpenBSW build (via `.bazelrc`): `//executables/referenceApp/etl_profile` (`reference_app`) / `//executables/unitTest/etl_profile` (`unit_test`) |
 | [`etl_impl`](../libs/bsw/loggerIntegration/BUILD.bazel) | Injects custom ETL implementation for loggerIntegration; otherwise selects based on platform | `--//libs/bsw/loggerIntegration:etl_impl` | `label_flag` | any `cc_library` label | `//platforms/s32k1xx/etlImpl:etl_impl` (s32k148), `//platforms/posix/etlImpl:etl_impl` (posix) |
 | [`lwip_configuration`](../libs/3rdparty/lwip/BUILD.bazel) | Injects custom lwIP configuration (lwipopts.h + sys_arch port); otherwise uses referenceApp default | `--//libs/3rdparty/lwip:lwip_configuration` | `label_flag` | any `cc_library` label | `//executables/referenceApp/lwipConfiguration:lwip_configuration` |
+| [`bsp_configuration`](../bazel/config/bsp/BUILD.bazel) | Injects the board-specific bspConfiguration headers the BSP drivers compile against; otherwise selects based on platform | `--//bazel/config/bsp:bsp_configuration` | `label_flag` | any `cc_library` label | `//executables/referenceApp/platforms/s32k148evb/bspConfiguration:bsp_configuration_headers` (s32k148), `//executables/referenceApp/platforms/posix/bspConfiguration:bsp_configuration_headers` (posix) |
 
 Examples:
 ```bash

--- a/libs/bsp/bspInputManager/BUILD.bazel
+++ b/libs/bsp/bspInputManager/BUILD.bazel
@@ -1,0 +1,38 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_input_manager",
+    srcs = [
+        "src/inputManager/AlternativeDigitalInput.cpp",
+        "src/inputManager/DigitalInput.cpp",
+        "src/inputManager/DigitalInputTester.cpp",
+    ],
+    hdrs = [
+        "include/inputManager/AlternativeDigitalInput.h",
+        "include/inputManager/DigitalInput.h",
+        "include/inputManager/DigitalInputTester.h",
+    ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//bazel/config/bsp:bsp_configuration",
+        "//libs/3rdparty/etl",
+        "//libs/bsp/bspDynamicClient:bsp_dynamic_client",
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//libs/bsw/bsp",
+        "//libs/bsw/platform",
+        "//libs/bsw/util",
+        "//platforms/s32k1xx/bsp/bspIo:bsp_io",
+    ],
+)

--- a/platforms/posix/bsp/BUILD.bazel
+++ b/platforms/posix/bsp/BUILD.bazel
@@ -1,0 +1,23 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "soc_bsp",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//platforms/posix/bsp/bspInterruptsImpl:bsp_interrupts_impl",
+        "//platforms/posix/bsp/bspMcu:bsp_mcu",
+        "//platforms/posix/bsp/bspStdio:bsp_stdio",
+        "//platforms/posix/bsp/bspSystemTime:bsp_system_time",
+    ],
+)

--- a/platforms/posix/bsp/bspEepromDriver/BUILD.bazel
+++ b/platforms/posix/bsp/bspEepromDriver/BUILD.bazel
@@ -1,0 +1,28 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_eeprom_driver",
+    srcs = [
+        "src/eeprom/EepromDriver.cpp",
+    ],
+    hdrs = [
+        "include/eeprom/EepromDriver.h",
+    ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//bazel/config/bsp:bsp_configuration",
+        "//libs/bsw/bsp",
+    ],
+)

--- a/platforms/posix/bsp/bspStdio/BUILD.bazel
+++ b/platforms/posix/bsp/bspStdio/BUILD.bazel
@@ -1,0 +1,26 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_stdio",
+    srcs = [
+        "src/bsp/stdIo/stdIo.cpp",
+    ],
+    implementation_deps = [
+        "//bazel/config/bsp:bsp_configuration",
+        "//libs/bsw/bsp",
+        "//libs/bsw/platform",
+        "//platforms/posix/bsp/bspUart:bsp_uart",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+)

--- a/platforms/s32k1xx/bsp/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/BUILD.bazel
@@ -1,0 +1,28 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "soc_bsp",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//platforms/s32k1xx/bsp/bspAdc:bsp_adc",
+        "//platforms/s32k1xx/bsp/bspClock:bsp_clock",
+        "//platforms/s32k1xx/bsp/bspCore:bsp_core",
+        "//platforms/s32k1xx/bsp/bspEepromDriver:bsp_eeprom_driver",
+        "//platforms/s32k1xx/bsp/bspInterruptsImpl:bsp_interrupts_impl",
+        "//platforms/s32k1xx/bsp/bspIo:bsp_io",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+        "//platforms/s32k1xx/bsp/bspUart:bsp_uart",
+        "//platforms/s32k1xx/safety/safeBspMcuWatchdog:safe_bsp_mcu_watchdog",
+    ],
+)

--- a/platforms/s32k1xx/bsp/bspClock/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspClock/BUILD.bazel
@@ -1,0 +1,24 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_clock",
+    srcs = ["src/clockConfig.cpp"],
+    hdrs = ["include/clock/clockConfig.h"],
+    implementation_deps = [
+        "//bazel/config/bsp:bsp_configuration",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+    ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+)

--- a/platforms/s32k1xx/bsp/bspFlexCan/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspFlexCan/BUILD.bazel
@@ -1,0 +1,32 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "bsp_flex_can",
+    srcs = ["src/can/FlexCANDevice.cpp"],
+    hdrs = [
+        "include/can/CANDevice.h",
+        "include/can/FlexCANDevice.h",
+    ],
+    implementation_deps = ["//libs/bsp/bspInterrupts:bsp_interrupts"],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//bazel/config/bsp:bsp_configuration",
+        "//libs/3rdparty/etl",
+        "//libs/bsw/bsp",
+        "//libs/bsw/cpp2can",
+        "//platforms/s32k1xx/bsp/bspIo:bsp_io",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+    ],
+)

--- a/platforms/s32k1xx/bsp/canflex2Transceiver/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/canflex2Transceiver/BUILD.bazel
@@ -1,0 +1,25 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "canflex2_transceiver",
+    srcs = ["src/can/transceiver/canflex2/CanFlex2Transceiver.cpp"],
+    hdrs = ["include/can/transceiver/canflex2/CanFlex2Transceiver.h"],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/bsw/async",
+        "//libs/bsw/lifecycle",
+        "//platforms/s32k1xx/bsp/bspFlexCan:bsp_flex_can",
+    ],
+)


### PR DESCRIPTION
## Migrate remaining BSP targets and `socBsp` aggregators

### Leaf targets:
- `libs/bsp/bspInputManager`
- `platforms/posix/bsp/bspEepromDriver`
- `platforms/posix/bsp/bspStdio`
- `platforms/s32k1xx/bsp/bspClock`
- `platforms/s32k1xx/bsp/bspFlexCan`
- `platforms/s32k1xx/bsp/canflex2Transceiver`

### `socBsp` aggregators:
CMake `socBsp` are empty INTERFACE libraries (no srcs/hdrs) that only forwards their per-platform lib deps as INTERFACE. The faithful Bazel translation are deps-only cc_libraries pinned to a specific platform via `target_compatible_with`:

- `//platforms/posix/bsp:soc_bsp` (`@platforms//os:linux`)
- /`/platforms/s32k1xx/bsp:soc_bsp` (`//bazel/platform/constraints/soc:s32k148`)

### `bsp_config` seam:
The BSP specific libs compile against a board-specific `bspConfiguration` that CMake supplies per platform via
`executables/referenceApp/platforms/<board>/bspConfiguration`.
In Bazel we model this as an overrideable label_flag (`//bazel/config/bsp:bsp_configuration`) which default to `bspConfiguration` based on target platform (`s32k148` / `posix`).
