### PR TITLE
Update timeout mechanism of cluster connection

### DIFF
--- a/executables/referenceApp/middlewareConfiguration/model/deployment.yaml
+++ b/executables/referenceApp/middlewareConfiguration/model/deployment.yaml
@@ -78,7 +78,6 @@ connections:
     source_cluster: *cluster0
     target_cluster: *cluster1
     connection_type: SkeletonOnly
-    has_timeouts: False
     proxies: []
     skeletons:
       - <<: *foo
@@ -87,7 +86,6 @@ connections:
     source_cluster: *cluster1
     target_cluster: *cluster0
     connection_type: ProxyOnly
-    has_timeouts: False
     proxies:
       - <<: *foo
         max_instances: 1

--- a/libs/bsw/middleware/include/middleware/core/ClusterConnection.h
+++ b/libs/bsw/middleware/include/middleware/core/ClusterConnection.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "IClusterConnectionConfigurationBase.h"
 #include "middleware/core/ClusterConnectionBase.h"
 #include "middleware/core/IClusterConnectionConfigurationBase.h"
 #include "middleware/core/Message.h"
@@ -22,103 +23,19 @@ class ProxyBase;
 class SkeletonBase;
 
 /**
- * Cluster connection for proxy-only communication without timeout support.
- * This class provides a cluster connection that only supports proxy subscriptions,
- * without timeout management. Skeleton subscriptions are not implemented and will return
- * NotImplemented.
- */
-class ClusterConnectionNoTimeoutProxyOnly final : public ClusterConnectionBase
-{
-    using Base = ClusterConnectionBase;
-
-public:
-    /** Constructs from \p configuration. */
-    explicit ClusterConnectionNoTimeoutProxyOnly(
-        IClusterConnectionConfigurationProxyOnly& configuration);
-
-    /** \see IClusterConnection::subscribe() */
-    HRESULT subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId) final;
-
-    /** Not supported: this is a proxy-only connection. */
-    HRESULT subscribe(SkeletonBase&, uint16_t const) final { return HRESULT::NotImplemented; }
-
-    /** \see IClusterConnection::unsubscribe() */
-    void unsubscribe(ProxyBase& proxy, uint16_t const serviceId) final;
-
-    /** No-op: this is a proxy-only connection. */
-    void unsubscribe(SkeletonBase&, uint16_t const) final {}
-};
-
-/**
- * Cluster connection for skeleton-only communication without timeout support.
- * This class provides a cluster connection that only supports skeleton subscriptions,
- * without timeout management. Proxy subscriptions are not implemented and will return
- * NotImplemented.
- */
-class ClusterConnectionNoTimeoutSkeletonOnly final : public ClusterConnectionBase
-{
-    using Base = ClusterConnectionBase;
-
-public:
-    /** Constructs from \p configuration. */
-    explicit ClusterConnectionNoTimeoutSkeletonOnly(
-        IClusterConnectionConfigurationSkeletonOnly& configuration);
-
-    /** Not supported: this is a skeleton-only connection. */
-    HRESULT subscribe(ProxyBase&, uint16_t const) final { return HRESULT::NotImplemented; }
-
-    /** \see IClusterConnection::subscribe() */
-    HRESULT subscribe(SkeletonBase& skeleton, uint16_t const serviceInstanceId) final;
-
-    /** No-op: this is a skeleton-only connection. */
-    void unsubscribe(ProxyBase&, uint16_t const) final {}
-
-    /** \see IClusterConnection::unsubscribe() */
-    void unsubscribe(SkeletonBase& skeleton, uint16_t const serviceId) final;
-};
-
-/**
- * Cluster connection for bidirectional communication without timeout support.
- * This class provides a cluster connection that supports both proxy and skeleton
- * subscriptions, without timeout management. It enables full bidirectional communication
- * between clusters.
- */
-class ClusterConnectionNoTimeoutBidirectional final : public ClusterConnectionBase
-{
-    using Base = ClusterConnectionBase;
-
-public:
-    /** Constructs from \p configuration. */
-    explicit ClusterConnectionNoTimeoutBidirectional(
-        IClusterConnectionConfigurationBidirectional& configuration);
-
-    /** \see IClusterConnection::subscribe() */
-    HRESULT subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId) final;
-
-    /** \see IClusterConnection::subscribe() */
-    HRESULT subscribe(SkeletonBase& skeleton, uint16_t const serviceInstanceId) final;
-
-    /** \see IClusterConnection::unsubscribe() */
-    void unsubscribe(ProxyBase& proxy, uint16_t const serviceId) final;
-
-    /** \see IClusterConnection::unsubscribe() */
-    void unsubscribe(SkeletonBase& skeleton, uint16_t const serviceId) final;
-};
-
-/**
  * Cluster connection for bidirectional communication with timeout support.
  * This class provides a cluster connection that supports both proxy and skeleton
  * subscriptions, with timeout management capabilities. It enables full bidirectional
  * communication between clusters with timeout tracking.
  */
-class ClusterConnectionBidirectionalWithTimeout final : public ClusterConnectionTimeoutBase
+class ClusterConnectionBidirectional final : public ClusterConnectionTimeoutBase
 {
     using Base = ClusterConnectionTimeoutBase;
 
 public:
     /** Constructs from \p configuration. */
-    explicit ClusterConnectionBidirectionalWithTimeout(
-        IClusterConnectionConfigurationBidirectionalWithTimeout& configuration);
+    explicit ClusterConnectionBidirectional(
+        IClusterConnectionConfigurationBidirectional& configuration);
 
     /** \see IClusterConnection::subscribe() */
     HRESULT subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId) final;
@@ -138,14 +55,13 @@ public:
  * This class provides a cluster connection that only supports proxy subscriptions,
  * with timeout management capabilities. Skeleton subscriptions are not implemented.
  */
-class ClusterConnectionProxyOnlyWithTimeout final : public ClusterConnectionTimeoutBase
+class ClusterConnectionProxyOnly final : public ClusterConnectionTimeoutBase
 {
     using Base = ClusterConnectionTimeoutBase;
 
 public:
     /** Constructs from \p configuration. */
-    explicit ClusterConnectionProxyOnlyWithTimeout(
-        IClusterConnectionConfigurationProxyOnlyWithTimeout& configuration);
+    explicit ClusterConnectionProxyOnly(IClusterConnectionConfigurationProxyOnly& configuration);
 
     /** \see IClusterConnection::subscribe() */
     HRESULT subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId) final;
@@ -165,14 +81,14 @@ public:
  * This class provides a cluster connection that only supports skeleton subscriptions,
  * with timeout management capabilities. Proxy subscriptions are not implemented.
  */
-class ClusterConnectionSkeletonOnlyWithTimeout final : public ClusterConnectionTimeoutBase
+class ClusterConnectionSkeletonOnly final : public ClusterConnectionTimeoutBase
 {
     using Base = ClusterConnectionTimeoutBase;
 
 public:
     /** Constructs from \p configuration. */
-    explicit ClusterConnectionSkeletonOnlyWithTimeout(
-        IClusterConnectionConfigurationSkeletonOnlyWithTimeout& configuration);
+    explicit ClusterConnectionSkeletonOnly(
+        IClusterConnectionConfigurationSkeletonOnly& configuration);
 
     /** Not supported: this is a skeleton-only connection. */
     HRESULT subscribe(ProxyBase&, uint16_t const) final { return HRESULT::NotImplemented; }
@@ -204,7 +120,7 @@ struct ClusterConnectionTypeSelector;
 
 /**
  * Type selector specialization for proxy-only configurations.
- * \tparam T the proxy-only configuration type
+ * \tparam T the proxy-only with configuration type
  */
 template<typename T>
 struct ClusterConnectionTypeSelector<
@@ -213,12 +129,12 @@ struct ClusterConnectionTypeSelector<
         ::etl::is_base_of<IClusterConnectionConfigurationProxyOnly, T>::value>::type>
 {
     /** The selected cluster connection type. */
-    using type = ClusterConnectionNoTimeoutProxyOnly;
+    using type = ClusterConnectionProxyOnly;
 };
 
 /**
  * Type selector specialization for skeleton-only configurations.
- * \tparam T the skeleton-only configuration type
+ * \tparam T the skeleton-only with configuration type
  */
 template<typename T>
 struct ClusterConnectionTypeSelector<
@@ -227,7 +143,7 @@ struct ClusterConnectionTypeSelector<
         ::etl::is_base_of<IClusterConnectionConfigurationSkeletonOnly, T>::value>::type>
 {
     /** The selected cluster connection type. */
-    using type = ClusterConnectionNoTimeoutSkeletonOnly;
+    using type = ClusterConnectionSkeletonOnly;
 };
 
 /**
@@ -241,49 +157,7 @@ struct ClusterConnectionTypeSelector<
         ::etl::is_base_of<IClusterConnectionConfigurationBidirectional, T>::value>::type>
 {
     /** The selected cluster connection type. */
-    using type = ClusterConnectionNoTimeoutBidirectional;
-};
-
-/**
- * Type selector specialization for proxy-only configurations with timeout.
- * \tparam T the proxy-only with timeout configuration type
- */
-template<typename T>
-struct ClusterConnectionTypeSelector<
-    T,
-    typename ::etl::enable_if<
-        ::etl::is_base_of<IClusterConnectionConfigurationProxyOnlyWithTimeout, T>::value>::type>
-{
-    /** The selected cluster connection type. */
-    using type = ClusterConnectionProxyOnlyWithTimeout;
-};
-
-/**
- * Type selector specialization for skeleton-only configurations with timeout.
- * \tparam T the skeleton-only with timeout configuration type
- */
-template<typename T>
-struct ClusterConnectionTypeSelector<
-    T,
-    typename ::etl::enable_if<
-        ::etl::is_base_of<IClusterConnectionConfigurationSkeletonOnlyWithTimeout, T>::value>::type>
-{
-    /** The selected cluster connection type. */
-    using type = ClusterConnectionSkeletonOnlyWithTimeout;
-};
-
-/**
- * Type selector specialization for bidirectional configurations with timeout.
- * \tparam T the bidirectional with timeout configuration type
- */
-template<typename T>
-struct ClusterConnectionTypeSelector<
-    T,
-    typename ::etl::enable_if<
-        ::etl::is_base_of<IClusterConnectionConfigurationBidirectionalWithTimeout, T>::value>::type>
-{
-    /** The selected cluster connection type. */
-    using type = ClusterConnectionBidirectionalWithTimeout;
+    using type = ClusterConnectionBidirectional;
 };
 
 } // namespace middleware::core

--- a/libs/bsw/middleware/include/middleware/core/IClusterConnectionConfigurationBase.h
+++ b/libs/bsw/middleware/include/middleware/core/IClusterConnectionConfigurationBase.h
@@ -159,11 +159,12 @@ protected:
 };
 
 /**
- * Configuration interface for proxy-only cluster connections.
- * Extends the base configuration interface with proxy subscription management.
- * This interface is used by cluster connections that only support proxy communication.
+ * Configuration interface for proxy-only cluster connections with timeout support.
+ * Extends the timeout configuration interface with proxy subscription management.
+ * This interface is used by cluster connections that support proxy communication with timeout
+ * tracking.
  */
-struct IClusterConnectionConfigurationProxyOnly : public IClusterConnectionConfigurationBase
+struct IClusterConnectionConfigurationProxyOnly : public ITimeoutConfiguration
 {
     IClusterConnectionConfigurationProxyOnly(IClusterConnectionConfigurationProxyOnly const&)
         = delete;
@@ -186,41 +187,12 @@ protected:
 };
 
 /**
- * Configuration interface for skeleton-only cluster connections.
- * Extends the base configuration interface with skeleton subscription management.
- * This interface is used by cluster connections that only support skeleton communication.
- */
-struct IClusterConnectionConfigurationSkeletonOnly : public IClusterConnectionConfigurationBase
-{
-    IClusterConnectionConfigurationSkeletonOnly(IClusterConnectionConfigurationSkeletonOnly const&)
-        = delete;
-    IClusterConnectionConfigurationSkeletonOnly&
-    operator=(IClusterConnectionConfigurationSkeletonOnly const&)
-        = delete;
-    IClusterConnectionConfigurationSkeletonOnly(IClusterConnectionConfigurationSkeletonOnly&&)
-        = delete;
-    IClusterConnectionConfigurationSkeletonOnly&
-    operator=(IClusterConnectionConfigurationSkeletonOnly&&)
-        = delete;
-
-    /** Subscribes \p skeleton for \p serviceInstanceId, returns HRESULT. */
-    virtual HRESULT subscribe(SkeletonBase& skeleton, uint16_t const serviceInstanceId) = 0;
-
-    /** Unsubscribes \p skeleton for \p serviceId. */
-    virtual void unsubscribe(SkeletonBase& skeleton, uint16_t const serviceId) = 0;
-
-protected:
-    virtual ~IClusterConnectionConfigurationSkeletonOnly() = default;
-    IClusterConnectionConfigurationSkeletonOnly()          = default;
-};
-
-/**
- * Configuration interface for bidirectional cluster connections.
- * Extends the base configuration interface with both proxy and skeleton subscription
+ * Configuration interface for bidirectional cluster connections with timeout support.
+ * Extends the timeout configuration interface with both proxy and skeleton subscription
  * management. This interface is used by cluster connections that support full bidirectional
- * communication.
+ * communication with timeout tracking.
  */
-struct IClusterConnectionConfigurationBidirectional : public IClusterConnectionConfigurationBase
+struct IClusterConnectionConfigurationBidirectional : public ITimeoutConfiguration
 {
     IClusterConnectionConfigurationBidirectional(
         IClusterConnectionConfigurationBidirectional const&)
@@ -247,78 +219,8 @@ struct IClusterConnectionConfigurationBidirectional : public IClusterConnectionC
     virtual void unsubscribe(SkeletonBase& skeleton, uint16_t const serviceId) = 0;
 
 protected:
-    virtual ~IClusterConnectionConfigurationBidirectional() = default;
     IClusterConnectionConfigurationBidirectional()          = default;
-};
-
-/**
- * Configuration interface for proxy-only cluster connections with timeout support.
- * Extends the timeout configuration interface with proxy subscription management.
- * This interface is used by cluster connections that support proxy communication with timeout
- * tracking.
- */
-struct IClusterConnectionConfigurationProxyOnlyWithTimeout : public ITimeoutConfiguration
-{
-    IClusterConnectionConfigurationProxyOnlyWithTimeout(
-        IClusterConnectionConfigurationProxyOnlyWithTimeout const&)
-        = delete;
-    IClusterConnectionConfigurationProxyOnlyWithTimeout&
-    operator=(IClusterConnectionConfigurationProxyOnlyWithTimeout const&)
-        = delete;
-    IClusterConnectionConfigurationProxyOnlyWithTimeout(
-        IClusterConnectionConfigurationProxyOnlyWithTimeout&&)
-        = delete;
-    IClusterConnectionConfigurationProxyOnlyWithTimeout&
-    operator=(IClusterConnectionConfigurationProxyOnlyWithTimeout&&)
-        = delete;
-
-    /** Subscribes \p proxy for \p serviceInstanceId, returns HRESULT. */
-    virtual HRESULT subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId) = 0;
-
-    /** Unsubscribes \p proxy for \p serviceId. */
-    virtual void unsubscribe(ProxyBase& proxy, uint16_t const serviceId) = 0;
-
-protected:
-    virtual ~IClusterConnectionConfigurationProxyOnlyWithTimeout() = default;
-    IClusterConnectionConfigurationProxyOnlyWithTimeout()          = default;
-};
-
-/**
- * Configuration interface for bidirectional cluster connections with timeout support.
- * Extends the timeout configuration interface with both proxy and skeleton subscription
- * management. This interface is used by cluster connections that support full bidirectional
- * communication with timeout tracking.
- */
-struct IClusterConnectionConfigurationBidirectionalWithTimeout : public ITimeoutConfiguration
-{
-    IClusterConnectionConfigurationBidirectionalWithTimeout(
-        IClusterConnectionConfigurationBidirectionalWithTimeout const&)
-        = delete;
-    IClusterConnectionConfigurationBidirectionalWithTimeout&
-    operator=(IClusterConnectionConfigurationBidirectionalWithTimeout const&)
-        = delete;
-    IClusterConnectionConfigurationBidirectionalWithTimeout(
-        IClusterConnectionConfigurationBidirectionalWithTimeout&&)
-        = delete;
-    IClusterConnectionConfigurationBidirectionalWithTimeout&
-    operator=(IClusterConnectionConfigurationBidirectionalWithTimeout&&)
-        = delete;
-
-    /** Subscribes \p proxy for \p serviceInstanceId, returns HRESULT. */
-    virtual HRESULT subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId) = 0;
-
-    /** Unsubscribes \p proxy for \p serviceId. */
-    virtual void unsubscribe(ProxyBase& proxy, uint16_t const serviceId) = 0;
-
-    /** Subscribes \p skeleton for \p serviceInstanceId, returns HRESULT. */
-    virtual HRESULT subscribe(SkeletonBase& skeleton, uint16_t const serviceInstanceId) = 0;
-
-    /** Unsubscribes \p skeleton for \p serviceId. */
-    virtual void unsubscribe(SkeletonBase& skeleton, uint16_t const serviceId) = 0;
-
-protected:
-    IClusterConnectionConfigurationBidirectionalWithTimeout()          = default;
-    virtual ~IClusterConnectionConfigurationBidirectionalWithTimeout() = default;
+    virtual ~IClusterConnectionConfigurationBidirectional() = default;
 };
 
 /**
@@ -327,19 +229,17 @@ protected:
  * This interface is used by cluster connections that support skeleton communication with timeout
  * tracking.
  */
-struct IClusterConnectionConfigurationSkeletonOnlyWithTimeout : public ITimeoutConfiguration
+struct IClusterConnectionConfigurationSkeletonOnly : public ITimeoutConfiguration
 {
-    IClusterConnectionConfigurationSkeletonOnlyWithTimeout(
-        IClusterConnectionConfigurationSkeletonOnlyWithTimeout const&)
+    IClusterConnectionConfigurationSkeletonOnly(IClusterConnectionConfigurationSkeletonOnly const&)
         = delete;
-    IClusterConnectionConfigurationSkeletonOnlyWithTimeout&
-    operator=(IClusterConnectionConfigurationSkeletonOnlyWithTimeout const&)
+    IClusterConnectionConfigurationSkeletonOnly&
+    operator=(IClusterConnectionConfigurationSkeletonOnly const&)
         = delete;
-    IClusterConnectionConfigurationSkeletonOnlyWithTimeout(
-        IClusterConnectionConfigurationSkeletonOnlyWithTimeout&&)
+    IClusterConnectionConfigurationSkeletonOnly(IClusterConnectionConfigurationSkeletonOnly&&)
         = delete;
-    IClusterConnectionConfigurationSkeletonOnlyWithTimeout&
-    operator=(IClusterConnectionConfigurationSkeletonOnlyWithTimeout&&)
+    IClusterConnectionConfigurationSkeletonOnly&
+    operator=(IClusterConnectionConfigurationSkeletonOnly&&)
         = delete;
 
     /** Subscribes \p skeleton for \p serviceInstanceId, returns HRESULT. */
@@ -349,8 +249,8 @@ struct IClusterConnectionConfigurationSkeletonOnlyWithTimeout : public ITimeoutC
     virtual void unsubscribe(SkeletonBase& skeleton, uint16_t const serviceId) = 0;
 
 protected:
-    virtual ~IClusterConnectionConfigurationSkeletonOnlyWithTimeout() = default;
-    IClusterConnectionConfigurationSkeletonOnlyWithTimeout()          = default;
+    virtual ~IClusterConnectionConfigurationSkeletonOnly() = default;
+    IClusterConnectionConfigurationSkeletonOnly()          = default;
 };
 
 } // namespace middleware::core

--- a/libs/bsw/middleware/simulation/model/deployment-test.yaml
+++ b/libs/bsw/middleware/simulation/model/deployment-test.yaml
@@ -78,7 +78,6 @@ connections:
     source_cluster: *cluster0
     target_cluster: *cluster1
     connection_type: SkeletonOnly
-    has_timeouts: False
     proxies: []
     skeletons:
       - <<: *foo
@@ -87,7 +86,6 @@ connections:
     source_cluster: *cluster1
     target_cluster: *cluster0
     connection_type: ProxyOnly
-    has_timeouts: False
     proxies:
       - <<: *foo
         max_instances: 1

--- a/libs/bsw/middleware/src/middleware/core/ClusterConnection.cpp
+++ b/libs/bsw/middleware/src/middleware/core/ClusterConnection.cpp
@@ -16,147 +16,70 @@
 namespace middleware::core
 {
 
-ClusterConnectionNoTimeoutProxyOnly::ClusterConnectionNoTimeoutProxyOnly(
+ClusterConnectionBidirectional::ClusterConnectionBidirectional(
+    IClusterConnectionConfigurationBidirectional& configuration)
+: Base(configuration)
+{}
+
+HRESULT
+ClusterConnectionBidirectional::subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId)
+{
+    return static_cast<IClusterConnectionConfigurationBidirectional&>(Base::getConfiguration())
+        .subscribe(proxy, serviceInstanceId);
+}
+
+void ClusterConnectionBidirectional::unsubscribe(ProxyBase& proxy, uint16_t const serviceId)
+{
+    static_cast<IClusterConnectionConfigurationBidirectional&>(Base::getConfiguration())
+        .unsubscribe(proxy, serviceId);
+}
+
+HRESULT
+ClusterConnectionBidirectional::subscribe(SkeletonBase& skeleton, uint16_t const serviceInstanceId)
+{
+    return static_cast<IClusterConnectionConfigurationBidirectional&>(Base::getConfiguration())
+        .subscribe(skeleton, serviceInstanceId);
+}
+
+void ClusterConnectionBidirectional::unsubscribe(SkeletonBase& skeleton, uint16_t const serviceId)
+{
+    static_cast<IClusterConnectionConfigurationBidirectional&>(Base::getConfiguration())
+        .unsubscribe(skeleton, serviceId);
+}
+
+ClusterConnectionProxyOnly::ClusterConnectionProxyOnly(
     IClusterConnectionConfigurationProxyOnly& configuration)
 : Base(configuration)
 {}
 
 HRESULT
-ClusterConnectionNoTimeoutProxyOnly::subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId)
+ClusterConnectionProxyOnly::subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId)
 {
     return static_cast<IClusterConnectionConfigurationProxyOnly&>(Base::getConfiguration())
         .subscribe(proxy, serviceInstanceId);
 }
 
-void ClusterConnectionNoTimeoutProxyOnly::unsubscribe(ProxyBase& proxy, uint16_t const serviceId)
+void ClusterConnectionProxyOnly::unsubscribe(ProxyBase& proxy, uint16_t const serviceId)
 {
     static_cast<IClusterConnectionConfigurationProxyOnly&>(Base::getConfiguration())
         .unsubscribe(proxy, serviceId);
 }
 
-ClusterConnectionNoTimeoutSkeletonOnly::ClusterConnectionNoTimeoutSkeletonOnly(
+ClusterConnectionSkeletonOnly::ClusterConnectionSkeletonOnly(
     IClusterConnectionConfigurationSkeletonOnly& configuration)
 : Base(configuration)
 {}
 
-HRESULT ClusterConnectionNoTimeoutSkeletonOnly::subscribe(
-    SkeletonBase& skeleton, uint16_t const serviceInstanceId)
+HRESULT
+ClusterConnectionSkeletonOnly::subscribe(SkeletonBase& skeleton, uint16_t const serviceInstanceId)
 {
     return static_cast<IClusterConnectionConfigurationSkeletonOnly&>(Base::getConfiguration())
         .subscribe(skeleton, serviceInstanceId);
 }
 
-void ClusterConnectionNoTimeoutSkeletonOnly::unsubscribe(
-    SkeletonBase& skeleton, uint16_t const serviceId)
+void ClusterConnectionSkeletonOnly::unsubscribe(SkeletonBase& skeleton, uint16_t const serviceId)
 {
     static_cast<IClusterConnectionConfigurationSkeletonOnly&>(Base::getConfiguration())
-        .unsubscribe(skeleton, serviceId);
-}
-
-ClusterConnectionNoTimeoutBidirectional::ClusterConnectionNoTimeoutBidirectional(
-    IClusterConnectionConfigurationBidirectional& configuration)
-: Base(configuration)
-{}
-
-HRESULT ClusterConnectionNoTimeoutBidirectional::subscribe(
-    ProxyBase& proxy, uint16_t const serviceInstanceId)
-{
-    return static_cast<IClusterConnectionConfigurationBidirectional&>(Base::getConfiguration())
-        .subscribe(proxy, serviceInstanceId);
-}
-
-HRESULT ClusterConnectionNoTimeoutBidirectional::subscribe(
-    SkeletonBase& skeleton, uint16_t const serviceInstanceId)
-{
-    return static_cast<IClusterConnectionConfigurationBidirectional&>(Base::getConfiguration())
-        .subscribe(skeleton, serviceInstanceId);
-}
-
-void ClusterConnectionNoTimeoutBidirectional::unsubscribe(
-    ProxyBase& proxy, uint16_t const serviceId)
-{
-    static_cast<IClusterConnectionConfigurationBidirectional&>(Base::getConfiguration())
-        .unsubscribe(proxy, serviceId);
-}
-
-void ClusterConnectionNoTimeoutBidirectional::unsubscribe(
-    SkeletonBase& skeleton, uint16_t const serviceId)
-{
-    static_cast<IClusterConnectionConfigurationBidirectional&>(Base::getConfiguration())
-        .unsubscribe(skeleton, serviceId);
-}
-
-ClusterConnectionBidirectionalWithTimeout::ClusterConnectionBidirectionalWithTimeout(
-    IClusterConnectionConfigurationBidirectionalWithTimeout& configuration)
-: Base(configuration)
-{}
-
-HRESULT ClusterConnectionBidirectionalWithTimeout::subscribe(
-    ProxyBase& proxy, uint16_t const serviceInstanceId)
-{
-    return static_cast<IClusterConnectionConfigurationBidirectionalWithTimeout&>(
-               Base::getConfiguration())
-        .subscribe(proxy, serviceInstanceId);
-}
-
-void ClusterConnectionBidirectionalWithTimeout::unsubscribe(
-    ProxyBase& proxy, uint16_t const serviceId)
-{
-    static_cast<IClusterConnectionConfigurationBidirectionalWithTimeout&>(Base::getConfiguration())
-        .unsubscribe(proxy, serviceId);
-}
-
-HRESULT ClusterConnectionBidirectionalWithTimeout::subscribe(
-    SkeletonBase& skeleton, uint16_t const serviceInstanceId)
-{
-    return static_cast<IClusterConnectionConfigurationBidirectionalWithTimeout&>(
-               Base::getConfiguration())
-        .subscribe(skeleton, serviceInstanceId);
-}
-
-void ClusterConnectionBidirectionalWithTimeout::unsubscribe(
-    SkeletonBase& skeleton, uint16_t const serviceId)
-{
-    static_cast<IClusterConnectionConfigurationBidirectionalWithTimeout&>(Base::getConfiguration())
-        .unsubscribe(skeleton, serviceId);
-}
-
-ClusterConnectionProxyOnlyWithTimeout::ClusterConnectionProxyOnlyWithTimeout(
-    IClusterConnectionConfigurationProxyOnlyWithTimeout& configuration)
-: Base(configuration)
-{}
-
-HRESULT
-ClusterConnectionProxyOnlyWithTimeout::subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId)
-{
-    return static_cast<IClusterConnectionConfigurationProxyOnlyWithTimeout&>(
-               Base::getConfiguration())
-        .subscribe(proxy, serviceInstanceId);
-}
-
-void ClusterConnectionProxyOnlyWithTimeout::unsubscribe(ProxyBase& proxy, uint16_t const serviceId)
-{
-    static_cast<IClusterConnectionConfigurationProxyOnlyWithTimeout&>(Base::getConfiguration())
-        .unsubscribe(proxy, serviceId);
-}
-
-ClusterConnectionSkeletonOnlyWithTimeout::ClusterConnectionSkeletonOnlyWithTimeout(
-    IClusterConnectionConfigurationSkeletonOnlyWithTimeout& configuration)
-: Base(configuration)
-{}
-
-HRESULT ClusterConnectionSkeletonOnlyWithTimeout::subscribe(
-    SkeletonBase& skeleton, uint16_t const serviceInstanceId)
-{
-    return static_cast<IClusterConnectionConfigurationSkeletonOnlyWithTimeout&>(
-               Base::getConfiguration())
-        .subscribe(skeleton, serviceInstanceId);
-}
-
-void ClusterConnectionSkeletonOnlyWithTimeout::unsubscribe(
-    SkeletonBase& skeleton, uint16_t const serviceId)
-{
-    static_cast<IClusterConnectionConfigurationSkeletonOnlyWithTimeout&>(Base::getConfiguration())
         .unsubscribe(skeleton, serviceId);
 }
 

--- a/libs/bsw/middleware/test/src/core/ConnectionTest.cpp
+++ b/libs/bsw/middleware/test/src/core/ConnectionTest.cpp
@@ -107,115 +107,6 @@ private:
 struct ClusterConnectionConfigurationProxyOnlyMock
 : public IClusterConnectionConfigurationProxyOnly
 , ClusterConfigurationMockBase
-{
-    HRESULT subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId) override
-    {
-        return ClusterConfigurationMockBase::subscribe(proxy, serviceInstanceId);
-    }
-
-    void unsubscribe(ProxyBase&, uint16_t const) override {}
-
-    HRESULT dispatchMessage(Message const& msg) const override
-    {
-        return ClusterConfigurationMockBase::dispatchMessage(msg);
-    }
-
-    uint8_t getSourceClusterId() const override
-    {
-        return ClusterConfigurationMockBase::getSourceClusterId();
-    }
-
-    uint8_t getTargetClusterId() const override
-    {
-        return ClusterConfigurationMockBase::getTargetClusterId();
-    }
-
-    bool write(Message const& msg) const override
-    {
-        return ClusterConfigurationMockBase::write(msg);
-    }
-
-    std::size_t registeredTransceiversCount(uint16_t const) const override { return 0; }
-};
-
-struct ClusterConnectionConfigurationSkeletonOnlyMock
-: public IClusterConnectionConfigurationSkeletonOnly
-, ClusterConfigurationMockBase
-{
-    HRESULT subscribe(SkeletonBase& skeleton, uint16_t const serviceInstanceId) override
-    {
-        return ClusterConfigurationMockBase::subscribe(skeleton, serviceInstanceId);
-    }
-
-    void unsubscribe(SkeletonBase&, uint16_t const) override {}
-
-    HRESULT dispatchMessage(Message const& msg) const override
-    {
-        return ClusterConfigurationMockBase::dispatchMessage(msg);
-    }
-
-    uint8_t getSourceClusterId() const override
-    {
-        return ClusterConfigurationMockBase::getSourceClusterId();
-    }
-
-    uint8_t getTargetClusterId() const override
-    {
-        return ClusterConfigurationMockBase::getTargetClusterId();
-    }
-
-    bool write(Message const& msg) const override
-    {
-        return ClusterConfigurationMockBase::write(msg);
-    }
-
-    std::size_t registeredTransceiversCount(uint16_t const) const override { return 0; }
-};
-
-struct ClusterConnectionConfigurationBidirectionalMock
-: public IClusterConnectionConfigurationBidirectional
-, ClusterConfigurationMockBase
-{
-    HRESULT subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId) override
-    {
-        return ClusterConfigurationMockBase::subscribe(proxy, serviceInstanceId);
-    }
-
-    void unsubscribe(ProxyBase&, uint16_t const) override {}
-
-    HRESULT subscribe(SkeletonBase& skeleton, uint16_t const serviceInstanceId) override
-    {
-        return ClusterConfigurationMockBase::subscribe(skeleton, serviceInstanceId);
-    }
-
-    void unsubscribe(SkeletonBase&, uint16_t const) override {}
-
-    HRESULT dispatchMessage(Message const& msg) const override
-    {
-        return ClusterConfigurationMockBase::dispatchMessage(msg);
-    }
-
-    uint8_t getSourceClusterId() const override
-    {
-        return ClusterConfigurationMockBase::getSourceClusterId();
-    }
-
-    uint8_t getTargetClusterId() const override
-    {
-        return ClusterConfigurationMockBase::getTargetClusterId();
-    }
-
-    bool write(Message const& msg) const override
-    {
-        return ClusterConfigurationMockBase::write(msg);
-    }
-
-    std::size_t registeredTransceiversCount(uint16_t const) const override { return 0; }
-};
-
-struct ClusterConnectionConfigurationProxyOnlyTimeoutMock
-: public IClusterConnectionConfigurationProxyOnlyWithTimeout
-, ClusterConfigurationMockBase
 , TimeoutTransceiverCounter
 {
     HRESULT subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId) override
@@ -257,8 +148,8 @@ struct ClusterConnectionConfigurationProxyOnlyTimeoutMock
     void updateTimeouts() override { TimeoutTransceiverCounter::updateTimeouts(); }
 };
 
-struct ClusterConnectionConfigurationSkeletonOnlyTimeoutMock
-: public IClusterConnectionConfigurationSkeletonOnlyWithTimeout
+struct ClusterConnectionConfigurationSkeletonOnlyMock
+: public IClusterConnectionConfigurationSkeletonOnly
 , ClusterConfigurationMockBase
 , TimeoutTransceiverCounter
 {
@@ -304,8 +195,8 @@ struct ClusterConnectionConfigurationSkeletonOnlyTimeoutMock
     void updateTimeouts() override { TimeoutTransceiverCounter::updateTimeouts(); }
 };
 
-struct ClusterConnectionConfigurationBidirectionalTimeoutMock
-: public IClusterConnectionConfigurationBidirectionalWithTimeout
+struct ClusterConnectionConfigurationBidirectionalMock
+: public IClusterConnectionConfigurationBidirectional
 , ClusterConfigurationMockBase
 , TimeoutTransceiverCounter
 {
@@ -379,32 +270,18 @@ TEST_F(ConnectionBaseTest, ConnectionsNotImplemented)
     Skeleton skeletonInstance(1, 2);
 
     ClusterConnectionConfigurationProxyOnlyMock confProxyOnly;
-    ClusterConnectionNoTimeoutProxyOnly connectionProxyOnly(confProxyOnly);
+    ClusterConnectionProxyOnly connectionProxyOnly(confProxyOnly);
     EXPECT_EQ(
         ::middleware::core::HRESULT::NotImplemented,
         connectionProxyOnly.subscribe(skeletonInstance, 123));
     EXPECT_NO_THROW(connectionProxyOnly.unsubscribe(skeletonInstance, 123));
 
     ClusterConnectionConfigurationSkeletonOnlyMock confSkeletonOnly;
-    ClusterConnectionNoTimeoutSkeletonOnly connectionSkeletonOnly(confSkeletonOnly);
+    ClusterConnectionSkeletonOnly connectionSkeletonOnly(confSkeletonOnly);
     EXPECT_EQ(
         ::middleware::core::HRESULT::NotImplemented,
         connectionSkeletonOnly.subscribe(proxyInstance, 123));
     EXPECT_NO_THROW(connectionSkeletonOnly.unsubscribe(proxyInstance, 123));
-
-    ClusterConnectionConfigurationProxyOnlyTimeoutMock confProxyOnlyTimeout;
-    ClusterConnectionProxyOnlyWithTimeout connectionProxyOnlyTimeout(confProxyOnlyTimeout);
-    EXPECT_EQ(
-        ::middleware::core::HRESULT::NotImplemented,
-        connectionProxyOnlyTimeout.subscribe(skeletonInstance, 123));
-    EXPECT_NO_THROW(connectionProxyOnlyTimeout.unsubscribe(skeletonInstance, 123));
-
-    ClusterConnectionConfigurationSkeletonOnlyTimeoutMock confSkeletonOnlyTimeout;
-    ClusterConnectionSkeletonOnlyWithTimeout connectionSkeletonOnlyTimeout(confSkeletonOnlyTimeout);
-    EXPECT_EQ(
-        ::middleware::core::HRESULT::NotImplemented,
-        connectionSkeletonOnlyTimeout.subscribe(proxyInstance, 123));
-    EXPECT_NO_THROW(connectionSkeletonOnlyTimeout.unsubscribe(proxyInstance, 123));
 }
 
 TEST_F(ConnectionBaseTest, SubscribeUnsubscribeProxyOnly)
@@ -412,7 +289,7 @@ TEST_F(ConnectionBaseTest, SubscribeUnsubscribeProxyOnly)
     Proxy proxyInstance(1, 2, 4);
     ClusterConnectionConfigurationProxyOnlyMock confProxyOnly;
 
-    ClusterConnectionNoTimeoutProxyOnly connectionProxyOnly(confProxyOnly);
+    ClusterConnectionProxyOnly connectionProxyOnly(confProxyOnly);
     EXPECT_EQ(::middleware::core::HRESULT::Ok, connectionProxyOnly.subscribe(proxyInstance, 1));
     EXPECT_NO_THROW(connectionProxyOnly.unsubscribe(proxyInstance, 1));
 }
@@ -422,7 +299,7 @@ TEST_F(ConnectionBaseTest, SubscribeUnsubscribeSkeletonOnly)
     Skeleton skeletonInstance(1, 2);
     ClusterConnectionConfigurationSkeletonOnlyMock confSkeletonOnly;
 
-    ClusterConnectionNoTimeoutSkeletonOnly connectionSkeletonOnly(confSkeletonOnly);
+    ClusterConnectionSkeletonOnly connectionSkeletonOnly(confSkeletonOnly);
     EXPECT_EQ(
         ::middleware::core::HRESULT::Ok, connectionSkeletonOnly.subscribe(skeletonInstance, 1));
     EXPECT_NO_THROW(connectionSkeletonOnly.unsubscribe(skeletonInstance, 1));
@@ -434,42 +311,7 @@ TEST_F(ConnectionBaseTest, SubscribeUnsubscribeBidirectional)
     Skeleton skeletonInstance(1, 2);
     ClusterConnectionConfigurationBidirectionalMock confBidirectional;
 
-    ClusterConnectionNoTimeoutBidirectional connectionBidirectional(confBidirectional);
-    EXPECT_EQ(
-        ::middleware::core::HRESULT::Ok, connectionBidirectional.subscribe(skeletonInstance, 1));
-    EXPECT_EQ(::middleware::core::HRESULT::Ok, connectionBidirectional.subscribe(proxyInstance, 1));
-    EXPECT_NO_THROW(connectionBidirectional.unsubscribe(skeletonInstance, 1));
-    EXPECT_NO_THROW(connectionBidirectional.unsubscribe(proxyInstance, 1));
-}
-
-TEST_F(ConnectionBaseTest, SubscribeUnsubscribeProxyOnlyWithTimeout)
-{
-    Proxy proxyInstance(1, 2, 4);
-    ClusterConnectionConfigurationProxyOnlyTimeoutMock confProxyOnlyTimeout;
-
-    ClusterConnectionProxyOnlyWithTimeout connectionProxyOnly(confProxyOnlyTimeout);
-    EXPECT_EQ(::middleware::core::HRESULT::Ok, connectionProxyOnly.subscribe(proxyInstance, 1));
-    EXPECT_NO_THROW(connectionProxyOnly.unsubscribe(proxyInstance, 1));
-}
-
-TEST_F(ConnectionBaseTest, SubscribeUnsubscribeSkeletonOnlyWithTimeout)
-{
-    Skeleton skeletonInstance(1, 2);
-    ClusterConnectionConfigurationSkeletonOnlyTimeoutMock confSkeletonOnlyTimeout;
-
-    ClusterConnectionSkeletonOnlyWithTimeout connectionSkeletonOnly(confSkeletonOnlyTimeout);
-    EXPECT_EQ(
-        ::middleware::core::HRESULT::Ok, connectionSkeletonOnly.subscribe(skeletonInstance, 1));
-    EXPECT_NO_THROW(connectionSkeletonOnly.unsubscribe(skeletonInstance, 1));
-}
-
-TEST_F(ConnectionBaseTest, SubscribeUnsubscribeBidirectionalWithTimeout)
-{
-    Proxy proxyInstance(1, 2, 4);
-    Skeleton skeletonInstance(1, 2);
-    ClusterConnectionConfigurationBidirectionalTimeoutMock confBidirectionalTimeout;
-
-    ClusterConnectionBidirectionalWithTimeout connectionBidirectional(confBidirectionalTimeout);
+    ClusterConnectionBidirectional connectionBidirectional(confBidirectional);
     EXPECT_EQ(
         ::middleware::core::HRESULT::Ok, connectionBidirectional.subscribe(skeletonInstance, 1));
     EXPECT_EQ(::middleware::core::HRESULT::Ok, connectionBidirectional.subscribe(proxyInstance, 1));
@@ -703,10 +545,9 @@ TEST_F(ConnectionBaseTest, processMessageFromReceivingSide)
 TEST_F(ConnectionBaseTest, ProxyRegistersAsTimeoutTransceiver)
 {
     ProxyWithTimeout proxyInstance(1, 2);
-    ClusterConnectionConfigurationSkeletonOnlyTimeoutMock confSkeletonOnly;
+    ClusterConnectionConfigurationSkeletonOnlyMock confSkeletonOnly;
     ::middleware::core::ClusterConnectionTypeSelector<
-        ClusterConnectionConfigurationSkeletonOnlyTimeoutMock>::type
-        actualConnection(confSkeletonOnly);
+        ClusterConnectionConfigurationSkeletonOnlyMock>::type actualConnection(confSkeletonOnly);
 
     EXPECT_NO_THROW(actualConnection.registerTimeoutTransceiver(proxyInstance));
     EXPECT_EQ(1, actualConnection.registeredTransceiversCount(1));

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_connections_srcCluster_to_tgtCluster.h.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_connections_srcCluster_to_tgtCluster.h.jinja
@@ -129,7 +129,6 @@ public:
 {% endif %}
     }
 
-{% if connection.has_timeouts %}
     void registerTimeoutTransceiver(core::ITimeoutHandler& transceiver) final
     {
         core::ITimeoutConfiguration::registerTimeoutTransceiver(transceiver, timeoutTransceivers_);
@@ -142,7 +141,6 @@ public:
 
     void updateTimeouts() final { core::ITimeoutConfiguration::updateTimeouts(timeoutTransceivers_); }
 
-{% endif %}
 {% if connection.proxies|length > 0 %}
     [[nodiscard]] core::HRESULT subscribe(core::ProxyBase& proxy, uint16_t serviceInstanceId) final
     {
@@ -180,9 +178,7 @@ public:
     {% for skeleton in connection.skeletons %}
     ::etl::vector<core::TransceiverBase*, {{skeleton.max_instances}}U> {{skeleton.namespace|replace("::", "")}}{{skeleton.name}}SkeletonTransceivers_;
     {% endfor %}
-    {% if connection.has_timeouts %}
-    ::etl::vector<core::ITimeoutHandler*, {{connection.proxies|length}}U> timeoutTransceivers_;
-    {% endif %}
+    ::etl::vector<core::ITimeoutHandler*, {{[connection.proxies|length,1]| max}}U> timeoutTransceivers_;
     {% if connection.proxies|length > 0 %}
     ::etl::array<core::meta::TransceiverContainer, {{connection.proxies|length}}U> proxyTransceivers_;
     {% endif %}

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.cpp.jinja
@@ -72,7 +72,7 @@ void process{{cluster.name}}Cluster(size_t messages, const bool updateTimeouts)
 
 void update{{cluster.name}}ClusterTimeouts()
 {
-{% for connection in connections if connection.source_cluster.name == cluster.name and connection.has_timeouts %}
+{% for connection in connections if connection.source_cluster.name == cluster.name %}
     ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}.updateTimeouts();
 {% endfor %}
 }

--- a/libs/bsw/middleware/tools/cpp_generator/templates/schemas/deployment.yaml
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/schemas/deployment.yaml
@@ -551,7 +551,6 @@ definitions:
       - source_cluster
       - target_cluster
       - connection_type
-      - has_timeouts
       - proxies
       - skeletons
     properties:
@@ -569,9 +568,6 @@ definitions:
           - "SkeletonOnlyWithTimeout"
           - "Bidirectional"
           - "BidirectionalWithTimeout"
-      has_timeouts:
-        type: boolean
-        description: "Whether this connection supports timeouts"
       proxies:
         type: array
         description: "Services consumed over this connection"


### PR DESCRIPTION
# Overview
This PR refactors the cluster connection timeout mechanism by removing the distinction between connections with and without timeout support. All cluster connections now uniformly support timeouts, simplifying the architecture and reducing code duplication.

# Key Changes

## 1. **Consolidation of Cluster Connection Classes**
The PR eliminates separate class variants and consolidates them into unified implementations:

### Removed Classes
- `ClusterConnectionNoTimeoutProxyOnly` - proxy-only without timeout
- `ClusterConnectionNoTimeoutSkeletonOnly` - skeleton-only without timeout
- `ClusterConnectionNoTimeoutBidirectional` - bidirectional without timeout
- `ClusterConnectionProxyOnlyWithTimeout` - proxy-only with timeout
- `ClusterConnectionSkeletonOnlyWithTimeout` - skeleton-only with timeout
- `ClusterConnectionBidirectionalWithTimeout` - bidirectional with timeout

### New Unified Classes
- `ClusterConnectionProxyOnly` - now always with timeout support
- `ClusterConnectionSkeletonOnly` - now always with timeout support
- `ClusterConnectionBidirectional` - now always with timeout support

## 2. **Configuration Interface Simplification**
All cluster connection configuration interfaces now inherit from `ITimeoutConfiguration` instead of `IClusterConnectionConfigurationBase`:

- `IClusterConnectionConfigurationProxyOnly` - now extends `ITimeoutConfiguration`
- `IClusterConnectionConfigurationSkeletonOnly` - now extends `ITimeoutConfiguration`
- `IClusterConnectionConfigurationBidirectional` - now extends `ITimeoutConfiguration`

Removed interfaces:
- `IClusterConnectionConfigurationProxyOnlyWithTimeout`
- `IClusterConnectionConfigurationSkeletonOnlyWithTimeout`
- `IClusterConnectionConfigurationBidirectionalWithTimeout`

## 3. **Template Updates (Jinja2)**
Removed conditional logic that checked `connection.has_timeouts`:

**File**: `cluster_connections_srcCluster_to_tgtCluster.h.jinja`
- Removed `{% if connection.has_timeouts %}` conditional blocks
- Timeout methods (`registerTimeoutTransceiver()`, `updateTimeouts()`) are now always generated
- Fixed timeout transceiver vector sizing: uses `max(connection.proxies|length, 1)` to ensure minimum size

**File**: `cluster_srcCluster.cpp.jinja`
- Updated connection filtering to remove `has_timeouts` check
- All connections now call `updateTimeouts()` method

## 4. **YAML Configuration Changes**
Removed the `has_timeouts` boolean field from deployment configurations:

**Files affected**:
- `executables/referenceApp/middlewareConfiguration/model/deployment.yaml`
- `libs/bsw/middleware/simulation/model/deployment-test.yaml`

**Schema changes** (`deployment.yaml` schema):
- Removed `has_timeouts` from required fields
- Removed `has_timeouts` property definition
- Connection types still support variants: ProxyOnly, SkeletonOnly, Bidirectional (with or without "WithTimeout" suffix for backward compatibility in schema)

## 5. **Type Selector Updates**
The `ClusterConnectionTypeSelector` template specializations have been updated:

- Proxy-only specialization now maps to `ClusterConnectionProxyOnly`
- Skeleton-only specialization now maps to `ClusterConnectionSkeletonOnly`
- Bidirectional specialization now maps to `ClusterConnectionBidirectional`
- Removed specializations for `WithTimeout` variants

## 6. **Test Updates**
Test mocks have been consolidated to reflect the new unified class hierarchy:

**Removed mock classes**:
- Separate mocks for timeout and non-timeout variants

**Consolidated mocks**:
- `ClusterConnectionConfigurationProxyOnlyMock` - now with timeout support
- `ClusterConnectionConfigurationSkeletonOnlyMock` - now with timeout support
- `ClusterConnectionConfigurationBidirectionalMock` - now with timeout support

**Removed tests**:
- Tests specifically for non-timeout variants have been removed
- Tests for timeout-only variants have been consolidated

**Updated tests**:
- All connection type tests now use unified class names
- Mock configurations inherit from both configuration interface and `TimeoutTransceiverCounter`
