### PR TITLE
Add PLATFORM_SUPPORT_* feature flags to Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,19 @@
 build:s32k148_gcc --platforms=//bazel/platform:s32k148
 # Default to gcc
 build:s32k148 --config=s32k148_gcc
-# Platform feature defines (CMake root add_compile_definitions(PLATFORM_SUPPORT_*=1) from
-# platforms/s32k148evb/Options.cmake). Global to the s32k148 build, like on the CMake side.
-build:s32k148 --copt=-DPLATFORM_SUPPORT_IO=1
+# All PLATFORM_SUPPORT_* flags (mirrors Options.cmake CACHE BOOL ... FORCE declarations).
+# Every flag is set explicitly so the platform's feature matrix is self-documenting.
+build:s32k148 --//bazel/config/features:can=true
+build:s32k148 --//bazel/config/features:ethernet=true
+build:s32k148 --//bazel/config/features:io=true
+build:s32k148 --//bazel/config/features:ipv6=false
+build:s32k148 --//bazel/config/features:middleware=false
+build:s32k148 --//bazel/config/features:mpu=true
+build:s32k148 --//bazel/config/features:rom_check=false
+build:s32k148 --//bazel/config/features:storage=true
+build:s32k148 --//bazel/config/features:transport=true
+build:s32k148 --//bazel/config/features:uds=true
+build:s32k148 --//bazel/config/features:watchdog=true
 
 # TODO: Temporary config only needed for artifact analysis
 # Make Bazel's build match CMake s32k148-freertos-gcc default config
@@ -13,6 +23,20 @@ build:s32k148_relwithdebinfo --copt=-O2
 build:s32k148_relwithdebinfo --copt=-DNDEBUG
 build:s32k148_threadx --config=s32k148
 build:s32k148_threadx --//bazel/config/rtos=threadx
+
+# All PLATFORM_SUPPORT_* flags for posix (mirrors posix/Options.cmake).
+# Options.cmake gates CAN on non-Darwin; this repo targets Linux so CAN is included.
+build:posix --//bazel/config/features:can=true
+build:posix --//bazel/config/features:ethernet=true
+build:posix --//bazel/config/features:io=false
+build:posix --//bazel/config/features:ipv6=false
+build:posix --//bazel/config/features:middleware=true
+build:posix --//bazel/config/features:mpu=false
+build:posix --//bazel/config/features:rom_check=false
+build:posix --//bazel/config/features:storage=true
+build:posix --//bazel/config/features:transport=true
+build:posix --//bazel/config/features:uds=true
+build:posix --//bazel/config/features:watchdog=false
 
 # Select the ETL profile for builds inside the OpenBSW repo based on executable_config (mirrors
 # CMake BUILD_EXECUTABLE). This ONLY applies when OpenBSW is the root module. Downstream consumers 

--- a/bazel/config/features/BUILD.bazel
+++ b/bazel/config/features/BUILD.bazel
@@ -1,0 +1,337 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""
+PLATFORM_SUPPORT_* feature flags (CMake: Options.cmake CACHE BOOL ... FORCE declarations).
+
+Each flag is a self-contained triple: bool_flag + config_settings + defines carrier lib.
+All flags default to False. .bazelrc sets every flag explicitly per platform config.
+Override any flag individually, e.g. --//bazel/config/features:can=false
+
+feature_defines aggregates all carrier libs for the common dep.
+"""
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+bool_flag(
+    name = "can",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "can_enabled",
+    flag_values = {":can": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "can_disabled",
+    flag_values = {":can": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "can_defines",
+    defines = select({
+        ":can_enabled": ["PLATFORM_SUPPORT_CAN=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "ethernet",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "ethernet_enabled",
+    flag_values = {":ethernet": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "ethernet_disabled",
+    flag_values = {":ethernet": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ethernet_defines",
+    defines = select({
+        ":ethernet_enabled": ["PLATFORM_SUPPORT_ETHERNET=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "io",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "io_enabled",
+    flag_values = {":io": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "io_disabled",
+    flag_values = {":io": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "io_defines",
+    defines = select({
+        ":io_enabled": ["PLATFORM_SUPPORT_IO=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "ipv6",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "ipv6_enabled",
+    flag_values = {":ipv6": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "ipv6_disabled",
+    flag_values = {":ipv6": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ipv6_defines",
+    defines = select({
+        ":ipv6_enabled": ["PLATFORM_SUPPORT_IPV6=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "middleware",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "middleware_enabled",
+    flag_values = {":middleware": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "middleware_disabled",
+    flag_values = {":middleware": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "middleware_defines",
+    defines = select({
+        ":middleware_enabled": ["PLATFORM_SUPPORT_MIDDLEWARE=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "mpu",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "mpu_enabled",
+    flag_values = {":mpu": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "mpu_disabled",
+    flag_values = {":mpu": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "mpu_defines",
+    defines = select({
+        ":mpu_enabled": ["PLATFORM_SUPPORT_MPU=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "rom_check",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "rom_check_enabled",
+    flag_values = {":rom_check": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "rom_check_disabled",
+    flag_values = {":rom_check": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "rom_check_defines",
+    defines = select({
+        ":rom_check_enabled": ["PLATFORM_SUPPORT_ROM_CHECK=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "storage",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "storage_enabled",
+    flag_values = {":storage": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "storage_disabled",
+    flag_values = {":storage": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "storage_defines",
+    defines = select({
+        ":storage_enabled": ["PLATFORM_SUPPORT_STORAGE=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "transport",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "transport_enabled",
+    flag_values = {":transport": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "transport_disabled",
+    flag_values = {":transport": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "transport_defines",
+    defines = select({
+        ":transport_enabled": ["PLATFORM_SUPPORT_TRANSPORT=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "uds",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "uds_enabled",
+    flag_values = {":uds": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "uds_disabled",
+    flag_values = {":uds": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "uds_defines",
+    defines = select({
+        ":uds_enabled": ["PLATFORM_SUPPORT_UDS=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "watchdog",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "watchdog_enabled",
+    flag_values = {":watchdog": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "watchdog_disabled",
+    flag_values = {":watchdog": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "watchdog_defines",
+    defines = select({
+        ":watchdog_enabled": ["PLATFORM_SUPPORT_WATCHDOG=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "feature_defines",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":can_defines",
+        ":ethernet_defines",
+        ":io_defines",
+        ":ipv6_defines",
+        ":middleware_defines",
+        ":mpu_defines",
+        ":rom_check_defines",
+        ":storage_defines",
+        ":transport_defines",
+        ":uds_defines",
+        ":watchdog_defines",
+    ],
+)

--- a/executables/referenceApp/safety/safeWatchdog/BUILD.bazel
+++ b/executables/referenceApp/safety/safeWatchdog/BUILD.bazel
@@ -1,0 +1,48 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "safe_watchdog_watchdog_support",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    deps = [
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+        "//platforms/s32k1xx/safety/safeBspMcuWatchdog:safe_bsp_mcu_watchdog",
+    ],
+)
+
+cc_library(name = "safe_watchdog_watchdog_support_none")
+
+alias(
+    name = "watchdog_support",
+    actual = select({
+        "//bazel/platform/constraints/soc:s32k148": ":safe_watchdog_watchdog_support",
+        "//conditions:default": ":safe_watchdog_watchdog_support_none",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "safe_watchdog",
+    srcs = ["src/safeWatchdog/SafeWatchdog.cpp"],
+    hdrs = ["include/safeWatchdog/SafeWatchdog.h"],
+    implementation_deps = [
+        ":watchdog_support",
+        "//executables/referenceApp/safety/safeSupervisor:safe_supervisor",
+        "//libs/safety/safeUtils:safe_utils",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//bazel/config/features:feature_defines",
+        "//libs/bsw/platform",
+    ],
+)


### PR DESCRIPTION
Add PLATFORM_SUPPORT_* feature flags to Bazel

bazel/config/features:
- bool_flag + config_setting + cc_library per PLATFORM_SUPPORT_* flag
- feature_defines aggregate

.bazelrc:
- replace --copt= platform defines with explicit bool_flag settings per config

safeWatchdog:
- migrate inline defines to feature_defines
