### PR TITLE
Add version of CodeCoverage.cmake

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -32,24 +32,24 @@ The project maintains the following source code repository:
 Eclipse OpenBSW relies on other open source libraries.
 We recommend to read their licenses, as their terms may differ from the terms described in our LICENSE:
 
-| Project                   | Version | License   | Path                                                                 |
-|---------------------------|---------|-----------|----------------------------------------------------------------------|
-| Corrosion                 | 0.6     | MIT       | ``libs/3rdparty/corrosion/LICENSE``                                  |
-| ETL                       | 20.48.1 | MIT       | ``libs/3rdparty/etl/LICENSE``                                        |
-| LwIP                      | 2.2.1   | BSD-3     | ``libs/3rdparty/lwip/COPYING``                                       |
-| googletest                | 1.12.1  | BSD-3     | ``libs/3rdparty/googletest/LICENSE``                                 |
-| printf                    | 5.2.0   | MIT       | ``libs/3rdparty/printf/LICENSE``                                     |
-| FreeRTOS Real Time Kernel | 10.6.2  | MIT       | ``platforms/posix/3rdparty/freeRtosPosix/LICENSE.md``                |
-| FreeRTOS Real Time Kernel | 10.6.2  | MIT       | ``platforms/s32k1xx/3rdparty/freertos_cm4_sysTick/LICENSE.md``       |
-| FreeRTOS Real Time Kernel | 10.6.2  | MIT       | ``libs/3rdparty/freeRtos/LICENSE.md``                                |
-| ThreadX Kernel            | 6.4.3   | MIT       | ``libs/3rdparty/threadx/LICENSE.md``                                 |
-| ThreadX Cortex M4 Port    | 6.4.3   | MIT       | ``platforms/s32k1xx/3rdparty/threadx/LICENSE.md``                    |
-| ThreadX Linux Port        | 6.4.3   | MIT       | ``platforms/posix/3rdparty/threadx/LICENSE.md``                      |
-| CMSIS                     | 6.1.0   | Apache v2 | ``libs/3rdparty/cmsis/LICENSE``                                      |
-| NXP S32K148 Headers       | 1.1a    | BSD-3     | ``platforms/s32k1xx/bsp/bspMcu/include/3rdparty/nxp/*.h``            |
-| ST STM32F4 Device Headers | 2.6.11  | Apache v2 | ``platforms/stm32/bsp/bspMcu/include/3rdparty/st/LICENSE``           |
-| ST STM32G4 Device Headers | 1.2.6   | Apache v2 | ``platforms/stm32/bsp/bspMcu/include/3rdparty/st/LICENSE``           |
-| CodeCoverage              |         | BSD-3     | ``cmake/modules/CodeCoverage.cmake``                                 |
+| Project                   | Version  | License   | Path                                                                 |
+|---------------------------|----------|-----------|----------------------------------------------------------------------|
+| Corrosion                 | 0.6      | MIT       | ``libs/3rdparty/corrosion/LICENSE``                                  |
+| ETL                       | 20.48.1  | MIT       | ``libs/3rdparty/etl/LICENSE``                                        |
+| LwIP                      | 2.2.1    | BSD-3     | ``libs/3rdparty/lwip/COPYING``                                       |
+| googletest                | 1.12.1   | BSD-3     | ``libs/3rdparty/googletest/LICENSE``                                 |
+| printf                    | 5.2.0    | MIT       | ``libs/3rdparty/printf/LICENSE``                                     |
+| FreeRTOS Real Time Kernel | 10.6.2   | MIT       | ``platforms/posix/3rdparty/freeRtosPosix/LICENSE.md``                |
+| FreeRTOS Real Time Kernel | 10.6.2   | MIT       | ``platforms/s32k1xx/3rdparty/freertos_cm4_sysTick/LICENSE.md``       |
+| FreeRTOS Real Time Kernel | 10.6.2   | MIT       | ``libs/3rdparty/freeRtos/LICENSE.md``                                |
+| ThreadX Kernel            | 6.4.3    | MIT       | ``libs/3rdparty/threadx/LICENSE.md``                                 |
+| ThreadX Cortex M4 Port    | 6.4.3    | MIT       | ``platforms/s32k1xx/3rdparty/threadx/LICENSE.md``                    |
+| ThreadX Linux Port        | 6.4.3    | MIT       | ``platforms/posix/3rdparty/threadx/LICENSE.md``                      |
+| CMSIS                     | 6.1.0    | Apache v2 | ``libs/3rdparty/cmsis/LICENSE``                                      |
+| NXP S32K148 Headers       | 1.1a     | BSD-3     | ``platforms/s32k1xx/bsp/bspMcu/include/3rdparty/nxp/*.h``            |
+| ST STM32F4 Device Headers | 2.6.11   | Apache v2 | ``platforms/stm32/bsp/bspMcu/include/3rdparty/st/LICENSE``           |
+| ST STM32G4 Device Headers | 1.2.6    | Apache v2 | ``platforms/stm32/bsp/bspMcu/include/3rdparty/st/LICENSE``           |
+| CodeCoverage              | 877bab9d | BSD-3     | ``cmake/modules/CodeCoverage.cmake``                                 |
 
 ## MISRA
 


### PR DESCRIPTION
Add version of CodeCoverage.cmake

Since the upstream has no tags use the SHA instead.
