### PR TITLE
Support logger api for signal based communication

### DIFF
--- a/libs/bsw/middleware/include/middleware/core/LoggerApi.h
+++ b/libs/bsw/middleware/include/middleware/core/LoggerApi.h
@@ -22,13 +22,23 @@ namespace middleware::logger
 {
 
 /** Log buffer size for allocation failures. */
-ETL_INLINE_VAR constexpr uint8_t ALLOCATION_FAILURE_LOG_SIZE     = 20U;
+ETL_INLINE_VAR constexpr uint8_t ALLOCATION_FAILURE_LOG_SIZE               = 20U;
 /** Log buffer size for initialization failures. */
-ETL_INLINE_VAR constexpr uint8_t INIT_FAILURE_LOG_SIZE           = 11U;
+ETL_INLINE_VAR constexpr uint8_t INIT_FAILURE_LOG_SIZE                     = 11U;
 /** Log buffer size for message sending failures. */
-ETL_INLINE_VAR constexpr uint8_t MSG_SEND_FAILURE_LOG_SIZE       = 16U;
+ETL_INLINE_VAR constexpr uint8_t MSG_SEND_FAILURE_LOG_SIZE                 = 16U;
 /** Log buffer size for cross-thread violations. */
-ETL_INLINE_VAR constexpr uint8_t CROSS_THREAD_VIOLATION_LOG_SIZE = 18U;
+ETL_INLINE_VAR constexpr uint8_t CROSS_THREAD_VIOLATION_LOG_SIZE           = 18U;
+/** Log buffer size for frame-related failures. */
+ETL_INLINE_VAR constexpr uint8_t FRAME_FAILURE_LOG_SIZE                    = 9U;
+/** Log buffer size for PDU-related failures. */
+ETL_INLINE_VAR constexpr uint8_t PDU_FAILURE_LOG_SIZE                      = 9U;
+/** Log buffer size for failures when broadcasting a PDU to a cluster. */
+ETL_INLINE_VAR constexpr uint8_t PDU_BROADCAST_FAILURE_LOG_SIZE            = 10U;
+/** Log buffer size for missing service/member mapping. */
+ETL_INLINE_VAR constexpr uint8_t SERVICE_MEMBER_MAPPING_NOT_FOUND_LOG_SIZE = 9U;
+/** Log buffer size for PDU payload exceeding frame capacity. */
+ETL_INLINE_VAR constexpr uint8_t PDU_PAYLOAD_OUT_OF_BOUNDS_LOG_SIZE        = 13U;
 
 /**
  * Helper template to count the total size of types in bytes.
@@ -152,5 +162,49 @@ void logCrossThreadViolation(
     uint16_t serviceInstanceId,
     uint32_t initId,
     uint32_t currentTaskId);
+
+/**
+ * Logs a frame-related failure.
+ * \param level the severity level of the log message
+ * \param error the specific error indicating the type of frame failure
+ * \param frameId the unrecognised frame ID
+ */
+void logFrameFailure(LogLevel level, Error error, uint32_t frameId);
+
+/**
+ * Logs a PDU-related failure.
+ * \param level the severity level of the log message
+ * \param error the specific error encountered during the PDU operation
+ * \param pduId the PDU ID associated with the failure
+ */
+void logPduFailure(LogLevel level, Error error, uint32_t pduId);
+
+/**
+ * Logs a failure when broadcasting a PDU to a cluster.
+ * \param level the severity level of the log message
+ * \param error the specific error/event code when broadcasting a PDU
+ * \param pduId the PDU ID being broadcasted
+ * \param clusterId the destination cluster ID
+ */
+void logPduBroadcastFailure(LogLevel level, Error error, uint32_t pduId, uint8_t clusterId);
+
+/**
+ * Logs a missing service/member mapping for a PDU.
+ * \param level the severity level of the log message
+ * \param error the specific error indicating mapping lookup failure
+ * \param serviceId the service ID
+ * \param memberId the member ID
+ */
+void logServiceMemberMappingNotFound(
+    LogLevel level, Error error, uint16_t serviceId, uint16_t memberId);
+
+/**
+ * Logs a PDU payload that exceeds the frame capacity.
+ * \param level the severity level of the log message
+ * \param error the specific error indicating payload bounds violation
+ * \param pduId the PDU ID whose payload is too large
+ * \param maxBytes the maximum number of bytes the frame can hold
+ */
+void logPduPayloadOutOfBounds(LogLevel level, Error error, uint32_t pduId, uint32_t maxBytes);
 
 } // namespace middleware::logger

--- a/libs/bsw/middleware/interfaces/include/middleware/logger/Logger.h
+++ b/libs/bsw/middleware/interfaces/include/middleware/logger/Logger.h
@@ -46,6 +46,26 @@ enum class Error : uint8_t
     ProxyCrossThreadViolation    = 6U,
     /** Skeleton cross-thread access violation. */
     SkeletonCrossThreadViolation = 7U,
+    /** Unknown CAN frame ID encountered. */
+    FrameIdUnknown               = 8U,
+    /** CAN frame to PDU conversion failure. */
+    FrameToPduConversion         = 9U,
+    /** PDU slot exceeds frame payload length. */
+    FrameSlotOutOfBounds         = 10U,
+    /** PDU to CAN frame conversion failure. */
+    PduToFrameConversion         = 11U,
+    /** No route found for a PDU ID. */
+    PduRouteUnknown              = 12U,
+    /** Memory allocation failure for a PDU payload. */
+    PduPayloadAllocation         = 13U,
+    /** PDU broadcast failure. */
+    PduBroadcast                 = 14U,
+    /** Service/member mapping not found for a PDU. */
+    ServiceMemberMappingNotFound = 15U,
+    /** PDU offset exceeds frame capacity. */
+    PduOffsetOutOfBounds         = 16U,
+    /** PDU payload exceeds frame capacity. */
+    PduPayloadOutOfBounds        = 17U,
 };
 
 /**

--- a/libs/bsw/middleware/src/middleware/core/LoggerApi.cpp
+++ b/libs/bsw/middleware/src/middleware/core/LoggerApi.cpp
@@ -69,6 +69,15 @@ void serialize(::etl::byte_stream_writer& writer, Values... values)
 
     serialize(writer, values...);
 }
+
+template<uint32_t Size, typename... Args>
+void logBinaryRecord(LogLevel const level, Args const&... args)
+{
+    ::etl::array<uint8_t, Size> temp{};
+    ::etl::byte_stream_writer writer{temp, ::etl::endian::native};
+    serialize<Size>(writer, args...);
+    middleware::logger::logBinary(level, temp);
+}
 } // namespace
 
 void logAllocationFailure(
@@ -79,16 +88,6 @@ void logAllocationFailure(
     uint32_t const size)
 {
     static char const* const kformat = "e:%d r:%d SC:%d TC:%d S:%d I:%d M:%d R:%d s:%d";
-
-    ::etl::array<uint8_t, ALLOCATION_FAILURE_LOG_SIZE> temp{};
-    ::etl::byte_stream_writer writer{temp, ::etl::endian::native};
-    serialize<ALLOCATION_FAILURE_LOG_SIZE>(
-        writer,
-        getMessageId(error),
-        static_cast<uint8_t>(error),
-        static_cast<uint8_t>(res),
-        msg,
-        size);
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     middleware::logger::log(
@@ -103,7 +102,14 @@ void logAllocationFailure(
         msg.getHeader().memberId,
         msg.getHeader().requestId,
         size);
-    middleware::logger::logBinary(level, temp);
+
+    logBinaryRecord<ALLOCATION_FAILURE_LOG_SIZE>(
+        level,
+        getMessageId(error),
+        static_cast<uint8_t>(error),
+        static_cast<uint8_t>(res),
+        msg,
+        size);
 }
 
 void logInitFailure(
@@ -116,18 +122,6 @@ void logInitFailure(
 {
     static char const* const kformat = "e:%d r:%d SC:%d S:%d I:%d";
 
-    ::etl::array<uint8_t, INIT_FAILURE_LOG_SIZE>
-        temp{}; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-    ::etl::byte_stream_writer writer{temp, ::etl::endian::native};
-    serialize<INIT_FAILURE_LOG_SIZE>(
-        writer,
-        getMessageId(error),
-        static_cast<uint8_t>(error),
-        static_cast<uint8_t>(res),
-        static_cast<uint8_t>(sourceCluster),
-        static_cast<uint16_t>(serviceId),
-        static_cast<uint16_t>(serviceInstanceId));
-
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     middleware::logger::log(
         level,
@@ -137,19 +131,21 @@ void logInitFailure(
         sourceCluster,
         serviceId,
         serviceInstanceId);
-    middleware::logger::logBinary(level, temp);
+
+    logBinaryRecord<INIT_FAILURE_LOG_SIZE>(
+        level,
+        getMessageId(error),
+        static_cast<uint8_t>(error),
+        static_cast<uint8_t>(res),
+        static_cast<uint8_t>(sourceCluster),
+        static_cast<uint16_t>(serviceId),
+        static_cast<uint16_t>(serviceInstanceId));
 }
 
 void logMessageSendingFailure(
     LogLevel const level, Error const error, core::HRESULT const res, core::Message const& msg)
 {
     static char const* const kformat = "e:%d r:%d SC:%d TC:%d S:%d I:%d M:%d R:%d";
-
-    ::etl::array<uint8_t, MSG_SEND_FAILURE_LOG_SIZE>
-        temp{}; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-    ::etl::byte_stream_writer writer{temp, ::etl::endian::native};
-    serialize<MSG_SEND_FAILURE_LOG_SIZE>(
-        writer, getMessageId(error), static_cast<uint8_t>(error), static_cast<uint8_t>(res), msg);
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     middleware::logger::log(
@@ -163,7 +159,9 @@ void logMessageSendingFailure(
         msg.getHeader().serviceInstanceId,
         msg.getHeader().memberId,
         msg.getHeader().requestId);
-    middleware::logger::logBinary(level, temp);
+
+    logBinaryRecord<MSG_SEND_FAILURE_LOG_SIZE>(
+        level, getMessageId(error), static_cast<uint8_t>(error), static_cast<uint8_t>(res), msg);
 }
 
 void logCrossThreadViolation(
@@ -177,19 +175,6 @@ void logCrossThreadViolation(
 {
     static char const* const kformat = "e:%d SC:%d S:%d I:%d T0:%d T1:%d";
 
-    ::etl::array<uint8_t, CROSS_THREAD_VIOLATION_LOG_SIZE>
-        temp{}; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-    ::etl::byte_stream_writer writer{temp, ::etl::endian::native};
-    serialize<CROSS_THREAD_VIOLATION_LOG_SIZE>(
-        writer,
-        getMessageId(error),
-        static_cast<uint8_t>(error),
-        static_cast<uint8_t>(sourceCluster),
-        static_cast<uint16_t>(serviceId),
-        static_cast<uint16_t>(serviceInstanceId),
-        static_cast<uint32_t>(initId),
-        static_cast<uint32_t>(currentTaskId));
-
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     middleware::logger::log(
         level,
@@ -200,7 +185,85 @@ void logCrossThreadViolation(
         serviceInstanceId,
         initId,
         currentTaskId);
-    middleware::logger::logBinary(level, temp);
+
+    logBinaryRecord<CROSS_THREAD_VIOLATION_LOG_SIZE>(
+        level,
+        getMessageId(error),
+        static_cast<uint8_t>(error),
+        static_cast<uint8_t>(sourceCluster),
+        static_cast<uint16_t>(serviceId),
+        static_cast<uint16_t>(serviceInstanceId),
+        static_cast<uint32_t>(initId),
+        static_cast<uint32_t>(currentTaskId));
+}
+
+void logFrameFailure(LogLevel const level, Error const error, uint32_t const frameId)
+{
+    static char const* const kformat = "e:%d ID:0x%x";
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    middleware::logger::log(level, kformat, static_cast<unsigned int>(error), frameId);
+    logBinaryRecord<FRAME_FAILURE_LOG_SIZE>(
+        level, getMessageId(error), static_cast<uint8_t>(error), static_cast<uint32_t>(frameId));
+}
+
+void logPduFailure(LogLevel const level, Error const error, uint32_t const pduId)
+{
+    static constexpr char kdecimalFormat[] = "e:%d ID:%u";
+    static constexpr char khexFormat[]     = "e:%d ID:0x%x";
+    char const* const kformat
+        = (error == Error::PduRouteUnknown || error == Error::PduPayloadAllocation) ? kdecimalFormat
+                                                                                    : khexFormat;
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    middleware::logger::log(level, kformat, static_cast<unsigned int>(error), pduId);
+    logBinaryRecord<PDU_FAILURE_LOG_SIZE>(
+        level, getMessageId(error), static_cast<uint8_t>(error), static_cast<uint32_t>(pduId));
+}
+
+void logPduBroadcastFailure(
+    LogLevel const level, Error const error, uint32_t const pduId, uint8_t const clusterId)
+{
+    static char const* const kformat = "e:%d ID:%u C:%u";
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    middleware::logger::log(level, kformat, static_cast<unsigned int>(error), pduId, clusterId);
+    logBinaryRecord<PDU_BROADCAST_FAILURE_LOG_SIZE>(
+        level,
+        getMessageId(error),
+        static_cast<uint8_t>(error),
+        static_cast<uint32_t>(pduId),
+        static_cast<uint8_t>(clusterId));
+}
+
+void logServiceMemberMappingNotFound(
+    LogLevel const level, Error const error, uint16_t const serviceId, uint16_t const memberId)
+{
+    static char const* const kformat = "e:%d S:%u M:%u";
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    middleware::logger::log(level, kformat, static_cast<unsigned int>(error), serviceId, memberId);
+    logBinaryRecord<SERVICE_MEMBER_MAPPING_NOT_FOUND_LOG_SIZE>(
+        level,
+        getMessageId(error),
+        static_cast<uint8_t>(error),
+        static_cast<uint16_t>(serviceId),
+        static_cast<uint16_t>(memberId));
+}
+
+void logPduPayloadOutOfBounds(
+    LogLevel const level, Error const error, uint32_t const pduId, uint32_t const maxBytes)
+{
+    static char const* const kformat = "e:%d ID:%u MAX:%u";
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+    middleware::logger::log(level, kformat, static_cast<unsigned int>(error), pduId, maxBytes);
+    logBinaryRecord<PDU_PAYLOAD_OUT_OF_BOUNDS_LOG_SIZE>(
+        level,
+        getMessageId(error),
+        static_cast<uint8_t>(error),
+        static_cast<uint32_t>(pduId),
+        static_cast<uint32_t>(maxBytes));
 }
 
 } // namespace middleware::logger

--- a/libs/bsw/middleware/test/src/core/LoggerApi.cpp
+++ b/libs/bsw/middleware/test/src/core/LoggerApi.cpp
@@ -150,4 +150,137 @@ TEST_F(LoggerApiTest, TestLogCrossThreadViolation)
         level, error, sourceCluster, serviceId, serviceInstanceId, initId, currentTaskId);
 }
 
+TEST_F(LoggerApiTest, TestLogFrameIdUnknown)
+{
+    // ARRANGE
+    logger::LogLevel const level = logger::LogLevel::Error;
+    logger::Error const error    = logger::Error::FrameIdUnknown;
+    uint32_t const frameId       = ::etl::numeric_limits<uint32_t>::max();
+
+    // ACT && ASSERT
+    _loggerMock.EXPECT_LOG(level, "e:%d ID:0x%x", error, frameId);
+    _loggerMock.EXPECT_EVENT_LOG(level, error, frameId);
+    middleware::logger::logFrameFailure(level, error, frameId);
+}
+
+TEST_F(LoggerApiTest, TestLogCanConversionFailureForFrameToPdu)
+{
+    // ARRANGE
+    logger::LogLevel const level = logger::LogLevel::Error;
+    logger::Error const error    = logger::Error::FrameToPduConversion;
+    uint32_t const frameId       = ::etl::numeric_limits<uint32_t>::max();
+
+    // ACT && ASSERT
+    _loggerMock.EXPECT_LOG(level, "e:%d ID:0x%x", error, frameId);
+    _loggerMock.EXPECT_EVENT_LOG(level, error, frameId);
+    middleware::logger::logFrameFailure(level, error, frameId);
+}
+
+TEST_F(LoggerApiTest, TestLogPduFailureForFrameSlotOutOfBounds)
+{
+    // ARRANGE
+    logger::LogLevel const level = logger::LogLevel::Error;
+    logger::Error const error    = logger::Error::FrameSlotOutOfBounds;
+    uint32_t const pduId         = ::etl::numeric_limits<uint32_t>::max();
+
+    // ACT && ASSERT
+    _loggerMock.EXPECT_LOG(level, "e:%d ID:0x%x", error, pduId);
+    _loggerMock.EXPECT_EVENT_LOG(level, error, pduId);
+    middleware::logger::logPduFailure(level, error, pduId);
+}
+
+TEST_F(LoggerApiTest, TestLogCanConversionFailureForPduToFrame)
+{
+    // ARRANGE
+    logger::LogLevel const level = logger::LogLevel::Error;
+    logger::Error const error    = logger::Error::PduToFrameConversion;
+    uint32_t const pduId         = ::etl::numeric_limits<uint32_t>::max();
+
+    // ACT && ASSERT
+    _loggerMock.EXPECT_LOG(level, "e:%d ID:0x%x", error, pduId);
+    _loggerMock.EXPECT_EVENT_LOG(level, error, pduId);
+    middleware::logger::logPduFailure(level, error, pduId);
+}
+
+TEST_F(LoggerApiTest, TestLogPduFailureForRouteUnknown)
+{
+    // ARRANGE
+    logger::LogLevel const level = logger::LogLevel::Error;
+    logger::Error const error    = logger::Error::PduRouteUnknown;
+    uint32_t const pduId         = ::etl::numeric_limits<uint32_t>::max();
+
+    // ACT && ASSERT
+    _loggerMock.EXPECT_LOG(level, "e:%d ID:%u", error, pduId);
+    _loggerMock.EXPECT_EVENT_LOG(level, error, pduId);
+    middleware::logger::logPduFailure(level, error, pduId);
+}
+
+TEST_F(LoggerApiTest, TestLogPduFailureForPayloadAllocation)
+{
+    // ARRANGE
+    logger::LogLevel const level = logger::LogLevel::Error;
+    logger::Error const error    = logger::Error::PduPayloadAllocation;
+    uint32_t const pduId         = ::etl::numeric_limits<uint32_t>::max();
+
+    // ACT && ASSERT
+    _loggerMock.EXPECT_LOG(level, "e:%d ID:%u", error, pduId);
+    _loggerMock.EXPECT_EVENT_LOG(level, error, pduId);
+    middleware::logger::logPduFailure(level, error, pduId);
+}
+
+TEST_F(LoggerApiTest, TestLogPduBroadcastFailure)
+{
+    // ARRANGE
+    logger::LogLevel const level = logger::LogLevel::Info;
+    logger::Error const error    = logger::Error::PduBroadcast;
+    uint32_t const pduId         = ::etl::numeric_limits<uint32_t>::max();
+    uint8_t const clusterId      = ::etl::numeric_limits<uint8_t>::max();
+
+    // ACT && ASSERT
+    _loggerMock.EXPECT_LOG(level, "e:%d ID:%u C:%u", error, pduId, clusterId);
+    _loggerMock.EXPECT_EVENT_LOG(level, error, pduId, clusterId);
+    middleware::logger::logPduBroadcastFailure(level, error, pduId, clusterId);
+}
+
+TEST_F(LoggerApiTest, TestLogServiceMemberMappingNotFound)
+{
+    // ARRANGE
+    logger::LogLevel const level = logger::LogLevel::Warning;
+    logger::Error const error    = logger::Error::ServiceMemberMappingNotFound;
+    uint16_t const serviceId     = ::etl::numeric_limits<uint16_t>::max();
+    uint16_t const memberId      = ::etl::numeric_limits<uint16_t>::max();
+
+    // ACT && ASSERT
+    _loggerMock.EXPECT_LOG(level, "e:%d S:%u M:%u", error, serviceId, memberId);
+    _loggerMock.EXPECT_EVENT_LOG(level, error, serviceId, memberId);
+    middleware::logger::logServiceMemberMappingNotFound(level, error, serviceId, memberId);
+}
+
+TEST_F(LoggerApiTest, TestLogPduFailureForOffsetOutOfBounds)
+{
+    // ARRANGE
+    logger::LogLevel const level = logger::LogLevel::Error;
+    logger::Error const error    = logger::Error::PduOffsetOutOfBounds;
+    uint32_t const pduId         = ::etl::numeric_limits<uint32_t>::max();
+
+    // ACT && ASSERT
+    _loggerMock.EXPECT_LOG(level, "e:%d ID:0x%x", error, pduId);
+    _loggerMock.EXPECT_EVENT_LOG(level, error, pduId);
+    middleware::logger::logPduFailure(level, error, pduId);
+}
+
+TEST_F(LoggerApiTest, TestLogPduPayloadOutOfBounds)
+{
+    // ARRANGE
+    logger::LogLevel const level = logger::LogLevel::Error;
+    logger::Error const error    = logger::Error::PduPayloadOutOfBounds;
+    uint32_t const pduId         = ::etl::numeric_limits<uint32_t>::max();
+    uint32_t const maxBytes      = ::etl::numeric_limits<uint32_t>::max();
+
+    // ACT && ASSERT
+    _loggerMock.EXPECT_LOG(level, "e:%d ID:%u MAX:%u", error, pduId, maxBytes);
+    _loggerMock.EXPECT_EVENT_LOG(level, error, pduId, maxBytes);
+    middleware::logger::logPduPayloadOutOfBounds(level, error, pduId, maxBytes);
+}
+
 } // namespace middleware::core::test

--- a/libs/bsw/middleware/test/src/logger/mock/LoggerMock.cpp
+++ b/libs/bsw/middleware/test/src/logger/mock/LoggerMock.cpp
@@ -52,6 +52,7 @@ void log(LogLevel const level, char const* const format, ...) // NOLINT(cert-dcl
                 {
                     case 'd': args.push_back(static_cast<uint32_t>(va_arg(ap, int))); continue;
                     case 'u':
+                    case 'x':
                         args.push_back(static_cast<uint32_t>(va_arg(ap, unsigned int)));
                         continue;
                     default: break;


### PR DESCRIPTION
# Support logger api for signal based commuinication (COM)

## Changed Files

- `libs/bsw/middleware/include/middleware/core/LoggerApi.h`
- `libs/bsw/middleware/interfaces/include/middleware/logger/Logger.h`
- `libs/bsw/middleware/src/middleware/core/LoggerApi.cpp`
- `libs/bsw/middleware/test/src/core/LoggerApi.cpp`
- `libs/bsw/middleware/test/src/logger/mock/LoggerMock.cpp`

## Functional Changes Implemented

### 1) Extended middleware logger error taxonomy for COM-related failures

Added new `middleware::logger::Error` enum values to represent frame/PDU issues:

- `FrameIdUnknown`
- `FrameToPduConversion`
- `FrameSlotOutOfBounds`
- `PduToFrameConversion`
- `PduRouteUnknown`
- `PduPayloadAllocation`
- `PduBroadcast`
- `ServiceMemberMappingNotFound`
- `PduOffsetOutOfBounds`
- `PduPayloadOutOfBounds`

This enables clearer categorization and filtering of COM-specific runtime failures.

### 2) Added dedicated LoggerApi entry points for COM logging scenarios

New public API functions were added in `LoggerApi`:

- `logFrameFailure(...)`
- `logPduFailure(...)`
- `logPduBroadcastFailure(...)`
- `logServiceMemberMappingNotFound(...)`
- `logPduPayloadOutOfBounds(...)`

### 3) Added binary payload size constants for new event formats

Introduced log payload size constants for new COM events:

- `FRAME_FAILURE_LOG_SIZE`
- `PDU_FAILURE_LOG_SIZE`
- `PDU_BROADCAST_FAILURE_LOG_SIZE`
- `SERVICE_MEMBER_MAPPING_NOT_FOUND_LOG_SIZE`
- `PDU_PAYLOAD_OUT_OF_BOUNDS_LOG_SIZE`

### 4) Refactored LoggerApi binary serialization path

Introduced a helper template:

- `logBinaryRecord<Size>(level, args...)`

The helper centralizes repetitive logic for:

- temporary buffer allocation,
- ETL byte stream writer construction,
- record serialization, and
- forwarding to `logBinary`.

Existing APIs (`logAllocationFailure`, `logInitFailure`, `logMessageSendingFailure`, `logCrossThreadViolation`) were updated to use this helper.

## Test Changes

### Expanded unit test coverage in LoggerApi tests

Added tests for all newly introduced COM logging entry points and relevant error cases, including:

- unknown frame ID
- frame<->PDU conversion failures
- PDU route unknown
- payload allocation failures
- broadcast failures
- service/member mapping missing
- offset and payload bounds issues

Each new test validates both:

- formatted textual log output, and
- expected binary event log payload arguments.