### PR TITLE
Migrate referenceApp safety modules and posix main to Bazel

### DIFF
--- a/executables/referenceApp/consoleCommands/BUILD.bazel
+++ b/executables/referenceApp/consoleCommands/BUILD.bazel
@@ -1,0 +1,73 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+# Circular dependency present in Bazel when modelling the CMake PLATFORM_SUPPORT_IO conditional: console_commands -> io_support -> console_commands.
+# Split off console_commands_headers to break the circular dependency for Bazel.
+cc_library(
+    name = "console_commands_headers",
+    hdrs = [
+        "include/can/console/CanCommand.h",
+        "include/lifecycle/console/LifecycleControlCommand.h",
+        "include/lifecycle/console/StatisticsCommand.h",
+        "include/safety/console/SafetyCommand.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//executables/referenceApp/asyncBinding:async_binding",
+        "//executables/referenceApp/asyncCoreConfiguration:async_core_configuration",
+        "//executables/referenceApp/configuration",
+        "//libs/bsw/cpp2can",
+        "//libs/bsw/lifecycle",
+        "//libs/bsw/runtime",
+        "//libs/safety/safeUtils:safe_utils",
+    ],
+)
+
+cc_library(
+    name = "console_commands_io_support",
+    srcs = [
+        "src/safety/console/SafetyCommand.cpp",
+    ],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    deps = [
+        ":console_commands_headers",
+        "//executables/referenceApp/platforms/s32k148evb/safety/safeIo:safe_io",
+        "//platforms/s32k1xx/bsp/bspIo:bsp_io",
+    ],
+)
+
+cc_library(name = "console_commands_io_support_none")
+
+alias(
+    name = "io_support",
+    actual = select({
+        "//bazel/platform/constraints/soc:s32k148": ":console_commands_io_support",
+        "//conditions:default": ":console_commands_io_support_none",
+    }),
+)
+
+cc_library(
+    name = "console_commands",
+    srcs = [
+        "src/can/console/CanCommand.cpp",
+        "src/lifecycle/console/LifecycleControlCommand.cpp",
+        "src/lifecycle/console/StatisticsCommand.cpp",
+    ],
+    implementation_deps = [
+        ":io_support",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":console_commands_headers",
+    ],
+)

--- a/executables/referenceApp/platforms/posix/main/BUILD.bazel
+++ b/executables/referenceApp/platforms/posix/main/BUILD.bazel
@@ -11,6 +11,41 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(
+    name = "main",
+    srcs = [
+        "src/lifecycle/StaticBsp.cpp",
+        "src/main.cpp",
+        "src/systems/CanSystem.cpp",
+        "src/systems/TapEthernetSystem.cpp",
+    ],
+    hdrs = [
+        "include/lifecycle/StaticBsp.h",
+        "include/systems/CanSystem.h",
+        "include/systems/TapEthernetSystem.h",
+    ],
+    implementation_deps = [
+        "//executables/referenceApp/asyncBinding:async_binding",
+        "//executables/referenceApp/configuration",
+        "//executables/referenceApp/platforms/posix/ethConfiguration:eth_configuration",
+        "//executables/referenceApp/safety/safeSupervisor:safe_supervisor",
+        "//libs/bsw/lifecycle",
+        "//libs/bsw/lwipSocket:lwip_socket",
+        "//platforms/posix/bsp/bspUart:bsp_uart",
+        "//platforms/posix/bsp/socketCanTransceiver:socket_can_transceiver",
+        "//platforms/posix/bsp/tapEthernetDriver:tap_ethernet_driver",
+    ],
+    local_defines = [
+        "PLATFORM_SUPPORT_CAN=1",
+        "PLATFORM_SUPPORT_ETHERNET=1",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//platforms/posix/bsp/bspEepromDriver:bsp_eeprom_driver",
+    ],
+)
+
+cc_library(
     name = "freertos_os_hooks",
     srcs = [
         "src/osHooks/freertos/osHooks.cpp",

--- a/executables/referenceApp/platforms/posix/safety/safeLifecycle/BUILD.bazel
+++ b/executables/referenceApp/platforms/posix/safety/safeLifecycle/BUILD.bazel
@@ -1,0 +1,23 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "safe_lifecycle",
+    srcs = ["src/safeLifecycle/SafetyManager.cpp"],
+    hdrs = ["include/safeLifecycle/SafetyManager.h"],
+    implementation_deps = [
+        "//executables/referenceApp/safety/safeSupervisor:safe_supervisor",
+        "//libs/safety/safeUtils:safe_utils",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)

--- a/executables/referenceApp/platforms/s32k148evb/safety/safeMemory/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/safety/safeMemory/BUILD.bazel
@@ -1,0 +1,42 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "safe_memory",
+    srcs = [
+        "src/safeMemory/IntegrityEccHandler.cpp",
+        "src/safeMemory/MemoryProtection.cpp",
+        "src/safeMemory/RomCheck.cpp",
+        "src/safeMemory/SafeMemory.cpp",
+    ],
+    hdrs = [
+        "include/safeMemory/IntegrityEccHandler.h",
+        "include/safeMemory/MemoryLocations.h",
+        "include/safeMemory/MemoryProtection.h",
+        "include/safeMemory/ProtectedRamScopedUnlock.h",
+        "include/safeMemory/RomCheck.h",
+        "include/safeMemory/SafeMemory.h",
+        "include/safeMemory/SafetyShell.h",
+        "include/safeMemory/mpu.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//executables/referenceApp/configuration",
+        "//executables/referenceApp/safety/safeSupervisor:safe_supervisor",
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//libs/bsw/async",
+        "//libs/bsw/platform",
+        "//libs/safety/safeUtils:safe_utils",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+    ],
+)

--- a/executables/referenceApp/platforms/s32k148evb/safety/safeSystem/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/safety/safeSystem/BUILD.bazel
@@ -1,0 +1,30 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "safe_system",
+    srcs = [
+        "src/safeSystem/SafeSystem.cpp",
+    ],
+    hdrs = [
+        "include/safeSystem/SafeSystem.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//executables/referenceApp/platforms/s32k148evb/safety/safeMemory:safe_memory",
+        "//executables/referenceApp/safety/safeSupervisor:safe_supervisor",
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//platforms/s32k1xx/bsp/bspIo:bsp_io",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+    ],
+)

--- a/executables/referenceApp/safety/safeWatchdog/BUILD.bazel
+++ b/executables/referenceApp/safety/safeWatchdog/BUILD.bazel
@@ -1,0 +1,46 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "safe_watchdog_watchdog_support",
+    defines = ["PLATFORM_SUPPORT_WATCHDOG=1"],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    deps = [
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+        "//platforms/s32k1xx/safety/safeBspMcuWatchdog:safe_bsp_mcu_watchdog",
+    ],
+)
+
+cc_library(name = "safe_watchdog_watchdog_support_none")
+
+alias(
+    name = "watchdog_support",
+    actual = select({
+        "//bazel/platform/constraints/soc:s32k148": ":safe_watchdog_watchdog_support",
+        "//conditions:default": ":safe_watchdog_watchdog_support_none",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "safe_watchdog",
+    srcs = ["src/safeWatchdog/SafeWatchdog.cpp"],
+    hdrs = ["include/safeWatchdog/SafeWatchdog.h"],
+    implementation_deps = [
+        ":watchdog_support",
+        "//executables/referenceApp/safety/safeSupervisor:safe_supervisor",
+        "//libs/safety/safeUtils:safe_utils",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = ["//libs/bsw/platform"],
+)

--- a/platforms/s32k1xx/bsp/bspIo/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspIo/BUILD.bazel
@@ -25,6 +25,8 @@ cc_library(
         "//libs/3rdparty/etl",
         "//libs/bsw/bsp",
         "//libs/bsw/platform",
+        "//platforms/s32k1xx/bsp/bspAdc:bsp_adc",  # required by AnalogInput.h (transitive include) which is not in CMake target_link_libraries
+        "//platforms/s32k1xx/bsp/bspEepromDriver:bsp_eeprom_driver",  # required by EepromConfiguration.h (transitive include) which is not in CMake target_link_libraries
         "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
     ],
 )


### PR DESCRIPTION
Migrate referenceApp safety modules and posix main to Bazel

libs:
- safeMemory: safe_memory
- safeSystem: safe_system
- safeWatchdog: safe_watchdog
- safeLifecycle: safe_lifecycle
- consoleCommands: console_commands
- main: main (posix)

config points:
- watchdog_support: constraint-gated facade (PLATFORM_SUPPORT_WATCHDOG define
  + bspMcu/safeBspMcuWatchdog) for safeWatchdog
- io_support: constraint-gated facade (SafetyCommand.cpp + safeIo/bspIo) with
  console_commands_headers split, for consoleCommands

additional changes:
- bsp_io: declare bspAdc + bspEepromDriver so the bsp config headers'
  transitive #includes resolve for safe_system
