### PR TITLE
Fix ETL_ASSERT hang by resetting the ECU explicitly

### DIFF
--- a/executables/referenceApp/application/src/main.cpp
+++ b/executables/referenceApp/application/src/main.cpp
@@ -10,30 +10,30 @@
 
 #include "app/app.h"
 
+#include "reset/softwareSystemReset.h"
+
 #include <etl/error_handler.h>
+#include <etl/platform.h>
+#include <etl/print.h>
 
-#if defined(__linux__) || defined(__APPLE__)
-#include <cstdlib>
-#include <iostream>
-#if __has_include("execinfo.h")
-#include <execinfo.h>
-#endif
+#include <cstdint>
 
-void etl_assert_function(etl::exception const& exception)
+/**
+ * Reports a failed ETL_ASSERT and resets the ECU.
+ *
+ * etl_profile.h defines ETL_MINIMAL_ERRORS, so what(), file_name() and line_number() of the
+ * exception carry no information. The return address is printed instead, which resolves back
+ * to the ETL_ASSERT call site with addr2line against the ELF of the same build.
+ *
+ * The reset is explicit rather than left to the watchdog, because the watchdog is serviced
+ * from TASK_SAFETY, which keeps running when a lower priority task stops. See #575.
+ */
+ETL_NORETURN void etl_assert_function(etl::exception const&)
 {
-#if __has_include("execinfo.h")
-    void* callstack[128];
-    backtrace_symbols_fd(callstack, backtrace(callstack, 128), 2 /* = stderr */);
-#endif
-    std::cout << "Assertion at " << exception.file_name() << ':' << exception.line_number() << " ("
-              << exception.what() << ") failed" << std::endl;
-    std::abort();
+    etl::print(
+        "ETL_ASSERT failed at {:#x}\r\n", reinterpret_cast<uintptr_t>(__builtin_return_address(0)));
+    softwareSystemReset();
 }
-#else // defined(__linux__) || defined(__APPLE__)
-#include <cstdlib>
-
-void etl_assert_function(etl::exception const&) { std::abort(); }
-#endif
 
 void app_main()
 {


### PR DESCRIPTION
`etl_assert_function()` called `std::abort()`, which on the bare metal targets ends in newlib's `_exit()`, a two byte branch to itself. The asserting task spins forever. Recovery was expected from the hardware watchdog, but the watchdog is serviced from `TASK_SAFETY`, the highest priority application task, which keeps running while a lower priority task is stuck, so no reset happens. Details and measurements are in #575.

This calls `softwareSystemReset()` directly, matching `HardFault_Handler_Final` in `isr_sys.cpp` and `libs/rust/panic_handler/src/lib.rs`.

The `__linux__` split is dropped because `softwareSystemReset()` exists on all four platforms. `ETL_MINIMAL_ERRORS` leaves `what()`, `file_name()` and `line_number()` empty, so the return address is printed instead; `addr2line` resolves it against the ELF from the same build.

On POSIX the exit code changes from 134 to 0, because `platforms/posix/bsp/bspMcu/src/reset/softwareSystemReset.cpp` is `terminal_cleanup(); _exit(0);`. Nothing observes it today: `test/pyTest/process_mgmt.py` relaunches on `returncode is not None` without reading the value, and no pytest sends `lc assert`.

Dropping `std::abort()` also removes the `raise(SIGABRT)` chain, so `_kill` and `_getpid` leave the link. Two of the six `not implemented` warnings in #511 disappear. Text grows by 1792 bytes (260532 to 262324) for the `etl::print` call.

No unit test: `application/src/main.cpp` is not built by any `tests-*` preset.

Verified: `s32k148-freertos-gcc` and `posix-freertos` build; `lc assert` on POSIX prints `ETL_ASSERT failed at 0x...`; `arm-none-eabi-nm` shows `abort`, `raise`, `_exit`, `_kill` and `_getpid` all gone; cr_checker passes. I have no S32K148 board, so this is not verified on hardware.

Resolves #575. See also #511.
