### PR TITLE
Add STM32 Nucleo board documentation

### DIFF
--- a/doc/dev/features/diagnostics.rst
+++ b/doc/dev/features/diagnostics.rst
@@ -1,0 +1,49 @@
+..
+   *******************************************************************************
+   Copyright (c) 2026 An Dao
+
+   This program and the accompanying materials are made available under the
+   terms of the Apache License Version 2.0 which is available at
+   https://www.apache.org/licenses/LICENSE-2.0
+
+   SPDX-License-Identifier: Apache-2.0
+   *******************************************************************************
+
+.. _feature_diagnostics:
+
+Diagnostics (DoCAN / UDS)
+=========================
+
+Overview
+--------
+
+The reference application provides DoCAN (ISO 15765-2) transport and UDS diagnostics on
+platforms that enable ``PLATFORM_SUPPORT_TRANSPORT`` and ``PLATFORM_SUPPORT_UDS``. The
+features described here are platform independent; each platform selects them through its
+``executables/referenceApp/platforms/<platform_name>/Options.cmake``.
+
+Tester addressing
+-----------------
+
+With ``PLATFORM_SUPPORT_OBD_UDS_ADDRESSING`` enabled, the DoCAN channel uses ISO 15765-4
+OBD-style tester addressing (0x7E0 request / 0x7E8 response, logical address 0x0600), so
+standard UDS tester tools work without a custom channel configuration. Platforms without
+the option keep the default example addressing.
+
+Programming session
+-------------------
+
+``PLATFORM_SUPPORT_PROGRAMMING_SESSION`` adds an application-level UDS programming
+session which keeps the UDS dispatcher alive instead of handing over to a bootloader.
+See ``executables/referenceApp/udsConfiguration/src/uds/session/DiagSession.cpp`` for
+the details.
+
+Demo services
+-------------
+
+``PLATFORM_SUPPORT_UDS_DEMO_SERVICES`` registers example UDS services in the reference
+application: ECU reset, an in-memory DTC store with read/clear/control services,
+security access, VIN write and demo routine control. They give a connected tester a
+complete diagnostic surface out-of-the-box and serve as worked examples for
+implementing application-level UDS jobs on top of the UDS stack. The implementations
+are located in ``executables/referenceApp/application/src/uds``.

--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -161,6 +161,7 @@ Eclipse OpenBSW is a trademark of the Eclipse Foundation.
 
     platforms/posix/index
     platforms/s32k148evb/index
+    platforms/stm32/index
 
 .. toctree::
     :maxdepth: 1
@@ -169,6 +170,7 @@ Eclipse OpenBSW is a trademark of the Eclipse Foundation.
 
     features/storage
     features/functional_safety
+    features/diagnostics
 
 .. toctree::
     :maxdepth: 1

--- a/doc/dev/platforms/stm32/index.rst
+++ b/doc/dev/platforms/stm32/index.rst
@@ -1,0 +1,75 @@
+..
+   *******************************************************************************
+   Copyright (c) 2026 An Dao
+
+   This program and the accompanying materials are made available under the
+   terms of the Apache License Version 2.0 which is available at
+   https://www.apache.org/licenses/LICENSE-2.0
+
+   SPDX-License-Identifier: Apache-2.0
+   *******************************************************************************
+
+.. _stm32_overview:
+
+STM32 Nucleo Boards
+===================
+
+Overview
+--------
+
+- The STM32 platform brings Eclipse OpenBSW to STMicroelectronics Nucleo development
+  boards: low-cost, widely available hardware with an on-board ST-LINK
+  debugger/programmer, so no external debug probe is needed.
+- Eclipse OpenBSW provides a reference application for these boards which can be built
+  out-of-the-box and flashed onto the board, providing an immediate starting point for
+  further development and learning.
+
+Supported boards
+----------------
+
+.. csv-table:: STM32 boards
+   :header: "Board", "MCU", "Core", "Flash / RAM", "CAN peripheral", "Form factor"
+   :widths: 18, 14, 16, 14, 14, 12
+
+   "NUCLEO-G474RE", "STM32G474RE", "Cortex-M4F, 170 MHz", "512 KB / 128 KB", "FDCAN", "Nucleo-64"
+   "NUCLEO-F413ZH", "STM32F413ZH", "Cortex-M4F, 100 MHz", "1.5 MB / 320 KB", "bxCAN", "Nucleo-144"
+
+Scope
+-----
+
+The reference application on the STM32 boards provides:
+
+- lifecycle management and the serial console over the ST-LINK virtual COM port,
+- CAN communication (FDCAN on the STM32G474RE, bxCAN on the STM32F413ZH),
+- DoCAN transport and UDS diagnostics (see :ref:`feature_diagnostics`),
+- a choice of RTOS: FreeRTOS (default) or ThreadX, selected via the
+  ``BUILD_TARGET_RTOS`` CMake option.
+
+The platform options enabled per board are defined in
+``executables/referenceApp/platforms/<board_name>/Options.cmake``.
+
+Reference Links
+---------------
+
+1. **NUCLEO-G474RE**:
+    - `NUCLEO-G474RE Product Page <https://www.st.com/en/evaluation-tools/nucleo-g474re.html>`_
+    - `STM32G474RE MCU Page <https://www.st.com/en/microcontrollers-microprocessors/stm32g474re.html>`_
+
+2. **NUCLEO-F413ZH**:
+    - `NUCLEO-F413ZH Product Page <https://www.st.com/en/evaluation-tools/nucleo-f413zh.html>`_
+    - `STM32F413ZH MCU Page <https://www.st.com/en/microcontrollers-microprocessors/stm32f413zh.html>`_
+
+3. **Software and Tools**:
+    - `STM32CubeProgrammer <https://www.st.com/en/development-tools/stm32cubeprog.html>`_
+    - `OpenOCD <https://openocd.org/>`_
+
+Availability
+------------
+
+Both boards are active STMicroelectronics products, available at low cost from the
+usual electronics distributors.
+
+Build environment
+-----------------
+
+For instructions on building for this platform see :ref:`learning_setup`


### PR DESCRIPTION
Adds a platform page under doc/dev/platforms describing the scope, source and availability of the supported STM32 Nucleo boards (NUCLEO-G474RE and NUCLEO-F413ZH), as suggested in #420.