### PR TITLE
Configure DoCAN addressing and UDS sessions

### DIFF
--- a/executables/referenceApp/application/src/systems/DoCanSystem.cpp
+++ b/executables/referenceApp/application/src/systems/DoCanSystem.cpp
@@ -40,8 +40,22 @@ uint32_t systemUs() { return ::bsw::time::TimestampProvider::getTimestampUs32Bit
 namespace docan
 {
 
+// PLATFORM_SUPPORT_OBD_UDS_ADDRESSING and PLATFORM_SUPPORT_PROGRAMMING_SESSION
+// are platform options (see the platforms' Options.cmake).
+// PLATFORM_SUPPORT_OBD_UDS_ADDRESSING switches the DoCAN channel to the
+// ISO 15765-4 OBD tester addressing (0x7E0 request / 0x7E8 response, logical
+// address 0x0600 in appConfig.h) so off-the-shelf UDS tester tools talk to the
+// board without a custom channel configuration. Platforms without the option
+// keep the original example addressing. PLATFORM_SUPPORT_PROGRAMMING_SESSION
+// adds an application-level UDS programming session (see
+// udsConfiguration/src/uds/session/DiagSession.cpp) that keeps the UDS
+// dispatcher alive instead of handing over to a bootloader.
 DoCanSystem::AddressingFilterType::AddressEntryType DoCanSystem::_addresses[]
-    = {{0x02A, 0x0F0U, 0x0F0U, LOGICAL_ADDRESS, 0, 0}};
+#ifdef PLATFORM_SUPPORT_OBD_UDS_ADDRESSING
+    = {{0x7E0U, 0x7E8U, 0x7E8U, LOGICAL_ADDRESS, 0, 0}};
+#else
+    = {{0x02AU, 0x0F0U, 0x0F0U, LOGICAL_ADDRESS, 0, 0}};
+#endif
 
 DoCanSystem::DoCanSystem(
     ::transport::ITransportSystem& transportSystem,

--- a/executables/referenceApp/configuration/include/app/appConfig.h
+++ b/executables/referenceApp/configuration/include/app/appConfig.h
@@ -13,7 +13,11 @@
 #include <async/TaskInitializer.h>
 
 #ifdef PLATFORM_SUPPORT_TRANSPORT
+#ifdef PLATFORM_SUPPORT_OBD_UDS_ADDRESSING
+static constexpr uint16_t LOGICAL_ADDRESS = 0x0600U;
+#else
 static constexpr uint16_t LOGICAL_ADDRESS = 0x002AU;
+#endif
 #endif // PLATFORM_SUPPORT_TRANSPORT
 
 #define safety_task_stackSize 2048U

--- a/executables/referenceApp/udsConfiguration/src/uds/session/DiagSession.cpp
+++ b/executables/referenceApp/udsConfiguration/src/uds/session/DiagSession.cpp
@@ -1,5 +1,6 @@
 /********************************************************************************
  * Copyright (c) 2024 Accenture
+ * Copyright (c) 2026 An Dao
  *
  * This program and the accompanying materials are made available under the
  * terms of the Apache License Version 2.0 which is available at
@@ -16,6 +17,41 @@
 
 namespace uds
 {
+
+#ifdef PLATFORM_SUPPORT_PROGRAMMING_SESSION
+// Session index of AppProgrammingSession. DiagSession::operator== compares
+// only toIndex(), so this index decides which DiagnosticSessionControl paths
+// treat the session as equal. It must be ApplicationExtendedSession's index
+// (0x03): only sessions equal to APPLICATION_EXTENDED_SESSION() get the S3
+// tester-present timeout armed (startTimeout()) and fall back to the default
+// session when it expires (expired_local()). It must NOT be
+// ProgrammingSession's index (0x04), whose switchSession() branch disables
+// the UDS dispatcher for a bootloader handover, nor
+// ApplicationDefaultSession's index (0x01), which would stop the timeout.
+static constexpr uint8_t APP_PROGRAMMING_SESSION_INDEX = 0x03U;
+
+// Application-level programming session. Uses SessionType PROGRAMMING (0x02)
+// for the correct response byte, but shares the extended session's index so
+// DiagnosticSessionControl keeps the UDS dispatcher alive and applies the
+// extended session's S3 timeout handling. Jobs restricted to the extended
+// session mask are consequently also allowed in this session.
+class AppProgrammingSession : public DiagSession
+{
+public:
+    AppProgrammingSession() : DiagSession(PROGRAMMING, APP_PROGRAMMING_SESSION_INDEX) {}
+
+    DiagReturnCode::Type isTransitionPossible(DiagSession::SessionType targetSession) override;
+
+    DiagSession& getTransitionResult(DiagSession::SessionType targetSession) override;
+};
+
+static AppProgrammingSession& appProgrammingSession()
+{
+    static AppProgrammingSession s;
+    return s;
+}
+#endif
+
 ApplicationDefaultSession& DiagSession::APPLICATION_DEFAULT_SESSION()
 {
     static ApplicationDefaultSession applicationDefaultSession;
@@ -67,7 +103,11 @@ ApplicationDefaultSession::isTransitionPossible(DiagSession::SessionType const t
         }
         case DiagSession::PROGRAMMING:
         {
+#ifdef PLATFORM_SUPPORT_PROGRAMMING_SESSION
+            return DiagReturnCode::OK;
+#else
             return DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED_IN_ACTIVE_SESSION;
+#endif
         }
         default:
         {
@@ -85,6 +125,12 @@ ApplicationDefaultSession::getTransitionResult(DiagSession::SessionType const ta
         {
             return DiagSession::APPLICATION_EXTENDED_SESSION();
         }
+#ifdef PLATFORM_SUPPORT_PROGRAMMING_SESSION
+        case DiagSession::PROGRAMMING:
+        {
+            return appProgrammingSession();
+        }
+#endif
         default:
         {
             return *this;
@@ -123,7 +169,11 @@ ApplicationExtendedSession::getTransitionResult(DiagSession::SessionType const t
         }
         case DiagSession::PROGRAMMING:
         {
+#ifdef PLATFORM_SUPPORT_PROGRAMMING_SESSION
+            return appProgrammingSession();
+#else
             return DiagSession::PROGRAMMING_SESSION();
+#endif
         }
         default:
         {
@@ -165,5 +215,47 @@ DiagSession& ProgrammingSession::getTransitionResult(DiagSession::SessionType co
         }
     }
 }
+
+#ifdef PLATFORM_SUPPORT_PROGRAMMING_SESSION
+// Application Programming Session
+
+DiagReturnCode::Type
+AppProgrammingSession::isTransitionPossible(DiagSession::SessionType const targetSession)
+{
+    switch (targetSession)
+    {
+        case DiagSession::DEFAULT:
+        case DiagSession::EXTENDED:
+        case DiagSession::PROGRAMMING:
+        {
+            return DiagReturnCode::OK;
+        }
+        default:
+        {
+            return DiagReturnCode::ISO_SUBFUNCTION_NOT_SUPPORTED;
+        }
+    }
+}
+
+DiagSession&
+AppProgrammingSession::getTransitionResult(DiagSession::SessionType const targetSession)
+{
+    switch (targetSession)
+    {
+        case DiagSession::DEFAULT:
+        {
+            return DiagSession::APPLICATION_DEFAULT_SESSION();
+        }
+        case DiagSession::EXTENDED:
+        {
+            return DiagSession::APPLICATION_EXTENDED_SESSION();
+        }
+        default:
+        {
+            return *this;
+        }
+    }
+}
+#endif
 
 } // namespace uds


### PR DESCRIPTION
## Purpose of this PR
- [ ] Bugfix
- [x] New Feature
- [ ] Documentation Update
- [ ] Other

## Description

Platform independent DoCAN/UDS configuration, split out of #421 as requested: ISO 15765-4 OBD-style tester addressing (0x7E0/0x7E8, logical address 0x0600) behind PLATFORM_SUPPORT_OBD_UDS_ADDRESSING, and an application-level UDS programming session behind PLATFORM_SUPPORT_PROGRAMMING_SESSION. Platforms opt in through their Options.cmake; no platform enables the options in this PR.