### PR TITLE
Migrate referenceApp safety core and config leaves to Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,9 @@
 build:s32k148_gcc --platforms=//bazel/platform:s32k148
 # Default to gcc
 build:s32k148 --config=s32k148_gcc
+# Platform feature defines (CMake root add_compile_definitions(PLATFORM_SUPPORT_*=1) from
+# platforms/s32k148evb/Options.cmake). Global to the s32k148 build, like on the CMake side.
+build:s32k148 --copt=-DPLATFORM_SUPPORT_IO=1
 
 # TODO: Temporary config only needed for artifact analysis
 # Make Bazel's build match CMake s32k148-freertos-gcc default config

--- a/bazel_migration/README.md
+++ b/bazel_migration/README.md
@@ -43,9 +43,10 @@ OpenBSW Bazel migration
 │   │   ├── asyncCoreConfiguration ✅
 │   │   ├── configuration ✅
 │   │   ├── lwipConfiguration ✅
+│   │   ├── safety/ ✅ (safeSupervisor)
 │   │   └── platforms/
-│   │       ├── posix/ ✅ (freeRtosCoreConfiguration, threadXCoreConfiguration, osHooks)
-│   │       └── s32k148evb/ ✅ (freeRtosCoreConfiguration, threadXCoreConfiguration, osHooks)
+│   │       ├── posix/ ✅ (freeRtosCoreConfiguration, threadXCoreConfiguration, osHooks, ethConfiguration)
+│   │       └── s32k148evb/ ✅ (freeRtosCoreConfiguration, threadXCoreConfiguration, osHooks, startUpAsm, ethConfiguration, safety/safeIo)
 │   └── unitTest/ 🔲
 │       └── configuration ✅
 ├── libs/

--- a/executables/referenceApp/platforms/posix/ethConfiguration/BUILD.bazel
+++ b/executables/referenceApp/platforms/posix/ethConfiguration/BUILD.bazel
@@ -1,0 +1,22 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "eth_configuration",
+    hdrs = ["include/ethConfig.h"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/etl",
+        "//libs/bsw/cpp2ethernet",
+    ],
+)

--- a/executables/referenceApp/platforms/s32k148evb/ethConfiguration/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/ethConfiguration/BUILD.bazel
@@ -1,0 +1,22 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "eth_configuration",
+    hdrs = ["include/ethConfig.h"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/etl",
+        "//libs/bsw/cpp2ethernet",
+    ],
+)

--- a/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
@@ -11,6 +11,31 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(
+    name = "start_up_asm",
+    # ThreadX adds a low-level init assembly source.
+    srcs = [
+        "src/bsp/bootHeader.S",
+        "src/bsp/startUp.S",
+    ] + select({
+        "//bazel/config/rtos:support_threadx": [
+            "src/bsp/threadx/tx_initialize_low_level.S",
+        ],
+        "//conditions:default": [],
+    }),
+    # ThreadX low-level init needs the async core configuration.
+    implementation_deps = select({
+        "//bazel/config/rtos:support_threadx": [
+            "//executables/referenceApp/asyncCoreConfiguration:async_core_configuration",
+        ],
+        "//conditions:default": [],
+    }),
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    # Force-link all objects; boot header and vectors are referenced by address, not symbol.
+    alwayslink = True,
+)
+
+cc_library(
     name = "freertos_os_hooks",
     srcs = [
         "src/osHooks/freertos/osHooks.cpp",

--- a/executables/referenceApp/platforms/s32k148evb/safety/safeIo/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/safety/safeIo/BUILD.bazel
@@ -1,0 +1,30 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "safe_io",
+    srcs = [
+        "src/safeIo/SafeIo.cpp",
+        "src/safeIo/SafeState.cpp",
+    ],
+    hdrs = [
+        "include/safeIo/SafeIo.h",
+        "include/safeIo/SafeState.h",
+    ],
+    implementation_deps = [
+        "//executables/referenceApp/safety/safeSupervisor:safe_supervisor_headers",
+        "//platforms/s32k1xx/bsp/bspIo:bsp_io",
+    ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+)

--- a/executables/referenceApp/safety/safeSupervisor/BUILD.bazel
+++ b/executables/referenceApp/safety/safeSupervisor/BUILD.bazel
@@ -1,0 +1,71 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# Circular dependency present on the CMake side: safeSupervisor -> safeIo -> safeSupervisor
+# Split off safe_supervisor_headers to break the circular dependency for Bazel
+cc_library(
+    name = "safe_supervisor_headers",
+    hdrs = [
+        "include/safeSupervisor/SafeSupervisor.h",
+        "include/safeSupervisor/utils/explicitly_constructible.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/bsw/platform",
+        "//libs/safety/safeMonitor:safe_monitor",
+    ],
+)
+
+# IO support wiring; present only on platforms that provide IO.
+cc_library(
+    name = "safe_supervisor_io_support",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    deps = [
+        "//executables/referenceApp/platforms/s32k148evb/safety/safeIo:safe_io",
+        "//platforms/s32k1xx/bsp/bspIo:bsp_io",
+    ],
+)
+
+cc_library(name = "safe_supervisor_io_support_none")
+
+alias(
+    name = "io_support",
+    actual = select({
+        "//bazel/platform/constraints/soc:s32k148": ":safe_supervisor_io_support",
+        "//conditions:default": ":safe_supervisor_io_support_none",
+    }),
+)
+
+alias(
+    name = "bsp_mcu",
+    actual = select({
+        "//bazel/platform/constraints/soc:s32k148": "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+        "@platforms//os:linux": "//platforms/posix/bsp/bspMcu:bsp_mcu",
+    }),
+)
+
+cc_library(
+    name = "safe_supervisor",
+    srcs = ["src/safeSupervisor/SafeSupervisor.cpp"],
+    implementation_deps = [
+        ":io_support",
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//libs/bsw/common",
+        "//libs/safety/safeUtils:safe_utils",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bsp_mcu",
+        ":safe_supervisor_headers",
+    ],
+)

--- a/libs/bsw/asyncFreeRtos/BUILD.bazel
+++ b/libs/bsw/asyncFreeRtos/BUILD.bazel
@@ -82,6 +82,11 @@ cc_library(
         "//libs/bsw/async:async_binding",
         "//libs/bsw/util",
     ],
+    # Only compiles under FreeRTOS; mark incompatible elsewhere so wildcard builds skip it.
+    target_compatible_with = select({
+        "//bazel/config/rtos:support_freertos": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     visibility = ["//visibility:public"],
 )
 

--- a/libs/bsw/asyncThreadX/BUILD.bazel
+++ b/libs/bsw/asyncThreadX/BUILD.bazel
@@ -83,6 +83,7 @@ cc_library(
         "//libs/bsw/async:async_binding",
         "//libs/bsw/util",
     ],
+    # Only compiles under ThreadX; mark incompatible elsewhere so wildcard builds skip it.
     target_compatible_with = select({
         "//bazel/config/rtos:support_threadx": [],
         "//conditions:default": ["@platforms//:incompatible"],


### PR DESCRIPTION
Migrate referenceApp safety core and config leaves to Bazel

libs:
- safeSupervisor: safe_supervisor
- safeIo: safe_io
- startUpAsm: start_up_asm

config points:
- ethConfiguration: eth_configuration (posix + s32k148evb)
- Bazel-only: safe_supervisor_headers, io_support, bsp_mcu
  (facades to break the s32k148 safe_supervisor <-> safe_io cycle)

additional changes:
- PLATFORM_SUPPORT_IO added in .bazelrc (build:s32k148) to match the
  CMake s32k148 compile definitions
- gate async_freertos_impl with target_compatible_with so wildcard
  builds pass under both RTOS configs (unrelated fix)
