### PR TITLE
Adjust Documentation copyright

### DIFF
--- a/doc/dev/conf.py
+++ b/doc/dev/conf.py
@@ -14,7 +14,7 @@ from docutils import nodes
 
 # General configuration
 project = "Eclipse OpenBSW Documentation"
-copyright = f"{datetime.now().year} Accenture"
+copyright = f"{datetime.now().year} Eclipse OpenBSW Contributors"
 
 extensions = [
     "sphinxcontrib.jquery",


### PR DESCRIPTION
Broaden the copyright statement attached to every documentation page generated to "Eclipse OpenBSW Contributors" instead of "Accenture".