### PR TITLE
Use etl::infinite_loop consistently

### DIFF
--- a/executables/referenceApp/consoleCommands/CMakeLists.txt
+++ b/executables/referenceApp/consoleCommands/CMakeLists.txt
@@ -22,7 +22,8 @@ target_link_libraries(
            runtime
            configuration
            cpp2can
-           safeUtils)
+           safeUtils
+           etl)
 
 if (PLATFORM_SUPPORT_IO)
     target_link_libraries(consoleCommands PRIVATE safeIo bspIo)

--- a/executables/referenceApp/consoleCommands/src/safety/console/SafetyCommand.cpp
+++ b/executables/referenceApp/consoleCommands/src/safety/console/SafetyCommand.cpp
@@ -13,6 +13,8 @@
 #include <io/Io.h>
 #include <safeUtils/SafetyLogger.h>
 
+#include <etl/infinite_loop.h>
+
 #include <cstdio>
 
 extern uint32_t __MPU_BSS_START[];
@@ -61,8 +63,7 @@ void SafetyCommand::executeCommand(::util::command::CommandContext&, uint8_t idx
         {
             // Using printf, because a regular logger call would not finish before reset.
             printf("Enter infinite loop to trigger watchdog reset\n");
-            while (true) {}
-            break;
+            etl::infinite_loop();
         }
         case ID_PRT:
         {

--- a/executables/referenceApp/platforms/posix/main/BUILD.bazel
+++ b/executables/referenceApp/platforms/posix/main/BUILD.bazel
@@ -51,6 +51,7 @@ cc_library(
         "src/osHooks/freertos/osHooks.cpp",
     ],
     implementation_deps = [
+        "//libs/3rdparty/etl",
         "//libs/3rdparty/freeRtos:freertos_headers",
     ],
     target_compatible_with = ["@platforms//os:linux"],

--- a/executables/referenceApp/platforms/posix/main/CMakeLists.txt
+++ b/executables/referenceApp/platforms/posix/main/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(
 
 if (BUILD_TARGET_RTOS STREQUAL "FREERTOS")
     add_library(osHooks src/osHooks/freertos/osHooks.cpp)
-    target_link_libraries(osHooks PRIVATE freeRtos)
+    target_link_libraries(osHooks PRIVATE freeRtos etl)
 elseif (BUILD_TARGET_RTOS STREQUAL "THREADX")
     add_library(osHooks src/osHooks/threadx/osHooks.cpp)
     target_link_libraries(osHooks PRIVATE threadX)

--- a/executables/referenceApp/platforms/posix/main/src/osHooks/freertos/osHooks.cpp
+++ b/executables/referenceApp/platforms/posix/main/src/osHooks/freertos/osHooks.cpp
@@ -11,11 +11,13 @@
 #include "FreeRTOS.h"
 #include "task.h"
 
+#include <etl/infinite_loop.h>
+
 extern "C"
 {
 void vApplicationStackOverflowHook(TaskHandle_t /* xTask */, char* /* pcTaskName */)
 {
-    while (true) {}
+    etl::infinite_loop();
 }
 
 } // extern "C"

--- a/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
@@ -41,6 +41,7 @@ cc_library(
         "src/osHooks/freertos/osHooks.cpp",
     ],
     implementation_deps = [
+        "//libs/3rdparty/etl",
         "//libs/3rdparty/freeRtos:freertos_headers",
         "//libs/bsw/common",
     ],
@@ -57,6 +58,7 @@ cc_library(
         "include/osHooks/threadx/osHooks.h",
     ],
     implementation_deps = [
+        "//libs/3rdparty/etl",
         "//libs/3rdparty/threadx:threadx_headers",
         "//libs/bsw/asyncThreadX:threadx_configuration",
         "//libs/bsw/common",

--- a/executables/referenceApp/platforms/s32k148evb/main/src/os/isr/isr_erm.cpp
+++ b/executables/referenceApp/platforms/s32k148evb/main/src/os/isr/isr_erm.cpp
@@ -8,6 +8,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+#include <etl/infinite_loop.h>
+
 #include <cstdio>
 
 extern "C"
@@ -16,7 +18,7 @@ void ERM_double_fault_IRQHandler()
 {
     printf("ERM_double_fault_IRQHandler\r\n");
     // uncorrectable double bit ECC fault was detected in SRAM
-    while (true) {}
+    etl::infinite_loop();
 }
 
 } // extern "C"

--- a/executables/referenceApp/platforms/s32k148evb/main/src/os/isr/isr_ftfc.cpp
+++ b/executables/referenceApp/platforms/s32k148evb/main/src/os/isr/isr_ftfc.cpp
@@ -8,6 +8,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+#include <etl/infinite_loop.h>
+
 #include <cstdio>
 
 extern "C"
@@ -16,7 +18,7 @@ void FTFC_Fault_IRQHandler()
 {
     printf("FTFC_Fault_IRQHandler\r\n");
     // uncorrectable double bit ECC fault was detected in Flash
-    while (true) {}
+    etl::infinite_loop();
 }
 
 } // extern "C"

--- a/executables/referenceApp/platforms/s32k148evb/main/src/os/isr/isr_sys.cpp
+++ b/executables/referenceApp/platforms/s32k148evb/main/src/os/isr/isr_sys.cpp
@@ -12,6 +12,8 @@
 
 #include <safeMemory/SafeMemory.h>
 
+#include <etl/infinite_loop.h>
+
 #include <cstdio>
 
 extern "C"
@@ -25,7 +27,7 @@ void HardFault_Handler()
 #ifndef UNIT_TEST
     asm volatile("b customHardFaultHandler");
 #else
-    while (true) {}
+    etl::infinite_loop();
 #endif
 }
 
@@ -34,21 +36,21 @@ void HardFault_Handler_Final()
     printf("HardFault_Handler_Final\r\n");
     ::safety::safe_memory::checkEccErrors();
     softwareSystemReset();
-    while (true) {}
+    etl::infinite_loop();
 }
 
 void BusFault_Handler()
 {
     printf("BusFault_Handler\r\n");
     softwareSystemReset();
-    while (true) {}
+    etl::infinite_loop();
 }
 
 void UsageFault_Handler()
 {
     printf("UsageFault_Handler\r\n");
     softwareSystemReset();
-    while (true) {}
+    etl::infinite_loop();
 }
 
 } // extern "C"

--- a/executables/referenceApp/platforms/s32k148evb/main/src/osHooks/freertos/osHooks.cpp
+++ b/executables/referenceApp/platforms/s32k148evb/main/src/osHooks/freertos/osHooks.cpp
@@ -11,6 +11,8 @@
 #include "FreeRTOS.h"
 #include "task.h"
 
+#include <etl/infinite_loop.h>
+
 #include <cstdio>
 
 extern "C"
@@ -23,7 +25,6 @@ void vApplicationStackOverflowHook(TaskHandle_t /* xTask */, char* /* pcTaskName
 void vIllegalISR()
 {
     printf("vIllegalISR\r\n");
-    for (;;)
-        ;
+    etl::infinite_loop();
 }
 }

--- a/executables/referenceApp/platforms/s32k148evb/main/src/osHooks/threadx/osHooks.cpp
+++ b/executables/referenceApp/platforms/s32k148evb/main/src/osHooks/threadx/osHooks.cpp
@@ -14,6 +14,8 @@
 #include "async/Hook.h"
 #include "tx_api.h"
 
+#include <etl/infinite_loop.h>
+
 #include <cstdio>
 
 extern "C"
@@ -53,7 +55,6 @@ void tx_low_power_exit() {}
 void vIllegalISR()
 {
     printf("vIllegalISR\r\n");
-    for (;;)
-        ;
+    etl::infinite_loop();
 }
 }

--- a/platforms/s32k1xx/bsp/bspClock/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspClock/BUILD.bazel
@@ -16,6 +16,7 @@ cc_library(
     hdrs = ["include/clock/clockConfig.h"],
     implementation_deps = [
         "//bazel/config/bsp:bsp_configuration",
+        "//libs/3rdparty/etl",
         "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
     ],
     strip_include_prefix = "include",

--- a/platforms/s32k1xx/bsp/bspClock/CMakeLists.txt
+++ b/platforms/s32k1xx/bsp/bspClock/CMakeLists.txt
@@ -2,4 +2,4 @@ add_library(bspClock src/clockConfig.cpp)
 
 target_include_directories(bspClock PUBLIC include)
 
-target_link_libraries(bspClock PRIVATE bspConfiguration bspMcu)
+target_link_libraries(bspClock PRIVATE bspConfiguration bspMcu etl)

--- a/platforms/s32k1xx/bsp/bspClock/src/clockConfig.cpp
+++ b/platforms/s32k1xx/bsp/bspClock/src/clockConfig.cpp
@@ -18,6 +18,8 @@
 
 #include <platform/estdint.h>
 
+#include <etl/infinite_loop.h>
+
 #ifdef SCG_SPLLCSR_SPLLEN_MASK
 #define PLL_AVAILABLE 1
 #else
@@ -416,7 +418,7 @@ void fircOff()
     }
     else
     {
-        while (true) {} // panic!
+        etl::infinite_loop(); // panic!
     }
 }
 
@@ -428,7 +430,7 @@ void extOscOff()
     }
     else
     {
-        while (true) {} // panic!
+        etl::infinite_loop(); // panic!
     }
 }
 
@@ -440,7 +442,7 @@ void pllOff()
     }
     else
     {
-        while (true) {} // panic!
+        etl::infinite_loop(); // panic!
     }
 }
 
@@ -503,7 +505,7 @@ void systemClock2Pll()
 
     spllSysClk();
 #else
-    while (true) {} // panic!
+    etl::infinite_loop(); // panic!
 #endif // PLL_AVAILABLE
 }
 } // extern "C"


### PR DESCRIPTION
Before C++26, an empty infinite loop without side effects is considered undefined behaviour and may be optimised away. This utility uses a compiler memory barrier to prevent that optimisation.

See [P2809R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2809r1.html) for background.