### PR TITLE
Add bazel support for libs/bsw mock targets

### DIFF
--- a/executables/referenceApp/asyncBinding/BUILD.bazel
+++ b/executables/referenceApp/asyncBinding/BUILD.bazel
@@ -15,7 +15,11 @@ cc_library(
     hdrs = ["include/async/AsyncBinding.h"],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
-    deps = ["//libs/bsw/runtime"],
+    deps = [
+        "//libs/bsw/async:async_headers",
+        "//libs/bsw/async:async_platform",
+        "//libs/bsw/runtime",
+    ],
 )
 
 cc_library(

--- a/libs/3rdparty/freeRtos/BUILD.bazel
+++ b/libs/3rdparty/freeRtos/BUILD.bazel
@@ -105,3 +105,24 @@ cc_library(
         "//libs/bsw/platform",
     ],
 )
+
+cc_library(
+    name = "freertos_mock",
+    testonly = True,
+    srcs = ["mock/src/os/FreeRtosMock.cpp"],
+    hdrs = [
+        "mock/include/FreeRTOS.h",
+        "mock/include/event_groups.h",
+        "mock/include/os/FreeRtosMock.h",
+        "mock/include/task.h",
+        "mock/include/timers.h",
+    ],
+    strip_include_prefix = "mock/include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/etl",
+        "//libs/3rdparty/googletest:gtest",
+        "//libs/bsw/asyncFreeRtos:freertos_configuration",
+        "//libs/bsw/platform",
+    ],
+)

--- a/libs/bsw/async/BUILD.bazel
+++ b/libs/bsw/async/BUILD.bazel
@@ -73,7 +73,6 @@ cc_library(
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
-        ":async_platform",
         "//libs/3rdparty/etl",
     ],
 )
@@ -84,5 +83,39 @@ cc_library(
     deps = [
         ":async_binding",
         ":async_headers",
+        ":async_platform",
     ],
+)
+
+cc_library(
+    name = "async_mock",
+    testonly = True,
+    hdrs = [
+        "mock/gmock/include/async/AsyncMock.h",
+        "mock/gmock/include/async/LockMock.h",
+        "mock/gmock/include/async/RunnableMock.h",
+        "mock/gmock/include/async/TestContext.h",
+        "mock/gmock/include/async/TimeoutMock.h",
+        "mock/gmock/include/async/Types.h",
+    ],
+    strip_include_prefix = "mock/gmock/include",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":async_headers",
+        "//libs/3rdparty/etl",
+        "//libs/3rdparty/googletest:gtest",
+        "//libs/bsw/platform",
+    ],
+)
+
+cc_library(
+    name = "async_mock_impl",
+    testonly = True,
+    srcs = [
+        "mock/gmock/src/async/AsyncMock.cpp",
+        "mock/gmock/src/async/TestContext.cpp",
+        "mock/gmock/src/async/Types.cpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":async_mock"],
 )

--- a/libs/bsw/asyncImpl/BUILD.bazel
+++ b/libs/bsw/asyncImpl/BUILD.bazel
@@ -27,3 +27,18 @@ cc_library(
         "//libs/bsw/platform",
     ],
 )
+
+cc_library(
+    name = "async_impl_mock",
+    testonly = True,
+    hdrs = [
+        "mock/include/async/RunnableMock.h",
+    ],
+    strip_include_prefix = "mock/include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/googletest:gtest",
+        "//libs/bsw/asyncImpl:async_impl",
+        "//libs/bsw/platform",
+    ],
+)

--- a/libs/bsw/bsp/BUILD.bazel
+++ b/libs/bsw/bsp/BUILD.bazel
@@ -21,3 +21,30 @@ cc_library(
         "//libs/bsw/platform",
     ],
 )
+
+cc_library(
+    name = "bsp_mock",
+    testonly = True,
+    srcs = [
+        "mock/src/bsp/timer/SystemTimerMock.cpp",
+    ],
+    hdrs = [
+        "mock/include/bsp/Uart.h",
+        "mock/include/bsp/can/canTransceiver/CanPhyMock.h",
+        "mock/include/bsp/eeprom/EepromDriverMock.h",
+        "mock/include/bsp/eepromemulation/EepromEmulationDriverMock.h",
+        "mock/include/bsp/flash/FlashDriverMock.h",
+        "mock/include/bsp/flash/FlashMock.h",
+        "mock/include/bsp/power/EcuPowerStateControllerMock.h",
+        "mock/include/bsp/timer/SystemTimerMock.h",
+        "mock/include/inputManager/DigitalInput.h",
+        "mock/include/outputManager/Output.h",
+    ],
+    strip_include_prefix = "mock/include",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bsp",
+        "//libs/3rdparty/etl",
+        "//libs/3rdparty/googletest:gtest_main",
+    ],
+)

--- a/libs/bsw/io/BUILD.bazel
+++ b/libs/bsw/io/BUILD.bazel
@@ -33,3 +33,19 @@ cc_library(
         "//libs/bsw/util",
     ],
 )
+
+cc_library(
+    name = "io_mock",
+    testonly = True,
+    hdrs = [
+        "mock/include/io/IReaderMock.h",
+        "mock/include/io/IWriterMock.h",
+    ],
+    strip_include_prefix = "mock/include",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":io",
+        "//libs/3rdparty/etl",
+        "//libs/3rdparty/googletest:gtest_main",
+    ],
+)

--- a/libs/bsw/io/examples/BUILD.bazel
+++ b/libs/bsw/io/examples/BUILD.bazel
@@ -12,8 +12,16 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(
     name = "io_examples",
-    #TODO: Complete the deps and srcs here once libs/3rdparty/googletest is migrated to bazel
+    srcs = [
+        "BufferedWriterExample.cpp",
+        "ForwardingReaderExample.cpp",
+        "JoinReaderExample.cpp",
+        "MemoryQueueExample.cpp",
+        "SplitWriterExample.cpp",
+        "VariantQueueExample.cpp",
+    ],
     implementation_deps = [
+        "//libs/3rdparty/googletest:gtest_main",
         "//libs/bsw/io",
     ],
 )

--- a/libs/bsw/lifecycle/BUILD.bazel
+++ b/libs/bsw/lifecycle/BUILD.bazel
@@ -30,3 +30,20 @@ cc_library(
         "//libs/bsw/util",
     ],
 )
+
+cc_library(
+    name = "lifecycle_mock",
+    testonly = True,
+    hdrs = [
+        "mock/gmock/include/lifecycle/LifecycleComponentCallbackMock.h",
+        "mock/gmock/include/lifecycle/LifecycleComponentMock.h",
+        "mock/gmock/include/lifecycle/LifecycleListenerMock.h",
+        "mock/gmock/include/lifecycle/LifecycleManagerMock.h",
+    ],
+    strip_include_prefix = "mock/gmock/include",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":lifecycle",
+        "//libs/3rdparty/googletest:gtest",
+    ],
+)

--- a/libs/bsw/lifecycle/examples/BUILD.bazel
+++ b/libs/bsw/lifecycle/examples/BUILD.bazel
@@ -12,11 +12,12 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(
     name = "lifecycle_examples",
+    testonly = True,
     srcs = ["src/examples.cpp"],
     hdrs = ["include/example.h"],
     implementation_deps = [
+        "//libs/bsw/async:async_mock",
         "//libs/bsw/lifecycle",
-        # TODO: migrate asyncMock unit test to Bazel, then add the dependency here.
     ],
     strip_include_prefix = "include",
 )

--- a/libs/bsw/logger/BUILD.bazel
+++ b/libs/bsw/logger/BUILD.bazel
@@ -23,3 +23,19 @@ cc_library(
         "//libs/bsw/util",
     ],
 )
+
+cc_library(
+    name = "logger_mock",
+    testonly = True,
+    hdrs = [
+        "mock/include/logger/PersistenceManagerMock.h",
+    ],
+    strip_include_prefix = "mock/include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs/3rdparty/googletest:gtest_main",
+        "//libs/bsw/bsp:bsp_mock",
+        "//libs/bsw/logger",
+        "//libs/bsw/util:util_mock",
+    ],
+)

--- a/libs/bsw/util/BUILD.bazel
+++ b/libs/bsw/util/BUILD.bazel
@@ -21,3 +21,29 @@ cc_library(
         "//libs/bsw/platform",
     ],
 )
+
+cc_library(
+    name = "util_mock",
+    testonly = True,
+    srcs = [
+        "mock/gmock/src/util/StdIoMock.cpp",
+        "mock/gmock/src/util/logger/TestConsoleLogger.cpp",
+    ],
+    hdrs = [
+        "mock/gmock/include/util/StdIoMock.h",
+        "mock/gmock/include/util/estd/function_mock.h",
+        "mock/gmock/include/util/estd/gtest_extensions.h",
+        "mock/gmock/include/util/logger/ComponentMappingMock.h",
+        "mock/gmock/include/util/logger/LoggerOutputMock.h",
+        "mock/gmock/include/util/logger/TestConsoleLogger.h",
+        "mock/gmock/include/util/stream/OutputStreamMock.h",
+        "mock/gmock/include/util/stream/SharedOutputStreamMock.h",
+    ],
+    strip_include_prefix = "mock/gmock/include",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":util",
+        "//libs/3rdparty/etl",
+        "//libs/3rdparty/googletest:gtest",
+    ],
+)


### PR DESCRIPTION
Add bazel support for libs/bsw mock targets

//libs/3rdparty/freeRtos:freertos_mock
//libs/bsw/util:util_mock
//libs/bsw/asyncImpl:async_impl_mock
//libs/bsw/async:async_mock
//libs/bsw/async:async_mock_impl
//libs/bsw/bsp:bsp_mock
//libs/bsw/io:io_mock
//libs/bsw/logger:logger_mock
//libs/bsw/lifecycle:lifecycle_mock
