### PR TITLE
Support middlewareConfiguration and codegen infrastructure in Bazel (2/5)

### DIFF
--- a/executables/referenceApp/application/BUILD.bazel
+++ b/executables/referenceApp/application/BUILD.bazel
@@ -1,0 +1,19 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "demo_logger",
+    hdrs = ["include/app/DemoLogger.h"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = ["//libs/bsw/util"],
+)

--- a/executables/referenceApp/middlewareConfiguration/BUILD.bazel
+++ b/executables/referenceApp/middlewareConfiguration/BUILD.bazel
@@ -1,0 +1,86 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load(
+    "//libs/bsw/middleware/tools/cpp_generator:middleware_codegen.bzl",
+    "middleware_codegen",
+)
+load(":generated_outputs.bzl", "GENERATED_OUTPUTS")
+
+middleware_codegen(
+    name = "middleware_configuration_generated",
+    deployment_yaml = "model/deployment.yaml",
+    generated_outputs = GENERATED_OUTPUTS,
+    visibility = ["//visibility:public"],
+    deps = ["//libs/bsw/middleware"],
+)
+
+# Drift guard: serialise the declared output list for comparison.
+write_file(
+    name = "generated_outputs_expected",
+    out = "generated_outputs_expected.txt",
+    content = sorted(GENERATED_OUTPUTS) + [""],
+    newline = "unix",
+)
+
+# Drift guard: query the generator for its actual output list without rendering.
+genrule(
+    name = "generated_outputs_actual",
+    srcs = [
+        "model/deployment.yaml",
+        "//libs/bsw/middleware/tools/cpp_generator:generator",
+    ],
+    outs = ["generated_outputs_actual.txt"],
+    cmd = ("/opt/venv/bin/python3" +
+           " libs/bsw/middleware/tools/cpp_generator/jinja2cpp.py" +
+           " --input libs/bsw/middleware/tools/cpp_generator" +
+           " --deployment-yaml $(execpath model/deployment.yaml)" +
+           " --list-outputs | LC_ALL=C sort > $@"),
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+# Drift guard: fail if generated_outputs.bzl is out of sync with the generator.
+diff_test(
+    name = "generated_outputs_drift_test",
+    failure_message = "generated_outputs.bzl is stale; regenerate it (see the header of that file).",
+    file1 = "generated_outputs_expected.txt",
+    file2 = "generated_outputs_actual.txt",
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+cc_library(
+    name = "middleware_configuration",
+    srcs = [
+        "platform_integration/logger/src/LoggerImpl.cpp",
+        "platform_integration/os/src/OsDefinitions.cpp",
+        "platform_integration/time/src/SystemTimeProvider.cpp",
+        "src/MemoryLayout.cpp",
+    ],
+    hdrs = ["include/MemoryLayout.h"],
+    implementation_deps = [
+        "//executables/referenceApp/application:demo_logger",
+        "//libs/bsw/bsp",
+    ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":middleware_configuration_generated",
+        "//executables/referenceApp/asyncBinding:async_binding",
+        "//libs/bsw/logger",
+        "//libs/bsw/middleware",
+    ],
+    # NOTE: alwayslink is required because LoggerImpl.cpp implements
+    # middleware::logger::logBinary(), a symbol declared inside //libs/bsw/middleware.
+    alwayslink = True,
+)

--- a/executables/referenceApp/middlewareConfiguration/BUILD.bazel
+++ b/executables/referenceApp/middlewareConfiguration/BUILD.bazel
@@ -8,8 +8,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load(
     "//libs/bsw/middleware/tools/cpp_generator:middleware_codegen.bzl",
@@ -23,39 +21,6 @@ middleware_codegen(
     generated_outputs = GENERATED_OUTPUTS,
     visibility = ["//visibility:public"],
     deps = ["//libs/bsw/middleware"],
-)
-
-# Drift guard: serialise the declared output list for comparison.
-write_file(
-    name = "generated_outputs_expected",
-    out = "generated_outputs_expected.txt",
-    content = sorted(GENERATED_OUTPUTS) + [""],
-    newline = "unix",
-)
-
-# Drift guard: query the generator for its actual output list without rendering.
-genrule(
-    name = "generated_outputs_actual",
-    srcs = [
-        "model/deployment.yaml",
-        "//libs/bsw/middleware/tools/cpp_generator:generator",
-    ],
-    outs = ["generated_outputs_actual.txt"],
-    cmd = ("/opt/venv/bin/python3" +
-           " libs/bsw/middleware/tools/cpp_generator/jinja2cpp.py" +
-           " --input libs/bsw/middleware/tools/cpp_generator" +
-           " --deployment-yaml $(execpath model/deployment.yaml)" +
-           " --list-outputs | LC_ALL=C sort > $@"),
-    target_compatible_with = ["@platforms//os:linux"],
-)
-
-# Drift guard: fail if generated_outputs.bzl is out of sync with the generator.
-diff_test(
-    name = "generated_outputs_drift_test",
-    failure_message = "generated_outputs.bzl is stale; regenerate it (see the header of that file).",
-    file1 = "generated_outputs_expected.txt",
-    file2 = "generated_outputs_actual.txt",
-    target_compatible_with = ["@platforms//os:linux"],
 )
 
 cc_library(

--- a/executables/referenceApp/middlewareConfiguration/generated_outputs.bzl
+++ b/executables/referenceApp/middlewareConfiguration/generated_outputs.bzl
@@ -1,0 +1,49 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""Output layout of the middleware code generator for model/deployment.yaml.
+
+The list is data-dependent and varies by the deployment model file. It mirrors the
+hard-coded output list in the CMake `middlewareConfiguration/CMakeLists.txt`
+(`_GENERATED_HEADERS` + `GENERATED_SRCS`).
+
+Regenerate after editing model/deployment.yaml:
+
+    docker compose run --rm development \\
+        /opt/venv/bin/python3 \\
+        libs/bsw/middleware/tools/cpp_generator/jinja2cpp.py \\
+        --input libs/bsw/middleware/tools/cpp_generator \\
+        --deployment-yaml executables/referenceApp/middlewareConfiguration/model/deployment.yaml \\
+        --list-outputs
+
+Drift between this file and the generator is caught by the
+`:generated_outputs_drift_test` target in BUILD.bazel.
+"""
+
+GENERATED_OUTPUTS = [
+    "src/generated_code/AllocatorSelectorDefinitions.cpp",
+    "include/generated_code/middleware/ClusterId.h",
+    "include/generated_code/shm/AllocatorsDefinitions.h",
+    "include/generated_code/middleware/shm/Config.h",
+    "src/generated_code/shm/Config.cpp",
+    "include/generated_code/shm/QueueDefinitions.h",
+    "include/generated_code/middleware/ClusterCluster0.h",
+    "src/generated_code/ClusterCluster0.cpp",
+    "include/generated_code/middleware/ClusterCluster1.h",
+    "src/generated_code/ClusterCluster1.cpp",
+    "include/generated_code/middleware/ClusterConnectionsCluster0Cluster1.h",
+    "include/generated_code/middleware/ClusterConnectionsCluster1Cluster0.h",
+    "include/generated_code/org/test/foo/FooCommon.h",
+    "include/generated_code/org/test/foo/FooProxy.h",
+    "include/generated_code/org/test/foo/FooSkeleton.h",
+    "src/generated_code/org/test/foo/FooCommon.cpp",
+    "src/generated_code/org/test/foo/FooProxy.cpp",
+    "src/generated_code/org/test/foo/FooSkeleton.cpp",
+]

--- a/executables/referenceApp/middlewareConfiguration/generated_outputs.bzl
+++ b/executables/referenceApp/middlewareConfiguration/generated_outputs.bzl
@@ -24,7 +24,7 @@ Regenerate after editing model/deployment.yaml:
         --list-outputs
 
 Drift between this file and the generator is caught by the
-`:generated_outputs_drift_test` target in BUILD.bazel.
+`:middleware_configuration_generated_drift_test` target in BUILD.bazel.
 """
 
 GENERATED_OUTPUTS = [

--- a/libs/bsw/middleware/tools/cpp_generator/BUILD.bazel
+++ b/libs/bsw/middleware/tools/cpp_generator/BUILD.bazel
@@ -1,0 +1,20 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# jinja2cpp.py plus every template/schema it reads, staged as action inputs for
+# the middleware_codegen genrule (see middleware_codegen.bzl)
+filegroup(
+    name = "generator",
+    srcs = ["jinja2cpp.py"] + glob([
+        "templates/jinja/**/*.jinja",
+        "templates/schemas/*.yaml",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/libs/bsw/middleware/tools/cpp_generator/README.md
+++ b/libs/bsw/middleware/tools/cpp_generator/README.md
@@ -46,7 +46,8 @@ python3 jinja2cpp.py \
   --deployment-yaml <path-to-deployment.yaml> \
   [--clang-format-config <path-to-.clang-format>] \
   [--no-clean] \
-  [--generation-mode {normal,mock}]
+  [--generation-mode {normal,mock}] \
+  [--list-outputs]
 ```
 
 ### Arguments
@@ -54,11 +55,33 @@ python3 jinja2cpp.py \
 | Argument | Required | Description |
 |---|---|---|
 | `--input` | Yes | Directory containing the `templates/` subdirectory (jinja, schemas) |
-| `--output` | Yes | Directory where `include/generated_code/` and `src/generated_code/` will be written |
+| `--output` | Conditional | Directory where `include/generated_code/` and `src/generated_code/` will be written. Required for generation; **not** required (and ignored) when `--list-outputs` is given |
 | `--deployment-yaml` | Yes | Path to the deployment YAML file |
 | `--clang-format-config` | No | Path to a `.clang-format` config file; auto-detected from repo root if omitted |
 | `--no-clean` | No | Skip deleting the output directories before generation |
 | `--generation-mode` | No | Default generation mode: `normal` (full generation) or `mock` (interface-only for testing). Default: `normal` |
+| `--list-outputs` | No | Print the relative path of every file a generation run would produce for the given `--deployment-yaml` (one per line, on stdout) and exit **without rendering or writing anything**. Loader diagnostics go to stderr so stdout stays a clean path list. Used to declare the generated output set to build systems (see [Bazel build integration](#bazel-build-integration)) |
+
+## Bazel build integration
+
+The Bazel build wraps this script in the `middleware_codegen` macro
+(`libs/bsw/middleware/tools/cpp_generator/middleware_codegen.bzl`), which mirrors
+the CMake `add_custom_command` + `add_library` pair. A `genrule` runs the script
+and a wrapper `cc_library` exposes the generated headers/sources.
+
+Key points:
+
+- **Interpreter:** the genrule invokes `/opt/venv/bin/python3` by absolute path . Bazel therefore 
+  relies on the development Docker image already having the dependencies installed in `/opt/venv`.
+- **Requirements contract:** `/opt/venv` is populated from 
+  `docker/development/files/requirements.lock`, which is `pip-compile`d from the 
+  `requirements.txt` files listed under [Prerequisites](#prerequisites). A bump to 
+  `requirements.txt` only reaches the genrule after the lock is regenerated **and** the image is 
+  rebuilt. There is no Bazel-level enforcement of this, so rebuild after any dependency change.
+- **Declared outputs:** the genrule must declare each generated file individually
+  (a mixed headers+sources directory artifact cannot be consumed safely by
+  `cc_library`). The output list is derived from `--list-outputs` and checked in,
+  so regenerate it whenever the deployment model changes the set of generated files.
 
 ## Quick test with the bundled test deployment
 

--- a/libs/bsw/middleware/tools/cpp_generator/jinja2cpp.py
+++ b/libs/bsw/middleware/tools/cpp_generator/jinja2cpp.py
@@ -346,6 +346,76 @@ def generate_files(
             render_template_with_context(template_path, context, output_path)
 
 
+def _resolve_output_paths(input_data) -> list[str]:
+    """Return the output file paths a generation run would produce for *input_data*.
+
+    Paths are relative to the output base directory and use forward slashes
+    (e.g. ``include/generated_code/middleware/ClusterId.h``). Nothing is rendered
+    or written; only the output layout is computed.
+
+    This mirrors the filtering and naming logic of :func:`generate_files` so that
+    build systems can declare the exact set of generated outputs up front.
+    Keep this in sync with :func:`generate_files`.
+    """
+    outputs: list[str] = []
+    has_mock = _has_mock_mode_service(input_data)
+
+    def _emit(template_type: str, item=None) -> None:
+        for template_name, output_pattern, output_dir_pattern in TEMPLATE_CONFIG[
+            template_type
+        ]:
+            if template_type == "global" and has_mock:
+                if template_name not in MOCK_GLOBAL_TEMPLATES:
+                    continue
+
+            if template_type == "per_service":
+                service_mode = _service_generation_mode(item)
+                if service_mode == "normal" and template_name in (
+                    "mock/service_proxy_mock.h.jinja",
+                    "mock/service_skeleton_mock.h.jinja",
+                ):
+                    continue
+                if (
+                    service_mode == "mock"
+                    and template_name not in MOCK_TEMPLATE_OVERRIDES
+                ):
+                    continue
+
+            if template_type == "global":
+                output_filename = output_pattern
+                output_dir = output_dir_pattern
+            elif template_type == "per_cluster":
+                output_filename = output_pattern.format(item.name)
+                output_dir = output_dir_pattern
+            elif template_type == "per_connection":
+                output_filename = output_pattern.format(
+                    item.source_cluster.name, item.target_cluster.name
+                )
+                output_dir = output_dir_pattern
+            elif template_type == "per_service":
+                service_name = getattr(item, "filename", item.name)
+                namespace_path = (
+                    item.namespace.replace("::", "/").lower()
+                    if hasattr(item, "namespace")
+                    else ""
+                )
+                output_filename = output_pattern.format(service_name)
+                output_dir = output_dir_pattern.format(namespace_path)
+
+            outputs.append(f"{output_dir}/{output_filename}")
+
+    _emit("global")
+    if not has_mock:
+        for cluster in getattr(input_data, "clusters", []):
+            _emit("per_cluster", cluster)
+        for connection in getattr(input_data, "connections", []):
+            _emit("per_connection", connection)
+    for service in getattr(input_data, "services", []):
+        _emit("per_service", service)
+
+    return outputs
+
+
 def clean_previous_generated_files(output_base: Path) -> None:
     """Delete previously generated output directories before a new generation run."""
     generated_dirs = [
@@ -426,8 +496,13 @@ def parse_args(argv=None) -> argparse.Namespace:
     parser.add_argument(
         "--output",
         type=Path,
-        required=True,
-        help="Base output directory where include/generated_code/ and src/generated_code/ will be created.",
+        required=False,
+        help="Base output directory where include/generated_code/ and src/generated_code/ will be created. Required unless --list-outputs is given.",
+    )
+    parser.add_argument(
+        "--list-outputs",
+        action="store_true",
+        help="Print the relative paths of all files a generation run would produce for the given deployment YAML (one per line) and exit, without rendering or writing anything. Used to declare the generated output set to build systems.",
     )
     parser.add_argument(
         "--deployment-yaml",
@@ -458,11 +533,37 @@ def main(argv=None) -> int:
     args = parse_args(argv)
 
     input_base = args.input.resolve()
-    output_base = args.output.resolve()
 
     if not input_base.is_dir():
         print(f"error: Input directory not found: {input_base}", file=sys.stderr)
         return 1
+
+    # --list-outputs: resolve the output layout from the deployment model and exit
+    # without rendering. Kept additive so it does not affect the generation path.
+    if args.list_outputs:
+        try:
+            deployment_yaml = args.deployment_yaml.resolve()
+            # Keep stdout clean (path list only); loader diagnostics go to stderr.
+            _saved_stdout = sys.stdout
+            sys.stdout = sys.stderr
+            try:
+                input_data = load_input_data(input_base, deployment_yaml)
+            finally:
+                sys.stdout = _saved_stdout
+        except Exception as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 1
+        for service in getattr(input_data, "services", []):
+            if not hasattr(service, "generation_mode") or not service.generation_mode:
+                service["generation_mode"] = args.generation_mode
+        for path in _resolve_output_paths(input_data):
+            print(path)
+        return 0
+
+    if args.output is None:
+        print("error: --output is required unless --list-outputs is given", file=sys.stderr)
+        return 1
+    output_base = args.output.resolve()
 
     print(f"Input base directory: {input_base}")
     print(f"Output base directory: {output_base}")

--- a/libs/bsw/middleware/tools/cpp_generator/jinja2cpp.py
+++ b/libs/bsw/middleware/tools/cpp_generator/jinja2cpp.py
@@ -556,7 +556,7 @@ def main(argv=None) -> int:
         for service in getattr(input_data, "services", []):
             if not hasattr(service, "generation_mode") or not service.generation_mode:
                 service["generation_mode"] = args.generation_mode
-        for path in _resolve_output_paths(input_data):
+        for path in sorted(_resolve_output_paths(input_data)):
             print(path)
         return 0
 

--- a/libs/bsw/middleware/tools/cpp_generator/middleware_codegen.bzl
+++ b/libs/bsw/middleware/tools/cpp_generator/middleware_codegen.bzl
@@ -21,6 +21,8 @@ to the generation output base, exactly as printed by
 `generated_outputs.bzl`) and verified against the generator output at build time.
 """
 
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 # The generator package: script, templates and schemas are staged via this
@@ -32,8 +34,6 @@ _GENERATOR_SCRIPT = _GENERATOR_INPUT + "/jinja2cpp.py"
 # Dev-container venv interpreter (has jinja2/jsonschema/PyYAML per
 # docker/development/files/requirements.lock). Absolute path by design.
 _PYTHON = "/opt/venv/bin/python3"
-
-_LINUX_ONLY = ["@platforms//os:linux"]
 
 def middleware_codegen(
         name,
@@ -70,11 +70,10 @@ def middleware_codegen(
             deployment = deployment_yaml,
         ),
         message = "Generating middleware C++ code from " + deployment_yaml,
-        target_compatible_with = _LINUX_ONLY,
     )
 
-    hdrs = [o for o in outs if o.endswith(".h") or o.endswith(".hpp")]
-    srcs = [o for o in outs if o.endswith(".cpp")]
+    hdrs = [out for out in outs if out.endswith(".h") or out.endswith(".hpp")]
+    srcs = [out for out in outs if out.endswith(".cpp")]
 
     cc_library(
         name = name,
@@ -85,7 +84,37 @@ def middleware_codegen(
         # symbols declared inside //libs/bsw/middleware, e.g.
         # AllocatorSelectorDefinitions.cpp implements middleware::memory::getAllocFunction().
         alwayslink = True,
-        target_compatible_with = _LINUX_ONLY,
         deps = deps or [],
         visibility = visibility,
+    )
+
+    write_file(
+        name = name + "_expected_outputs",
+        out = name + "_expected_outputs.txt",
+        content = sorted(generated_outputs) + [""],
+        newline = "unix",
+    )
+
+    native.genrule(
+        name = name + "_actual_outputs",
+        srcs = [deployment_yaml, _GENERATOR],
+        outs = [name + "_actual_outputs.txt"],
+        cmd = ("{python} {script} --input {input}" +
+               " --deployment-yaml $(execpath {deployment})" +
+               " --list-outputs > $@").format(
+            python = _PYTHON,
+            script = _GENERATOR_SCRIPT,
+            input = _GENERATOR_INPUT,
+            deployment = deployment_yaml,
+        ),
+    )
+
+    diff_test(
+        name = name + "_drift_test",
+        failure_message = (
+            name + ": generated_outputs.bzl is stale. " +
+            "See " + native.package_name() + "/generated_outputs.bzl for regeneration instructions."
+        ),
+        file1 = name + "_expected_outputs.txt",
+        file2 = name + "_actual_outputs.txt",
     )

--- a/libs/bsw/middleware/tools/cpp_generator/middleware_codegen.bzl
+++ b/libs/bsw/middleware/tools/cpp_generator/middleware_codegen.bzl
@@ -1,0 +1,91 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""Middleware C++ code generation macro.
+
+`middleware_codegen` runs `jinja2cpp.py` over a deployment YAML model and wraps
+the generated C++ in a `cc_library`. It models the `add_custom_command`
++ `add_library` pair in `middlewareConfiguration/CMakeLists.txt` on the Cmake side.
+
+The set of generated files is data-dependent and varies by the deployment
+model file, so callers pass `generated_outputs`: the list of output paths relative
+to the generation output base, exactly as printed by
+`jinja2cpp.py --list-outputs`. That list is checked in (e.g. a
+`generated_outputs.bzl`) and verified against the generator output at build time.
+"""
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# The generator package: script, templates and schemas are staged via this
+# filegroup, and the script/input dir are referenced by their execroot paths.
+_GENERATOR = "//libs/bsw/middleware/tools/cpp_generator:generator"
+_GENERATOR_INPUT = "libs/bsw/middleware/tools/cpp_generator"
+_GENERATOR_SCRIPT = _GENERATOR_INPUT + "/jinja2cpp.py"
+
+# Dev-container venv interpreter (has jinja2/jsonschema/PyYAML per
+# docker/development/files/requirements.lock). Absolute path by design.
+_PYTHON = "/opt/venv/bin/python3"
+
+_LINUX_ONLY = ["@platforms//os:linux"]
+
+def middleware_codegen(
+        name,
+        deployment_yaml,
+        generated_outputs,
+        deps = None,
+        visibility = None):
+    """Generate middleware C++ from `deployment_yaml` and expose it as a cc_library.
+
+    Args:
+      name: Name of the generated `cc_library`. The backing genrule is
+        `<name>_srcs`.
+      deployment_yaml: Label of the deployment YAML model (single source of truth).
+      generated_outputs: List of output paths relative to the generation output
+        base (as emitted by `jinja2cpp.py --list-outputs`). `.h`/`.hpp` entries
+        become `hdrs`, `.cpp` entries become `srcs`.
+      deps: Extra `cc_library` deps the generated code needs to compile
+        (e.g. `//libs/bsw/middleware`).
+      visibility: Visibility of the generated `cc_library`.
+    """
+    gen_root = name + "_generated"
+    outs = [gen_root + "/" + path for path in generated_outputs]
+
+    native.genrule(
+        name = name + "_srcs",
+        srcs = [deployment_yaml, _GENERATOR],
+        outs = outs,
+        cmd = ("{python} {script} --input {input} --output $(RULEDIR)/{gen_root}" +
+               " --deployment-yaml $(execpath {deployment})").format(
+            python = _PYTHON,
+            script = _GENERATOR_SCRIPT,
+            input = _GENERATOR_INPUT,
+            gen_root = gen_root,
+            deployment = deployment_yaml,
+        ),
+        message = "Generating middleware C++ code from " + deployment_yaml,
+        target_compatible_with = _LINUX_ONLY,
+    )
+
+    hdrs = [o for o in outs if o.endswith(".h") or o.endswith(".hpp")]
+    srcs = [o for o in outs if o.endswith(".cpp")]
+
+    cc_library(
+        name = name,
+        srcs = srcs,
+        hdrs = hdrs,
+        strip_include_prefix = gen_root + "/include/generated_code",
+        # alwayslink is required because the generated .cpp files implement
+        # symbols declared inside //libs/bsw/middleware, e.g.
+        # AllocatorSelectorDefinitions.cpp implements middleware::memory::getAllocFunction().
+        alwayslink = True,
+        target_compatible_with = _LINUX_ONLY,
+        deps = deps or [],
+        visibility = visibility,
+    )


### PR DESCRIPTION
Support middlewareConfiguration and codegen infrastructure in Bazel

middleware/tools/cpp_generator:
- middleware_codegen
- generator

middlewareConfiguration:
- middleware_configuration
- generated_outputs_drift_test

application:
- demo_logger

Note: Python invoked via dev-container venv; generator deps are
pre-installed in the image, no network access at build time.
