### PR TITLE
Clean cluster connections

### DIFF
--- a/executables/referenceApp/middlewareConfiguration/model/deployment.yaml
+++ b/executables/referenceApp/middlewareConfiguration/model/deployment.yaml
@@ -77,7 +77,6 @@ connections:
   - &cluster0_cluster1
     source_cluster: *cluster0
     target_cluster: *cluster1
-    connection_type: SkeletonOnly
     proxies: []
     skeletons:
       - <<: *foo
@@ -85,7 +84,6 @@ connections:
   - &cluster1_cluster0
     source_cluster: *cluster1
     target_cluster: *cluster0
-    connection_type: ProxyOnly
     proxies:
       - <<: *foo
         max_instances: 1

--- a/libs/bsw/middleware/include/middleware/core/ClusterConnection.h
+++ b/libs/bsw/middleware/include/middleware/core/ClusterConnection.h
@@ -15,27 +15,24 @@
 #include "middleware/core/IClusterConnectionConfigurationBase.h"
 #include "middleware/core/Message.h"
 
-#include <etl/type_traits.h>
-
 namespace middleware::core
 {
 class ProxyBase;
 class SkeletonBase;
 
 /**
- * Cluster connection for bidirectional communication with timeout support.
- * This class provides a cluster connection that supports both proxy and skeleton
- * subscriptions, with timeout management capabilities. It enables full bidirectional
- * communication between clusters with timeout tracking.
+ * Unified cluster connection with timeout support.
+ *
+ * This class forwards proxy/skeleton subscribe operations to a unified configuration
+ * object, independent from the underlying connection topology.
  */
-class ClusterConnectionBidirectional final : public ClusterConnectionTimeoutBase
+class ClusterConnection final : public ClusterConnectionTimeoutBase
 {
     using Base = ClusterConnectionTimeoutBase;
 
 public:
     /** Constructs from \p configuration. */
-    explicit ClusterConnectionBidirectional(
-        IClusterConnectionConfigurationBidirectional& configuration);
+    explicit ClusterConnection(IClusterConnectionConfiguration& configuration);
 
     /** \see IClusterConnection::subscribe() */
     HRESULT subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId) final;
@@ -48,116 +45,6 @@ public:
 
     /** \see IClusterConnection::unsubscribe() */
     void unsubscribe(SkeletonBase& skeleton, uint16_t const serviceId) final;
-};
-
-/**
- * Cluster connection for proxy-only communication with timeout support.
- * This class provides a cluster connection that only supports proxy subscriptions,
- * with timeout management capabilities. Skeleton subscriptions are not implemented.
- */
-class ClusterConnectionProxyOnly final : public ClusterConnectionTimeoutBase
-{
-    using Base = ClusterConnectionTimeoutBase;
-
-public:
-    /** Constructs from \p configuration. */
-    explicit ClusterConnectionProxyOnly(IClusterConnectionConfigurationProxyOnly& configuration);
-
-    /** \see IClusterConnection::subscribe() */
-    HRESULT subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId) final;
-
-    /** Not supported: this is a proxy-only connection. */
-    HRESULT subscribe(SkeletonBase&, uint16_t const) final { return HRESULT::NotImplemented; }
-
-    /** \see IClusterConnection::unsubscribe() */
-    void unsubscribe(ProxyBase& proxy, uint16_t const serviceId) final;
-
-    /** No-op: this is a proxy-only connection. */
-    void unsubscribe(SkeletonBase&, uint16_t const) final {}
-};
-
-/**
- * Cluster connection for skeleton-only communication with timeout support.
- * This class provides a cluster connection that only supports skeleton subscriptions,
- * with timeout management capabilities. Proxy subscriptions are not implemented.
- */
-class ClusterConnectionSkeletonOnly final : public ClusterConnectionTimeoutBase
-{
-    using Base = ClusterConnectionTimeoutBase;
-
-public:
-    /** Constructs from \p configuration. */
-    explicit ClusterConnectionSkeletonOnly(
-        IClusterConnectionConfigurationSkeletonOnly& configuration);
-
-    /** Not supported: this is a skeleton-only connection. */
-    HRESULT subscribe(ProxyBase&, uint16_t const) final { return HRESULT::NotImplemented; }
-
-    /** \see IClusterConnection::subscribe() */
-    HRESULT subscribe(SkeletonBase&, uint16_t const) final;
-
-    /** No-op: this is a skeleton-only connection. */
-    void
-    unsubscribe([[maybe_unused]] ProxyBase& proxy, [[maybe_unused]] uint16_t const serviceId) final
-    {}
-
-    /** \see IClusterConnection::unsubscribe() */
-    void unsubscribe(SkeletonBase&, [[maybe_unused]] uint16_t const) final;
-};
-
-/**
- * Type selector for cluster connection implementations.
- * This template struct selects the appropriate cluster connection type based on the
- * configuration type provided. It uses SFINAE (Substitution Failure Is Not An Error) with
- * enable_if to select the correct specialization. Instantiation without a valid configuration
- * type will lead to a compilation error by design.
- *
- * \tparam T the configuration type
- * \tparam Specialization SFINAE enabler parameter
- */
-template<typename T, typename Specialization = void>
-struct ClusterConnectionTypeSelector;
-
-/**
- * Type selector specialization for proxy-only configurations.
- * \tparam T the proxy-only with configuration type
- */
-template<typename T>
-struct ClusterConnectionTypeSelector<
-    T,
-    typename ::etl::enable_if<
-        ::etl::is_base_of<IClusterConnectionConfigurationProxyOnly, T>::value>::type>
-{
-    /** The selected cluster connection type. */
-    using type = ClusterConnectionProxyOnly;
-};
-
-/**
- * Type selector specialization for skeleton-only configurations.
- * \tparam T the skeleton-only with configuration type
- */
-template<typename T>
-struct ClusterConnectionTypeSelector<
-    T,
-    typename ::etl::enable_if<
-        ::etl::is_base_of<IClusterConnectionConfigurationSkeletonOnly, T>::value>::type>
-{
-    /** The selected cluster connection type. */
-    using type = ClusterConnectionSkeletonOnly;
-};
-
-/**
- * Type selector specialization for bidirectional configurations.
- * \tparam T the bidirectional configuration type
- */
-template<typename T>
-struct ClusterConnectionTypeSelector<
-    T,
-    typename ::etl::enable_if<
-        ::etl::is_base_of<IClusterConnectionConfigurationBidirectional, T>::value>::type>
-{
-    /** The selected cluster connection type. */
-    using type = ClusterConnectionBidirectional;
 };
 
 } // namespace middleware::core

--- a/libs/bsw/middleware/include/middleware/core/IClusterConnectionConfigurationBase.h
+++ b/libs/bsw/middleware/include/middleware/core/IClusterConnectionConfigurationBase.h
@@ -25,7 +25,7 @@ class SkeletonBase;
 namespace meta
 {
 struct TransceiverContainer;
-}
+} // namespace meta
 
 /**
  * Base interface for cluster connection configurations.
@@ -159,52 +159,18 @@ protected:
 };
 
 /**
- * Configuration interface for proxy-only cluster connections with timeout support.
- * Extends the timeout configuration interface with proxy subscription management.
- * This interface is used by cluster connections that support proxy communication with timeout
- * tracking.
+ * Unified configuration interface for cluster connections with timeout support.
+ *
+ * A single configuration type is used for all connection topologies. Implementations
+ * may return HRESULT::NotImplemented or no-op for unsupported subscribe/unsubscribe
+ * directions.
  */
-struct IClusterConnectionConfigurationProxyOnly : public ITimeoutConfiguration
+struct IClusterConnectionConfiguration : public ITimeoutConfiguration
 {
-    IClusterConnectionConfigurationProxyOnly(IClusterConnectionConfigurationProxyOnly const&)
-        = delete;
-    IClusterConnectionConfigurationProxyOnly&
-    operator=(IClusterConnectionConfigurationProxyOnly const&)
-        = delete;
-    IClusterConnectionConfigurationProxyOnly(IClusterConnectionConfigurationProxyOnly&&) = delete;
-    IClusterConnectionConfigurationProxyOnly& operator=(IClusterConnectionConfigurationProxyOnly&&)
-        = delete;
-
-    /** Subscribes \p proxy for \p serviceInstanceId, returns HRESULT. */
-    virtual HRESULT subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId) = 0;
-
-    /** Unsubscribes \p proxy for \p serviceId. */
-    virtual void unsubscribe(ProxyBase& proxy, uint16_t const serviceId) = 0;
-
-protected:
-    virtual ~IClusterConnectionConfigurationProxyOnly() = default;
-    IClusterConnectionConfigurationProxyOnly()          = default;
-};
-
-/**
- * Configuration interface for bidirectional cluster connections with timeout support.
- * Extends the timeout configuration interface with both proxy and skeleton subscription
- * management. This interface is used by cluster connections that support full bidirectional
- * communication with timeout tracking.
- */
-struct IClusterConnectionConfigurationBidirectional : public ITimeoutConfiguration
-{
-    IClusterConnectionConfigurationBidirectional(
-        IClusterConnectionConfigurationBidirectional const&)
-        = delete;
-    IClusterConnectionConfigurationBidirectional&
-    operator=(IClusterConnectionConfigurationBidirectional const&)
-        = delete;
-    IClusterConnectionConfigurationBidirectional(IClusterConnectionConfigurationBidirectional&&)
-        = delete;
-    IClusterConnectionConfigurationBidirectional&
-    operator=(IClusterConnectionConfigurationBidirectional&&)
-        = delete;
+    IClusterConnectionConfiguration(IClusterConnectionConfiguration const&)            = delete;
+    IClusterConnectionConfiguration& operator=(IClusterConnectionConfiguration const&) = delete;
+    IClusterConnectionConfiguration(IClusterConnectionConfiguration&&)                 = delete;
+    IClusterConnectionConfiguration& operator=(IClusterConnectionConfiguration&&)      = delete;
 
     /** Subscribes \p proxy for \p serviceInstanceId, returns HRESULT. */
     virtual HRESULT subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId) = 0;
@@ -219,38 +185,8 @@ struct IClusterConnectionConfigurationBidirectional : public ITimeoutConfigurati
     virtual void unsubscribe(SkeletonBase& skeleton, uint16_t const serviceId) = 0;
 
 protected:
-    IClusterConnectionConfigurationBidirectional()          = default;
-    virtual ~IClusterConnectionConfigurationBidirectional() = default;
-};
-
-/**
- * Configuration interface for skeleton-only cluster connections with timeout support.
- * Extends the timeout configuration interface with skeleton subscription management.
- * This interface is used by cluster connections that support skeleton communication with timeout
- * tracking.
- */
-struct IClusterConnectionConfigurationSkeletonOnly : public ITimeoutConfiguration
-{
-    IClusterConnectionConfigurationSkeletonOnly(IClusterConnectionConfigurationSkeletonOnly const&)
-        = delete;
-    IClusterConnectionConfigurationSkeletonOnly&
-    operator=(IClusterConnectionConfigurationSkeletonOnly const&)
-        = delete;
-    IClusterConnectionConfigurationSkeletonOnly(IClusterConnectionConfigurationSkeletonOnly&&)
-        = delete;
-    IClusterConnectionConfigurationSkeletonOnly&
-    operator=(IClusterConnectionConfigurationSkeletonOnly&&)
-        = delete;
-
-    /** Subscribes \p skeleton for \p serviceInstanceId, returns HRESULT. */
-    virtual HRESULT subscribe(SkeletonBase& skeleton, uint16_t const serviceInstanceId) = 0;
-
-    /** Unsubscribes \p skeleton for \p serviceId. */
-    virtual void unsubscribe(SkeletonBase& skeleton, uint16_t const serviceId) = 0;
-
-protected:
-    virtual ~IClusterConnectionConfigurationSkeletonOnly() = default;
-    IClusterConnectionConfigurationSkeletonOnly()          = default;
+    virtual ~IClusterConnectionConfiguration() = default;
+    IClusterConnectionConfiguration()          = default;
 };
 
 } // namespace middleware::core

--- a/libs/bsw/middleware/simulation/model/deployment-test.yaml
+++ b/libs/bsw/middleware/simulation/model/deployment-test.yaml
@@ -77,7 +77,6 @@ connections:
   - &cluster0_cluster1
     source_cluster: *cluster0
     target_cluster: *cluster1
-    connection_type: SkeletonOnly
     proxies: []
     skeletons:
       - <<: *foo
@@ -85,7 +84,6 @@ connections:
   - &cluster1_cluster0
     source_cluster: *cluster1
     target_cluster: *cluster0
-    connection_type: ProxyOnly
     proxies:
       - <<: *foo
         max_instances: 1

--- a/libs/bsw/middleware/src/middleware/core/ClusterConnection.cpp
+++ b/libs/bsw/middleware/src/middleware/core/ClusterConnection.cpp
@@ -16,70 +16,31 @@
 namespace middleware::core
 {
 
-ClusterConnectionBidirectional::ClusterConnectionBidirectional(
-    IClusterConnectionConfigurationBidirectional& configuration)
+ClusterConnection::ClusterConnection(IClusterConnectionConfiguration& configuration)
 : Base(configuration)
 {}
 
-HRESULT
-ClusterConnectionBidirectional::subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId)
+HRESULT ClusterConnection::subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId)
 {
-    return static_cast<IClusterConnectionConfigurationBidirectional&>(Base::getConfiguration())
+    return static_cast<IClusterConnectionConfiguration&>(Base::getConfiguration())
         .subscribe(proxy, serviceInstanceId);
 }
 
-void ClusterConnectionBidirectional::unsubscribe(ProxyBase& proxy, uint16_t const serviceId)
+void ClusterConnection::unsubscribe(ProxyBase& proxy, uint16_t const serviceId)
 {
-    static_cast<IClusterConnectionConfigurationBidirectional&>(Base::getConfiguration())
+    static_cast<IClusterConnectionConfiguration&>(Base::getConfiguration())
         .unsubscribe(proxy, serviceId);
 }
 
-HRESULT
-ClusterConnectionBidirectional::subscribe(SkeletonBase& skeleton, uint16_t const serviceInstanceId)
+HRESULT ClusterConnection::subscribe(SkeletonBase& skeleton, uint16_t const serviceInstanceId)
 {
-    return static_cast<IClusterConnectionConfigurationBidirectional&>(Base::getConfiguration())
+    return static_cast<IClusterConnectionConfiguration&>(Base::getConfiguration())
         .subscribe(skeleton, serviceInstanceId);
 }
 
-void ClusterConnectionBidirectional::unsubscribe(SkeletonBase& skeleton, uint16_t const serviceId)
+void ClusterConnection::unsubscribe(SkeletonBase& skeleton, uint16_t const serviceId)
 {
-    static_cast<IClusterConnectionConfigurationBidirectional&>(Base::getConfiguration())
-        .unsubscribe(skeleton, serviceId);
-}
-
-ClusterConnectionProxyOnly::ClusterConnectionProxyOnly(
-    IClusterConnectionConfigurationProxyOnly& configuration)
-: Base(configuration)
-{}
-
-HRESULT
-ClusterConnectionProxyOnly::subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId)
-{
-    return static_cast<IClusterConnectionConfigurationProxyOnly&>(Base::getConfiguration())
-        .subscribe(proxy, serviceInstanceId);
-}
-
-void ClusterConnectionProxyOnly::unsubscribe(ProxyBase& proxy, uint16_t const serviceId)
-{
-    static_cast<IClusterConnectionConfigurationProxyOnly&>(Base::getConfiguration())
-        .unsubscribe(proxy, serviceId);
-}
-
-ClusterConnectionSkeletonOnly::ClusterConnectionSkeletonOnly(
-    IClusterConnectionConfigurationSkeletonOnly& configuration)
-: Base(configuration)
-{}
-
-HRESULT
-ClusterConnectionSkeletonOnly::subscribe(SkeletonBase& skeleton, uint16_t const serviceInstanceId)
-{
-    return static_cast<IClusterConnectionConfigurationSkeletonOnly&>(Base::getConfiguration())
-        .subscribe(skeleton, serviceInstanceId);
-}
-
-void ClusterConnectionSkeletonOnly::unsubscribe(SkeletonBase& skeleton, uint16_t const serviceId)
-{
-    static_cast<IClusterConnectionConfigurationSkeletonOnly&>(Base::getConfiguration())
+    static_cast<IClusterConnectionConfiguration&>(Base::getConfiguration())
         .unsubscribe(skeleton, serviceId);
 }
 

--- a/libs/bsw/middleware/test/src/core/ConnectionTest.cpp
+++ b/libs/bsw/middleware/test/src/core/ConnectionTest.cpp
@@ -78,15 +78,6 @@ private:
     mutable ::etl::optional<::middleware::core::Message> messageReceived;
 };
 
-struct ProxyWithTimeout
-: public Proxy
-, public ::middleware::core::ITimeoutHandler
-{
-    using Proxy::Proxy;
-
-    void updateTimeouts() override {}
-};
-
 struct TimeoutTransceiverCounter
 {
     void up() { _cnt++; }
@@ -104,99 +95,8 @@ private:
     bool _triggered{false};
 };
 
-struct ClusterConnectionConfigurationProxyOnlyMock
-: public IClusterConnectionConfigurationProxyOnly
-, ClusterConfigurationMockBase
-, TimeoutTransceiverCounter
-{
-    HRESULT subscribe(ProxyBase& proxy, uint16_t const serviceInstanceId) override
-    {
-        return ClusterConfigurationMockBase::subscribe(proxy, serviceInstanceId);
-    }
-
-    void unsubscribe(ProxyBase&, uint16_t const) override {}
-
-    HRESULT dispatchMessage(Message const& msg) const override
-    {
-        return ClusterConfigurationMockBase::dispatchMessage(msg);
-    }
-
-    uint8_t getSourceClusterId() const override
-    {
-        return ClusterConfigurationMockBase::getSourceClusterId();
-    }
-
-    uint8_t getTargetClusterId() const override
-    {
-        return ClusterConfigurationMockBase::getTargetClusterId();
-    }
-
-    bool write(Message const& msg) const override
-    {
-        return ClusterConfigurationMockBase::write(msg);
-    }
-
-    std::size_t registeredTransceiversCount(uint16_t const) const override { return 0; }
-
-    void registerTimeoutTransceiver(ITimeoutHandler&) override { TimeoutTransceiverCounter::up(); }
-
-    void unregisterTimeoutTransceiver(ITimeoutHandler&) override
-    {
-        TimeoutTransceiverCounter::down();
-    }
-
-    void updateTimeouts() override { TimeoutTransceiverCounter::updateTimeouts(); }
-};
-
-struct ClusterConnectionConfigurationSkeletonOnlyMock
-: public IClusterConnectionConfigurationSkeletonOnly
-, ClusterConfigurationMockBase
-, TimeoutTransceiverCounter
-{
-    HRESULT subscribe(SkeletonBase& skeleton, uint16_t const serviceInstanceId) override
-    {
-        return ClusterConfigurationMockBase::subscribe(skeleton, serviceInstanceId);
-    }
-
-    void unsubscribe(SkeletonBase&, uint16_t const) override {}
-
-    HRESULT dispatchMessage(Message const& msg) const override
-    {
-        return ClusterConfigurationMockBase::dispatchMessage(msg);
-    }
-
-    uint8_t getSourceClusterId() const override
-    {
-        return ClusterConfigurationMockBase::getSourceClusterId();
-    }
-
-    uint8_t getTargetClusterId() const override
-    {
-        return ClusterConfigurationMockBase::getTargetClusterId();
-    }
-
-    bool write(Message const& msg) const override
-    {
-        return ClusterConfigurationMockBase::write(msg);
-    }
-
-    std::size_t registeredTransceiversCount(uint16_t const) const override
-    {
-        return TimeoutTransceiverCounter::getValue();
-    }
-
-    void registerTimeoutTransceiver(ITimeoutHandler&) override { TimeoutTransceiverCounter::up(); }
-
-    void unregisterTimeoutTransceiver(ITimeoutHandler&) override
-    {
-        TimeoutTransceiverCounter::down();
-    }
-
-    void updateTimeouts() override { TimeoutTransceiverCounter::updateTimeouts(); }
-};
-
-struct ClusterConnectionConfigurationBidirectionalMock
-: public IClusterConnectionConfigurationBidirectional
+struct ClusterConnectionConfigurationMock
+: public IClusterConnectionConfiguration
 , ClusterConfigurationMockBase
 , TimeoutTransceiverCounter
 {
@@ -259,64 +159,37 @@ public:
     middleware::logger::test::DslLogger _loggerMock{};
 };
 
-/* Testing final method implementations, implemented in the base classes,
- * not meant to be supported on the public interfaces.
- *
- * For instance: subscribing with a skeleton on a Proxy-Only class
- */
-TEST_F(ConnectionBaseTest, ConnectionsNotImplemented)
-{
-    Proxy proxyInstance(1, 2, 4);
-    Skeleton skeletonInstance(1, 2);
-
-    ClusterConnectionConfigurationProxyOnlyMock confProxyOnly;
-    ClusterConnectionProxyOnly connectionProxyOnly(confProxyOnly);
-    EXPECT_EQ(
-        ::middleware::core::HRESULT::NotImplemented,
-        connectionProxyOnly.subscribe(skeletonInstance, 123));
-    EXPECT_NO_THROW(connectionProxyOnly.unsubscribe(skeletonInstance, 123));
-
-    ClusterConnectionConfigurationSkeletonOnlyMock confSkeletonOnly;
-    ClusterConnectionSkeletonOnly connectionSkeletonOnly(confSkeletonOnly);
-    EXPECT_EQ(
-        ::middleware::core::HRESULT::NotImplemented,
-        connectionSkeletonOnly.subscribe(proxyInstance, 123));
-    EXPECT_NO_THROW(connectionSkeletonOnly.unsubscribe(proxyInstance, 123));
-}
-
 TEST_F(ConnectionBaseTest, SubscribeUnsubscribeProxyOnly)
 {
     Proxy proxyInstance(1, 2, 4);
-    ClusterConnectionConfigurationProxyOnlyMock confProxyOnly;
+    ClusterConnectionConfigurationMock configuration;
 
-    ClusterConnectionProxyOnly connectionProxyOnly(confProxyOnly);
-    EXPECT_EQ(::middleware::core::HRESULT::Ok, connectionProxyOnly.subscribe(proxyInstance, 1));
-    EXPECT_NO_THROW(connectionProxyOnly.unsubscribe(proxyInstance, 1));
+    ClusterConnection connection(configuration);
+    EXPECT_EQ(::middleware::core::HRESULT::Ok, connection.subscribe(proxyInstance, 1));
+    EXPECT_NO_THROW(connection.unsubscribe(proxyInstance, 1));
 }
 
 TEST_F(ConnectionBaseTest, SubscribeUnsubscribeSkeletonOnly)
 {
     Skeleton skeletonInstance(1, 2);
-    ClusterConnectionConfigurationSkeletonOnlyMock confSkeletonOnly;
+    ClusterConnectionConfigurationMock configuration;
 
-    ClusterConnectionSkeletonOnly connectionSkeletonOnly(confSkeletonOnly);
-    EXPECT_EQ(
-        ::middleware::core::HRESULT::Ok, connectionSkeletonOnly.subscribe(skeletonInstance, 1));
-    EXPECT_NO_THROW(connectionSkeletonOnly.unsubscribe(skeletonInstance, 1));
+    ClusterConnection connection(configuration);
+    EXPECT_EQ(::middleware::core::HRESULT::Ok, connection.subscribe(skeletonInstance, 1));
+    EXPECT_NO_THROW(connection.unsubscribe(skeletonInstance, 1));
 }
 
 TEST_F(ConnectionBaseTest, SubscribeUnsubscribeBidirectional)
 {
     Proxy proxyInstance(1, 2, 4);
     Skeleton skeletonInstance(1, 2);
-    ClusterConnectionConfigurationBidirectionalMock confBidirectional;
+    ClusterConnectionConfigurationMock configuration;
 
-    ClusterConnectionBidirectional connectionBidirectional(confBidirectional);
-    EXPECT_EQ(
-        ::middleware::core::HRESULT::Ok, connectionBidirectional.subscribe(skeletonInstance, 1));
-    EXPECT_EQ(::middleware::core::HRESULT::Ok, connectionBidirectional.subscribe(proxyInstance, 1));
-    EXPECT_NO_THROW(connectionBidirectional.unsubscribe(skeletonInstance, 1));
-    EXPECT_NO_THROW(connectionBidirectional.unsubscribe(proxyInstance, 1));
+    ClusterConnection connection(configuration);
+    EXPECT_EQ(::middleware::core::HRESULT::Ok, connection.subscribe(skeletonInstance, 1));
+    EXPECT_EQ(::middleware::core::HRESULT::Ok, connection.subscribe(proxyInstance, 1));
+    EXPECT_NO_THROW(connection.unsubscribe(skeletonInstance, 1));
+    EXPECT_NO_THROW(connection.unsubscribe(proxyInstance, 1));
 }
 
 TEST_F(ConnectionBaseTest, SendMessageSameClusterNoError)
@@ -331,9 +204,8 @@ TEST_F(ConnectionBaseTest, SendMessageSameClusterNoError)
         4);
 
     Skeleton skeletonInstance(1, 2);
-    ClusterConnectionConfigurationSkeletonOnlyMock confSkeletonOnly;
-    ::middleware::core::ClusterConnectionTypeSelector<
-        ClusterConnectionConfigurationSkeletonOnlyMock>::type actualConnection(confSkeletonOnly);
+    ClusterConnectionConfigurationMock confSkeletonOnly;
+    ::middleware::core::ClusterConnection actualConnection(confSkeletonOnly);
 
     // ptr to base class trick as observed in {Proxy/Skeleton}Base
     ::middleware::core::IClusterConnection* ptrToBase = &actualConnection;
@@ -354,9 +226,8 @@ TEST_F(ConnectionBaseTest, SendMessageClusterToClusterNoError)
         4);
 
     Skeleton skeletonInstance(1, 2);
-    ClusterConnectionConfigurationSkeletonOnlyMock confSkeletonOnly;
-    ::middleware::core::ClusterConnectionTypeSelector<
-        ClusterConnectionConfigurationSkeletonOnlyMock>::type actualConnection(confSkeletonOnly);
+    ClusterConnectionConfigurationMock confSkeletonOnly;
+    ::middleware::core::ClusterConnection actualConnection(confSkeletonOnly);
 
     // ptr to base class trick as observed in {Proxy/Skeleton}Base
     ::middleware::core::IClusterConnection* ptrToBase = &actualConnection;
@@ -377,9 +248,8 @@ TEST_F(ConnectionBaseTest, SendMessageClusterToClusterFailed)
         4);
 
     Skeleton skeletonInstance(1, 2);
-    ClusterConnectionConfigurationSkeletonOnlyMock confSkeletonOnly;
-    ::middleware::core::ClusterConnectionTypeSelector<
-        ClusterConnectionConfigurationSkeletonOnlyMock>::type actualConnection(confSkeletonOnly);
+    ClusterConnectionConfigurationMock confSkeletonOnly;
+    ::middleware::core::ClusterConnection actualConnection(confSkeletonOnly);
 
     // ptr to base class trick as observed in {Proxy/Skeleton}Base
     ::middleware::core::IClusterConnection* ptrToBase = &actualConnection;
@@ -416,9 +286,8 @@ TEST_F(ConnectionBaseTest, SendMessageSameClusterServiceNotFound)
         4);
 
     Skeleton skeletonInstance(1, 2);
-    ClusterConnectionConfigurationSkeletonOnlyMock confSkeletonOnly;
-    ::middleware::core::ClusterConnectionTypeSelector<
-        ClusterConnectionConfigurationSkeletonOnlyMock>::type actualConnection(confSkeletonOnly);
+    ClusterConnectionConfigurationMock confSkeletonOnly;
+    ::middleware::core::ClusterConnection actualConnection(confSkeletonOnly);
 
     // ptr to base class trick as observed in {Proxy/Skeleton}Base
     ::middleware::core::IClusterConnection* ptrToBase = &actualConnection;
@@ -458,9 +327,8 @@ TEST_F(ConnectionBaseTest, SendMessageSameClusterServiceBusy)
         4);
 
     Skeleton skeletonInstance(1, 2);
-    ClusterConnectionConfigurationSkeletonOnlyMock confSkeletonOnly;
-    ::middleware::core::ClusterConnectionTypeSelector<
-        ClusterConnectionConfigurationSkeletonOnlyMock>::type actualConnection(confSkeletonOnly);
+    ClusterConnectionConfigurationMock confSkeletonOnly;
+    ::middleware::core::ClusterConnection actualConnection(confSkeletonOnly);
 
     // ptr to base class trick as observed in {Proxy/Skeleton}Base
     ::middleware::core::IClusterConnection* ptrToBase = &actualConnection;
@@ -500,9 +368,8 @@ TEST_F(ConnectionBaseTest, SendMessageSameClusterServiceBusyFireAndForget)
         4);
 
     Skeleton skeletonInstance(1, 2);
-    ClusterConnectionConfigurationSkeletonOnlyMock confSkeletonOnly;
-    ::middleware::core::ClusterConnectionTypeSelector<
-        ClusterConnectionConfigurationSkeletonOnlyMock>::type actualConnection(confSkeletonOnly);
+    ClusterConnectionConfigurationMock confSkeletonOnly;
+    ::middleware::core::ClusterConnection actualConnection(confSkeletonOnly);
 
     // ptr to base class trick as observed in {Proxy/Skeleton}Base
     ::middleware::core::IClusterConnection* ptrToBase = &actualConnection;
@@ -528,9 +395,8 @@ TEST_F(ConnectionBaseTest, processMessageFromReceivingSide)
         4);
 
     Skeleton skeletonInstance(1, 2);
-    ClusterConnectionConfigurationSkeletonOnlyMock confSkeletonOnly;
-    ::middleware::core::ClusterConnectionTypeSelector<
-        ClusterConnectionConfigurationSkeletonOnlyMock>::type actualConnection(confSkeletonOnly);
+    ClusterConnectionConfigurationMock confSkeletonOnly;
+    ::middleware::core::ClusterConnection actualConnection(confSkeletonOnly);
 
     // ptr to base class trick as observed in {Proxy/Skeleton}Base
     ::middleware::core::IClusterConnection* ptrToBase = &actualConnection;
@@ -544,10 +410,18 @@ TEST_F(ConnectionBaseTest, processMessageFromReceivingSide)
 
 TEST_F(ConnectionBaseTest, ProxyRegistersAsTimeoutTransceiver)
 {
+    struct ProxyWithTimeout
+    : public Proxy
+    , public ::middleware::core::ITimeoutHandler
+    {
+        using Proxy::Proxy;
+
+        void updateTimeouts() override {}
+    };
+
     ProxyWithTimeout proxyInstance(1, 2);
-    ClusterConnectionConfigurationSkeletonOnlyMock confSkeletonOnly;
-    ::middleware::core::ClusterConnectionTypeSelector<
-        ClusterConnectionConfigurationSkeletonOnlyMock>::type actualConnection(confSkeletonOnly);
+    ClusterConnectionConfigurationMock confSkeletonOnly;
+    ::middleware::core::ClusterConnection actualConnection(confSkeletonOnly);
 
     EXPECT_NO_THROW(actualConnection.registerTimeoutTransceiver(proxyInstance));
     EXPECT_EQ(1, actualConnection.registeredTransceiversCount(1));
@@ -561,9 +435,8 @@ TEST_F(ConnectionBaseTest, ProxyRegistersAsTimeoutTransceiver)
 
 TEST_F(ConnectionBaseTest, SyntheticClusterIdGetter)
 {
-    ClusterConnectionConfigurationSkeletonOnlyMock confSkeletonOnly;
-    ::middleware::core::ClusterConnectionTypeSelector<
-        ClusterConnectionConfigurationSkeletonOnlyMock>::type actualConnection(confSkeletonOnly);
+    ClusterConnectionConfigurationMock confSkeletonOnly;
+    ::middleware::core::ClusterConnection actualConnection(confSkeletonOnly);
 
     // ptr to base class trick as observed in {Proxy/Skeleton}Base
     ::middleware::core::IClusterConnection* ptrToBase = &actualConnection;

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_connections_srcCluster_to_tgtCluster.h.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_connections_srcCluster_to_tgtCluster.h.jinja
@@ -48,10 +48,10 @@
 namespace middleware::meta
 {
 
-class ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}}Meta : public core::IClusterConnectionConfiguration{{connection.connection_type}}
+class ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}}Meta : public core::IClusterConnectionConfiguration
 {
 public:
-    using Base = core::IClusterConnectionConfiguration{{connection.connection_type}};
+    using Base = core::IClusterConnectionConfiguration;
 
     ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}}Meta()
 {% if (connection.proxies|length > 0) and (connection.skeletons|length > 0) %}
@@ -141,34 +141,52 @@ public:
 
     void updateTimeouts() final { core::ITimeoutConfiguration::updateTimeouts(timeoutTransceivers_); }
 
-{% if connection.proxies|length > 0 %}
     [[nodiscard]] core::HRESULT subscribe(core::ProxyBase& proxy, uint16_t serviceInstanceId) final
     {
+{% if connection.proxies|length > 0 %}
         return core::meta::DbManipulator::subscribe(
             proxyTransceivers_.begin(), proxyTransceivers_.end(), proxy, serviceInstanceId);
+{% else %}
+        static_cast<void>(proxy);
+        static_cast<void>(serviceInstanceId);
+        return core::HRESULT::NotImplemented;
+{% endif %}
     }
 
     void unsubscribe(core::ProxyBase& proxy, uint16_t serviceId) final
     {
+{% if connection.proxies|length > 0 %}
         core::meta::DbManipulator::unsubscribe(
             proxyTransceivers_.begin(), proxyTransceivers_.end(), proxy, serviceId);
+{% else %}
+        static_cast<void>(proxy);
+        static_cast<void>(serviceId);
+{% endif %}
     }
 
-{% endif %}
-{% if connection.skeletons|length > 0 %}
     [[nodiscard]] core::HRESULT subscribe(core::SkeletonBase& skeleton, uint16_t serviceInstanceId) final
     {
+{% if connection.skeletons|length > 0 %}
         return core::meta::DbManipulator::subscribe(
             skeletonTransceivers_.begin(), skeletonTransceivers_.end(), skeleton, serviceInstanceId);
+{% else %}
+        static_cast<void>(skeleton);
+        static_cast<void>(serviceInstanceId);
+        return core::HRESULT::NotImplemented;
+{% endif %}
     }
 
     void unsubscribe(core::SkeletonBase& skeleton, uint16_t serviceId) final
     {
+{% if connection.skeletons|length > 0 %}
         core::meta::DbManipulator::unsubscribe(
             skeletonTransceivers_.begin(), skeletonTransceivers_.end(), skeleton, serviceId);
+{% else %}
+        static_cast<void>(skeleton);
+        static_cast<void>(serviceId);
+{% endif %}
     }
 
-{% endif %}
     ~ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}}Meta() = default;
 
   private:

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.cpp.jinja
@@ -80,7 +80,7 @@ void update{{cluster.name}}ClusterTimeouts()
 // ***************************** {{cluster.name}} *****************************
 {% for connection in connections if connection.source_cluster.name == cluster.name %}
 meta::ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Meta ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config;
-core::ClusterConnectionTypeSelector<meta::ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Meta>::type ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}(ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config);
+core::ClusterConnection ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}(ClusterConnection{{cluster.name}}To{{connection.target_cluster.name}}Config);
 {% endfor %}
 
 void initialize{{cluster.name}}ClusterConnection()

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.h.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_srcCluster.h.jinja
@@ -34,7 +34,7 @@ namespace middleware
 {
 
 {% for connection in connections if connection.source_cluster.name == cluster.name %}
-extern core::ClusterConnectionTypeSelector<meta::ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}}Meta>::type ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}};
+extern core::ClusterConnection ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}};
 {% endfor %}
 
 void initialize{{cluster.name}}ClusterConnection();

--- a/libs/bsw/middleware/tools/cpp_generator/templates/schemas/deployment.yaml
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/schemas/deployment.yaml
@@ -550,7 +550,6 @@ definitions:
     required:
       - source_cluster
       - target_cluster
-      - connection_type
       - proxies
       - skeletons
     properties:
@@ -558,16 +557,6 @@ definitions:
         $ref: "#/definitions/cluster"
       target_cluster:
         $ref: "#/definitions/cluster"
-      connection_type:
-        type: string
-        description: "Type of connection"
-        enum:
-          - "ProxyOnly"
-          - "SkeletonOnly"
-          - "ProxyOnlyWithTimeout"
-          - "SkeletonOnlyWithTimeout"
-          - "Bidirectional"
-          - "BidirectionalWithTimeout"
       proxies:
         type: array
         description: "Services consumed over this connection"


### PR DESCRIPTION
**Description**
Remove the `connection_type` deployment property and simplify cluster connection
configuration around the declared proxy and skeleton services.

The deployment schema and reference/simulation models no longer require or
include `connection_type`. The generated connection code, core connection API,
and connection tests are updated to use the simplified configuration.