### PR TITLE
ReferenceApp middleware deps abstraction

### DIFF
--- a/executables/referenceApp/middlewareConfiguration/CMakeLists.txt
+++ b/executables/referenceApp/middlewareConfiguration/CMakeLists.txt
@@ -74,4 +74,5 @@ target_include_directories(
     middleware
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/platform_integration/concurrency/include)
 
-target_link_libraries(middlewareConfiguration PUBLIC middleware logger)
+target_link_libraries(middlewareConfiguration PUBLIC asyncBinding middleware
+                                                     logger)

--- a/executables/referenceApp/middlewareConfiguration/platform_integration/concurrency/include/middleware/concurrency/lock_types.h
+++ b/executables/referenceApp/middlewareConfiguration/platform_integration/concurrency/include/middleware/concurrency/lock_types.h
@@ -15,7 +15,7 @@ namespace middleware::concurrency::integration
 {
 
 /**
- * No-op scope guard for single-core lock — simulation stub.
+ * No-op scope guard for the single-core referenceApp integration.
  */
 struct ScopedCoreLock
 {
@@ -29,7 +29,7 @@ struct ScopedCoreLock
 };
 
 /**
- * No-op scope guard for ECU-wide lock — simulation stub.
+ * No-op scope guard for the ECU-wide lock in the single-core referenceApp integration.
  */
 struct ScopedECULock
 {

--- a/executables/referenceApp/middlewareConfiguration/platform_integration/logger/src/LoggerImpl.cpp
+++ b/executables/referenceApp/middlewareConfiguration/platform_integration/logger/src/LoggerImpl.cpp
@@ -8,7 +8,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include <cstdarg>
-#include <cstdio>
 
 #include <etl/span.h>
 #include <util/logger/Logger.h>
@@ -19,39 +18,30 @@
 namespace middleware::logger
 {
 
-// NOLINTBEGIN(cert-dcl50-cpp,cppcoreguidelines-pro-type-vararg,cert-err33-c,clang-analyzer-valist.Uninitialized)
+// NOLINTBEGIN(cert-dcl50-cpp,cppcoreguidelines-pro-type-vararg)
 void log(LogLevel const level, char const* const f, ...)
 {
     std::va_list ap;
     va_start(ap, f);
-    char buffer[256];
-    (void)vsnprintf(buffer, sizeof(buffer), f, ap);
-    va_end(ap);
-    // NOLINTEND(cert-dcl50-cpp,cppcoreguidelines-pro-type-vararg,cert-err33-c,clang-analyzer-valist.Uninitialized)
-
-    // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
-    switch (level)
+    auto const logLevel = [&]()
     {
-        case LogLevel::Critical:
-            ::util::logger::Logger::critical(::util::logger::DEMO, "%s", buffer);
-            break;
-        case LogLevel::Error:
-            ::util::logger::Logger::error(::util::logger::DEMO, "%s", buffer);
-            break;
-        case LogLevel::Warning:
-            ::util::logger::Logger::warn(::util::logger::DEMO, "%s", buffer);
-            break;
-        case LogLevel::Info:
-            ::util::logger::Logger::info(::util::logger::DEMO, "%s", buffer);
-            break;
-        case LogLevel::Debug:
-        case LogLevel::Trace:
-            ::util::logger::Logger::debug(::util::logger::DEMO, "%s", buffer);
-            break;
-        default: break;
-    }
-    // NOLINTEND(cppcoreguidelines-pro-type-vararg)
+        switch (level)
+        {
+            case LogLevel::Critical: return ::util::logger::LEVEL_CRITICAL;
+            case LogLevel::Error:    return ::util::logger::LEVEL_ERROR;
+            case LogLevel::Warning:  return ::util::logger::LEVEL_WARN;
+            case LogLevel::Info:     return ::util::logger::LEVEL_INFO;
+            case LogLevel::Debug:
+            case LogLevel::Trace:    return ::util::logger::LEVEL_DEBUG;
+            case LogLevel::None:     break;
+        }
+        return ::util::logger::LEVEL_NONE;
+    }();
+    ::util::logger::Logger::log(::util::logger::DEMO, logLevel, f, ap);
+    va_end(ap);
 }
+
+// NOLINTEND(cert-dcl50-cpp,cppcoreguidelines-pro-type-vararg)
 
 void logBinary(LogLevel const /*level*/, etl::span<uint8_t const> const /*data*/) {}
 

--- a/executables/referenceApp/middlewareConfiguration/platform_integration/os/src/OsDefinitions.cpp
+++ b/executables/referenceApp/middlewareConfiguration/platform_integration/os/src/OsDefinitions.cpp
@@ -9,7 +9,7 @@
  ********************************************************************************/
 #include <cstdint>
 
-#include <unistd.h>
+#include <async/AsyncBinding.h>
 
 #include <middleware/os/TaskIdProvider.h>
 
@@ -18,12 +18,7 @@ namespace middleware
 namespace os
 {
 
-uint32_t getProcessId()
-{
-    pid_t const tid = gettid();
-    static_assert(sizeof tid <= sizeof(uint32_t), "Size of tid is bigger than sizeof(uint32_t)");
-    return static_cast<uint32_t>(tid);
-}
+uint32_t getProcessId() { return ::async::AsyncBinding::AdapterType::getCurrentTaskContext(); }
 
 } // namespace os
 } // namespace middleware

--- a/executables/referenceApp/middlewareConfiguration/platform_integration/time/src/SystemTimeProvider.cpp
+++ b/executables/referenceApp/middlewareConfiguration/platform_integration/time/src/SystemTimeProvider.cpp
@@ -7,27 +7,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-#include <chrono>
+#include <bsp/timer/SystemTimer.h>
 
 #include <middleware/time/SystemTimerProvider.h>
 
 namespace middleware::time
 {
 
-uint32_t getCurrentTimeInMs()
-{
-    return static_cast<uint32_t>(
-        std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
-            .time_since_epoch()
-            .count());
-}
+uint32_t getCurrentTimeInMs() { return getSystemTimeMs32Bit(); }
 
-uint32_t getCurrentTimeInUs()
-{
-    return static_cast<uint32_t>(
-        std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::steady_clock::now())
-            .time_since_epoch()
-            .count());
-}
+uint32_t getCurrentTimeInUs() { return getSystemTimeUs32Bit(); }
 
 } // namespace middleware::time


### PR DESCRIPTION
Align the referenceApp middleware integrations with the existing platform abstraction boundaries.
- Route middleware task identification through asyncBinding instead of direct POSIX APIs.
- Route middleware time access through the BSP system timer APIs.
- Forward middleware log messages directly through the referenceApp logger facade.
- Clarify the single-core referenceApp lock provider documentation.


This pull request will unblock the conclusion of: https://github.com/eclipse-openbsw/openbsw/pull/558