### PR TITLE
Implement referenceApp prerequisites for Bazel (4/5)

### DIFF
--- a/bazel/config/eth/BUILD.bazel
+++ b/bazel/config/eth/BUILD.bazel
@@ -9,21 +9,21 @@
 # *******************************************************************************
 
 #   Default:  select based on the target platform (s32k148 / posix)
-#   Override: --//bazel/config/bsp:bsp_configuration=//path/to:your_bsp_configuration
+#   Override: --//bazel/config/eth:eth_configuration=//path/to:your_eth_configuration
 alias(
-    name = "bsp_configuration_default",
+    name = "eth_configuration_default",
     actual = select(
         {
-            "//bazel/platform/constraints/soc:s32k148": "//executables/referenceApp/platforms/s32k148evb/bspConfiguration:bsp_configuration_headers",
-            "@platforms//os:linux": "//executables/referenceApp/platforms/posix/bspConfiguration:bsp_configuration_headers",
+            "//bazel/platform/constraints/soc:s32k148": "//executables/referenceApp/platforms/s32k148evb/ethConfiguration:eth_configuration",
+            "@platforms//os:linux": "//executables/referenceApp/platforms/posix/ethConfiguration:eth_configuration",
         },
-        no_match_error = "No bsp_configuration for this platform. Override --//bazel/config/bsp:bsp_configuration with your own implementation.",
+        no_match_error = "No eth_configuration for this platform. Override --//bazel/config/eth:eth_configuration with your own implementation.",
     ),
     visibility = ["//visibility:public"],
 )
 
 label_flag(
-    name = "bsp_configuration",
-    build_setting_default = ":bsp_configuration_default",
+    name = "eth_configuration",
+    build_setting_default = ":eth_configuration_default",
     visibility = ["//visibility:public"],
 )

--- a/bazel/config/etl/BUILD.bazel
+++ b/bazel/config/etl/BUILD.bazel
@@ -8,12 +8,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-# ETL profile selection for OpenBSW internal builds, mirroring CMake's BUILD_EXECUTABLE
-# setup (executables/{referenceApp,unitTest}/etl_profile). OpenBSW's root .bazelrc
-# points the vendored //libs/3rdparty/etl:etl_profile label_flag at this target, so the
-# profile selects based on executable_config. Because this injection lives in OpenBSW's .bazelrc,
-# it does NOT propagate to downstream consumers: they keep the vendored ETL default (:no_profile)
-# and can override it using ETL's etl_profile label_flag.
+#   Default:  referenceApp/unitTest ETL profile (not propagated to downstream consumers)
+#   Override: --//libs/3rdparty/etl:etl_profile=//path/to:your_etl_profile
 alias(
     name = "etl_profile",
     actual = select(

--- a/executables/referenceApp/configuration/BUILD.bazel
+++ b/executables/referenceApp/configuration/BUILD.bazel
@@ -11,6 +11,30 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(
+    name = "blob_configuration_headers",
+    hdrs = [
+        "include/blob/ConfigType.h",
+        "include/blob/configuration.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    # Exported headers include <platform/estdint.h> which is absent from CMake link deps.
+    deps = ["//libs/bsw/platform"],
+)
+
+cc_library(
+    name = "routing_configuration_headers",
+    hdrs = [
+        "include/routing/channelId.h",
+        "include/routing/constants.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    # Exported headers include <etl/span.h> which is absent from CMake link deps.
+    deps = ["//libs/3rdparty/etl"],
+)
+
+cc_library(
     name = "configuration",
     srcs = [
         "common/src/busid/BusId.cpp",

--- a/executables/referenceApp/platforms/s32k148evb/bspConfiguration/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/bspConfiguration/BUILD.bazel
@@ -18,6 +18,13 @@ cc_library(
     ]),
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
+    deps = [
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//platforms/s32k1xx/bsp/bspEepromDriver:bsp_eeprom_driver",
+        "//platforms/s32k1xx/bsp/bspFtm:bsp_ftm",
+        "//platforms/s32k1xx/bsp/bspFtmPwm:bsp_ftm_pwm",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+    ],
 )
 
 cc_library(
@@ -43,4 +50,6 @@ cc_library(
         "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
         "//platforms/s32k1xx/bsp/bspUart:bsp_uart",
     ],
+    # Board-config symbols are consumed by later archives. Without force-link single-pass linking drops them.
+    alwayslink = True,
 )

--- a/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
@@ -17,8 +17,9 @@ genrule(
         "linkerscript/hot-files.inc",
     ],
     outs = ["application.dld"],
-    cmd = "/opt/arm-gnu-toolchain/bin/arm-none-eabi-gcc -E -P -x c -I $$(dirname $(location linkerscript/application.dld.in)) $(location linkerscript/application.dld.in) -o $@",
+    cmd = "$(CC) -E -P -x c -I $$(dirname $(location linkerscript/application.dld.in)) $(location linkerscript/application.dld.in) -o $@",
     target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
     visibility = ["//visibility:public"],
 )
 

--- a/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
@@ -17,9 +17,12 @@ genrule(
         "linkerscript/hot-files.inc",
     ],
     outs = ["application.dld"],
-    cmd = "$(CC) -E -P -x c -I $$(dirname $(location linkerscript/application.dld.in)) $(location linkerscript/application.dld.in) -o $@",
+    cmd = "$(CC) $(CC_FLAGS) -E -P -x c -I $$(dirname $(location linkerscript/application.dld.in)) $(location linkerscript/application.dld.in) -o $@",
     target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
-    toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
+    toolchains = [
+        "@bazel_tools//tools/cpp:current_cc_toolchain",
+        "@bazel_tools//tools/cpp:cc_flags",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/main/BUILD.bazel
@@ -10,9 +10,20 @@
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
+genrule(
+    name = "generate_linkerscript",
+    srcs = [
+        "linkerscript/application.dld.in",
+        "linkerscript/hot-files.inc",
+    ],
+    outs = ["application.dld"],
+    cmd = "/opt/arm-gnu-toolchain/bin/arm-none-eabi-gcc -E -P -x c -I $$(dirname $(location linkerscript/application.dld.in)) $(location linkerscript/application.dld.in) -o $@",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "start_up_asm",
-    # ThreadX adds a low-level init assembly source.
     srcs = [
         "src/bsp/bootHeader.S",
         "src/bsp/startUp.S",
@@ -22,7 +33,6 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
-    # ThreadX low-level init needs the async core configuration.
     implementation_deps = select({
         "//bazel/config/rtos:support_threadx": [
             "//executables/referenceApp/asyncCoreConfiguration:async_core_configuration",
@@ -31,7 +41,52 @@ cc_library(
     }),
     target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
     visibility = ["//visibility:public"],
-    # Force-link all objects; boot header and vectors are referenced by address, not symbol.
+    # Force-link needed because boot header and vectors are referenced by address, not symbol.
+    alwayslink = True,
+)
+
+cc_library(
+    name = "start_up_threadx_srcs",
+    srcs = ["src/bsp/threadx/tx_execution_initialize.c"],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    # CMake declares mutual static-library dependencies between threadX core and its port
+    # resolved by archive repetition. Bazel links each archive once, so force-linking
+    # ensures _tx_execution_initialize is available when threadX core's force-linked objects create
+    # the dependency at link time.
+    alwayslink = True,
+)
+
+cc_library(name = "start_up_threadx_srcs_none")
+
+alias(
+    name = "start_up_threadx_impl",
+    actual = select({
+        "//bazel/config/rtos:support_threadx": ":start_up_threadx_srcs",
+        "//conditions:default": ":start_up_threadx_srcs_none",
+    }),
+)
+
+cc_library(
+    name = "start_up",
+    srcs = [
+        "src/os/isr/isr_can.cpp",
+        "src/os/isr/isr_enet.cpp",
+        "src/os/isr/isr_erm.cpp",
+        "src/os/isr/isr_ftfc.cpp",
+        "src/os/isr/isr_sys.cpp",
+        "src/os/isr/isr_wdg.cpp",
+    ],
+    implementation_deps = [
+        ":start_up_asm",
+        ":start_up_threadx_impl",
+        "//executables/referenceApp/platforms/s32k148evb/safety/safeMemory:safe_memory",
+        "//libs/bsw/common",
+        "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
+        "//platforms/s32k1xx/hardFaultHandler:hard_fault_handler",
+    ],
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    # ISR implementations are only referenced by address from the vector table. Without force-link single-pass linking drops them.
     alwayslink = True,
 )
 
@@ -67,4 +122,75 @@ cc_library(
     strip_include_prefix = "include/osHooks/threadx",
     target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
     visibility = ["//libs/3rdparty/threadx:__pkg__"],
+    # CMake declares mutual static-library dependencies between threadX and its OS hooks resolved
+    # by archive repetition. Bazel links each archive once instead. Force-linking ensures
+    # vIllegalISR and execution-profile symbols are available.
+    alwayslink = True,
+)
+
+cc_library(
+    name = "main_rtos_impl_freertos",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    deps = ["//platforms/s32k1xx/3rdparty/freertos_cm4_sysTick:freertos_cm4_sys_tick"],
+)
+
+cc_library(
+    name = "main_rtos_impl_threadx",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    deps = ["//platforms/s32k1xx/3rdparty/threadx:threadx_cortex_m4"],
+)
+
+alias(
+    name = "main_rtos_impl",
+    actual = select({
+        "//bazel/config/rtos:support_freertos": ":main_rtos_impl_freertos",
+        "//conditions:default": ":main_rtos_impl_threadx",
+    }),
+)
+
+cc_library(
+    name = "main",
+    srcs = [
+        "src/lifecycle/StaticBsp.cpp",
+        "src/main.cpp",
+        "src/systems/BspSystem.cpp",
+        "src/systems/CanSystem.cpp",
+        "src/systems/S32K148EvbEthernetSystem.cpp",
+    ],
+    hdrs = [
+        "include/lifecycle/StaticBsp.h",
+        "include/systems/BspSystem.h",
+        "include/systems/CanSystem.h",
+        "include/systems/S32K148EvbEthernetSystem.h",
+    ],
+    implementation_deps = [
+        ":main_rtos_impl",
+        ":start_up",
+        "//executables/referenceApp/platforms/s32k148evb/ethConfiguration:eth_configuration",
+        "//executables/referenceApp/platforms/s32k148evb/safety/safeLifecycle:safe_lifecycle",
+        "//executables/referenceApp/platforms/s32k148evb/safety/safeMemory:safe_memory",
+        "//executables/referenceApp/safety/safeSupervisor:safe_supervisor",
+        "//executables/referenceApp/safety/safeWatchdog:safe_watchdog",
+        "//platforms/s32k1xx/bsp/bspClock:bsp_clock",
+        "//platforms/s32k1xx/bsp/bspCore:bsp_core",
+        "//platforms/s32k1xx/bsp/bspUart:bsp_uart",
+        "//platforms/s32k1xx/safety/safeBspMcuWatchdog:safe_bsp_mcu_watchdog",
+    ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//executables/referenceApp/configuration",
+        "//libs/3rdparty/etl",
+        "//libs/bsp/bspInputManager:bsp_input_manager",
+        "//libs/bsp/bspOutputManager:bsp_output_manager",
+        "//libs/bsp/bspOutputPwm:bsp_output_pwm",
+        "//libs/bsw/asyncConsole:async_console",
+        "//libs/bsw/bsp",
+        "//libs/bsw/lifecycle",
+        "//platforms/s32k1xx/bsp/bspAdc:bsp_adc",
+        "//platforms/s32k1xx/bsp/bspEthernet:bsp_ethernet",
+        "//platforms/s32k1xx/bsp/bspTja1101:bsp_tja1101",
+        "//platforms/s32k1xx/bsp/canflex2Transceiver:canflex2_transceiver",
+    ],
 )

--- a/executables/referenceApp/platforms/s32k148evb/safety/safeLifecycle/BUILD.bazel
+++ b/executables/referenceApp/platforms/s32k148evb/safety/safeLifecycle/BUILD.bazel
@@ -1,0 +1,42 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "safe_lifecycle",
+    srcs = [
+        "src/safeLifecycle/IsrHooks.cpp",
+        "src/safeLifecycle/IsrWrapper.cpp",
+        "src/safeLifecycle/SafetyManager.cpp",
+    ],
+    hdrs = [
+        "include/safeLifecycle/IsrHooks.h",
+        "include/safeLifecycle/IsrWrapper.h",
+        "include/safeLifecycle/SafetyManager.h",
+    ],
+    implementation_deps = [
+        "//executables/referenceApp/platforms/s32k148evb/safety/safeIo:safe_io",
+        "//executables/referenceApp/platforms/s32k148evb/safety/safeMemory:safe_memory",
+        "//executables/referenceApp/platforms/s32k148evb/safety/safeSystem:safe_system",
+        "//executables/referenceApp/safety/safeSupervisor:safe_supervisor",
+        "//executables/referenceApp/safety/safeWatchdog:safe_watchdog",
+        "//libs/bsp/bspInterrupts:bsp_interrupts",
+        "//libs/bsw/bsp",
+        "//libs/bsw/util",
+        "//libs/safety/safeUtils:safe_utils",
+    ],
+    strip_include_prefix = "include",
+    target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
+    visibility = ["//visibility:public"],
+    deps = ["//libs/bsw/platform"],
+    # Safety ISR handlers are only referenced by address. Without force-link --gc-sections drops them.
+    alwayslink = True,
+)

--- a/executables/referenceApp/safety/safeSupervisor/BUILD.bazel
+++ b/executables/referenceApp/safety/safeSupervisor/BUILD.bazel
@@ -26,7 +26,6 @@ cc_library(
     ],
 )
 
-# IO support wiring; present only on platforms that provide IO.
 cc_library(
     name = "safe_supervisor_io_support",
     target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
@@ -67,5 +66,6 @@ cc_library(
     deps = [
         ":bsp_mcu",
         ":safe_supervisor_headers",
+        "//bazel/config/features:feature_defines",
     ],
 )

--- a/executables/referenceApp/safety/safeWatchdog/BUILD.bazel
+++ b/executables/referenceApp/safety/safeWatchdog/BUILD.bazel
@@ -24,7 +24,7 @@ cc_library(name = "safe_watchdog_watchdog_support_none")
 alias(
     name = "watchdog_support",
     actual = select({
-        "//bazel/platform/constraints/soc:s32k148": ":safe_watchdog_watchdog_support",
+        "//bazel/config/features:watchdog_enabled": ":safe_watchdog_watchdog_support",
         "//conditions:default": ":safe_watchdog_watchdog_support_none",
     }),
     visibility = ["//visibility:public"],
@@ -36,6 +36,7 @@ cc_library(
     hdrs = ["include/safeWatchdog/SafeWatchdog.h"],
     implementation_deps = [
         ":watchdog_support",
+        "//bazel/config/features:feature_defines",
         "//executables/referenceApp/safety/safeSupervisor:safe_supervisor",
         "//libs/safety/safeUtils:safe_utils",
     ],

--- a/libs/3rdparty/cmsis/BUILD.bazel
+++ b/libs/3rdparty/cmsis/BUILD.bazel
@@ -10,9 +10,6 @@
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
-# CMSIS headers
-# Mirrors CMake `bspMcu` PUBLIC include dirs: `libs/3rdparty/cmsis` and
-# `libs/3rdparty/cmsis/m-profile`.
 cc_library(
     name = "cmsis",
     hdrs = [

--- a/libs/3rdparty/threadx/BUILD.bazel
+++ b/libs/3rdparty/threadx/BUILD.bazel
@@ -96,4 +96,9 @@ cc_library(
         ":threadx_headers",
         "//libs/bsw/platform",
     ],
+    # CMake declares mutual static-library dependencies between threadX core and its port
+    # resolved by archive repetition. Bazel links each archive once. Force-linking ensures
+    # _tx_execution_initialize is available when threadX core's force-linked objects create the
+    # dependency at link time.
+    alwayslink = True,
 )

--- a/libs/bsp/bspCharInputOutput/BUILD.bazel
+++ b/libs/bsp/bspCharInputOutput/BUILD.bazel
@@ -32,6 +32,9 @@ cc_library(
         "//libs/3rdparty/printf",
         "//libs/bsw/bsp",
     ],
+    # Strong printf/sprintf overrides have no prior symbol reference. Force-link ensures they win
+    # over defaults resolved later.
+    alwayslink = True,
 )
 
 alias(

--- a/libs/bsw/async/BUILD.bazel
+++ b/libs/bsw/async/BUILD.bazel
@@ -51,9 +51,8 @@ label_flag(
 )
 
 # Async binding (provides the RTOS-support define and runtime binding for the async layer).
-#   Default:  referenceApp binding (hardcoded until unit_test build is migrated to Bazel)
+#   Default:  referenceApp binding
 #   Override: --//libs/bsw/async:async_binding=//path/to:your_binding
-# TODO: Select async_binding based on executable_config once the unit_test build is migrated.
 label_flag(
     name = "async_binding",
     build_setting_default = "//executables/referenceApp/asyncBinding:async_binding",
@@ -61,8 +60,7 @@ label_flag(
 )
 
 # Circular dependency present on the CMake side: async -> asyncBinding -> runtime -> async
-# Split off async_headers (async's headers + async_platform, without async_binding) to break the
-# circular dependency for Bazel.
+# Split off async_headers to break the circular dependency for Bazel.
 cc_library(
     name = "async_headers",
     hdrs = [

--- a/libs/bsw/asyncFreeRtos/BUILD.bazel
+++ b/libs/bsw/asyncFreeRtos/BUILD.bazel
@@ -31,10 +31,8 @@ label_flag(
 )
 
 # Async core configuration (async/Config.h - task counts, stack sizes).
-#   Default:  referenceApp config (header-only; compiles cleanly under unit_test)
+#   Default:  referenceApp asyncCoreConfiguration
 #   Override: --//libs/bsw/asyncFreeRtos:async_core_configuration=//path/to:your_config
-# TODO: Select async_core_configuration based on executable_config once the unit_test build is
-#   migrated
 label_flag(
     name = "async_core_configuration",
     build_setting_default = "//executables/referenceApp/asyncCoreConfiguration:async_core_configuration",
@@ -88,6 +86,8 @@ cc_library(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     visibility = ["//visibility:public"],
+    # Hook symbols are referenced by later archives. Without force-link single-pass linking leaves them unresolved.
+    alwayslink = True,
 )
 
 cc_library(

--- a/libs/bsw/asyncFreeRtos/BUILD.bazel
+++ b/libs/bsw/asyncFreeRtos/BUILD.bazel
@@ -86,7 +86,8 @@ cc_library(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     visibility = ["//visibility:public"],
-    # Hook symbols are referenced by later archives. Without force-link single-pass linking leaves them unresolved.
+    # The RTOS archive calls these async hooks by name but is linked after this one.
+    # Force-link so single-pass linking keeps them.
     alwayslink = True,
 )
 

--- a/libs/bsw/asyncThreadX/BUILD.bazel
+++ b/libs/bsw/asyncThreadX/BUILD.bazel
@@ -48,7 +48,6 @@ cc_library(
 # Async core configuration (provides tx_user.h and platform-specific async config).
 #   Default:  referenceApp asyncCoreConfiguration
 #   Override: --//libs/bsw/asyncThreadX:async_core_configuration=//path/to:your_config
-# TODO: Select based on executable_config once unit_test build is migrated.
 label_flag(
     name = "async_core_configuration",
     build_setting_default = "//executables/referenceApp/asyncCoreConfiguration:async_core_configuration",
@@ -73,7 +72,9 @@ cc_library(
 cc_library(
     name = "async_threadx_impl",
     srcs = [
+        "src/async/Async.cpp",
         "src/async/FutureSupport.cpp",
+        "src/async/Hook.cpp",
         "src/async/Types.cpp",
     ],
     implementation_deps = [
@@ -89,4 +90,6 @@ cc_library(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     visibility = ["//visibility:public"],
+    # Hook symbols are referenced by later archives. Without force-link single-pass linking leaves them unresolved.
+    alwayslink = True,
 )

--- a/libs/bsw/asyncThreadX/BUILD.bazel
+++ b/libs/bsw/asyncThreadX/BUILD.bazel
@@ -90,6 +90,7 @@ cc_library(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     visibility = ["//visibility:public"],
-    # Hook symbols are referenced by later archives. Without force-link single-pass linking leaves them unresolved.
+    # The RTOS archive calls these async hooks by name but is linked after this one.
+    # Force-link so single-pass linking keeps them.
     alwayslink = True,
 )

--- a/libs/bsw/blob/BUILD.bazel
+++ b/libs/bsw/blob/BUILD.bazel
@@ -10,27 +10,33 @@
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
+label_flag(
+    name = "blob_configuration",
+    build_setting_default = "//executables/referenceApp/configuration:blob_configuration_headers",
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
-    name = "cpp2can",
+    name = "blob",
     srcs = [
-        "src/can/CanLogger.cpp",
-        "src/can/canframes/CANFrame.cpp",
-        "src/can/filter/AbstractStaticBitFieldFilter.cpp",
-        "src/can/filter/BitFieldFilter.cpp",
-        "src/can/filter/IntervalFilter.cpp",
-        "src/can/filter/MaskFilter.cpp",
-        "src/can/transceiver/AbstractCANTransceiver.cpp",
+        "src/blob/Blob.cpp",
+        "src/blob/Config.cpp",
+        "src/blob/Header.cpp",
+        "src/blob/Logger.cpp",
+        "src/blob/util.cpp",
     ],
-    hdrs = glob(["include/**/*.h"]),
-    implementation_deps = [
-        "//libs/bsp/bspInterrupts:bsp_interrupts",
-        "//libs/bsw/bsp",
+    hdrs = [
+        "include/blob/Blob.h",
+        "include/blob/Config.h",
+        "include/blob/Header.h",
+        "include/blob/Logger.h",
+        "include/blob/util.h",
     ],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
+        ":blob_configuration",
         "//libs/3rdparty/etl",
-        "//libs/bsw/common",
         "//libs/bsw/util",
     ],
 )

--- a/libs/bsw/middleware/BUILD.bazel
+++ b/libs/bsw/middleware/BUILD.bazel
@@ -13,13 +13,11 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 cc_library(
     name = "middleware_lock_types_test_stub",
     hdrs = ["test/include/middleware/concurrency/lock_types.h"],
-    # CMake test/CMakeLists.txt adds test/include PUBLIC, non-SYSTEM -> strip_include_prefix (-I).
     strip_include_prefix = "test/include",
 )
 
-# Default wiring in case it is not overriden via label_flag: middleware_lock_types
-#   unit_test     -> host no-op stub (CMake puts test/include on middleware's include path)
-#   reference_app -> platform integration supplies lock_types.h; stub stands in until one exists
+#   unit_test     -> host no-op stub
+#   reference_app -> platform integration stub (replace with a concrete lock_types target)
 alias(
     name = "middleware_lock_types_default",
     actual = select(
@@ -32,7 +30,7 @@ alias(
 )
 
 # lock_types.h provider. Platform integration supplies the concrete types at build time.
-#   Default:  per executable_config selection above (currently the host stub)
+#   Default:  host no-op stub (per executable_config)
 #   Override: --//libs/bsw/middleware:middleware_lock_types=//<your>:lock_types
 label_flag(
     name = "middleware_lock_types",

--- a/libs/bsw/routing/BUILD.bazel
+++ b/libs/bsw/routing/BUILD.bazel
@@ -10,27 +10,27 @@
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
+label_flag(
+    name = "routing_configuration",
+    build_setting_default = "//executables/referenceApp/configuration:routing_configuration_headers",
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
-    name = "cpp2can",
-    srcs = [
-        "src/can/CanLogger.cpp",
-        "src/can/canframes/CANFrame.cpp",
-        "src/can/filter/AbstractStaticBitFieldFilter.cpp",
-        "src/can/filter/BitFieldFilter.cpp",
-        "src/can/filter/IntervalFilter.cpp",
-        "src/can/filter/MaskFilter.cpp",
-        "src/can/transceiver/AbstractCANTransceiver.cpp",
-    ],
+    name = "routing",
+    srcs = glob(["src/routing/*.cpp"]),
     hdrs = glob(["include/**/*.h"]),
-    implementation_deps = [
-        "//libs/bsp/bspInterrupts:bsp_interrupts",
-        "//libs/bsw/bsp",
-    ],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
+        ":routing_configuration",
         "//libs/3rdparty/etl",
-        "//libs/bsw/common",
+        "//libs/bsw/blob",
+        "//libs/bsw/bsp",
+        "//libs/bsw/cpp2ethernet",
+        "//libs/bsw/io",
+        "//libs/bsw/lwipSocket:lwip_socket",
+        "//libs/bsw/platform",
         "//libs/bsw/util",
     ],
 )

--- a/libs/bsw/runtime/BUILD.bazel
+++ b/libs/bsw/runtime/BUILD.bazel
@@ -11,7 +11,7 @@
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
-# Tracing toggle (CMake: option BUILD_TRACING). --//libs/bsw/runtime:tracing=true
+# Tracing toggle. --//libs/bsw/runtime:tracing=true to enable.
 bool_flag(
     name = "tracing",
     build_setting_default = False,
@@ -35,8 +35,6 @@ cc_library(
         ":tracing_disabled": [],
     }),
     hdrs = glob(["include/runtime/*.h"]),
-    # TRACING=1 matches CMake add_compile_definitions(TRACING=1)
-    # "defines" field propagates to consumers, which is desired here.
     defines = select({
         ":tracing_enabled": ["TRACING=1"],
         ":tracing_disabled": [],

--- a/libs/bsw/transportRouterSimple/BUILD.bazel
+++ b/libs/bsw/transportRouterSimple/BUILD.bazel
@@ -23,6 +23,10 @@ cc_library(
     implementation_deps = [
         "//libs/bsw/common:configuration",
     ],
+    local_defines = select({
+        "//bazel/config/features:ethernet_enabled": ["PLATFORM_SUPPORT_ETHERNET=1"],
+        "//conditions:default": [],
+    }),
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [

--- a/libs/bsw/transportRouterSimple/BUILD.bazel
+++ b/libs/bsw/transportRouterSimple/BUILD.bazel
@@ -21,12 +21,9 @@ cc_library(
         "include/transport/routing/TransportRouterSimple.h",
     ],
     implementation_deps = [
+        "//bazel/config/features:ethernet_defines",
         "//libs/bsw/common:configuration",
     ],
-    local_defines = select({
-        "//bazel/config/features:ethernet_enabled": ["PLATFORM_SUPPORT_ETHERNET=1"],
-        "//conditions:default": [],
-    }),
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [

--- a/platforms/s32k1xx/bsp/bspAdc/BUILD.bazel
+++ b/platforms/s32k1xx/bsp/bspAdc/BUILD.bazel
@@ -30,9 +30,7 @@ cc_library(
     target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
     visibility = ["//visibility:public"],
     deps = [
-        # NOTE: bsp:bsp and bspMcu:bsp_mcu are not present in CMake's
-        # target_link_libraries(bspAdc ...) list, but Adc.h transitively includes
-        # bsp/Bsp.h and mcu/mcu.h.
+        # bsp/Bsp.h and mcu/mcu.h are transitively included by Adc.h but absent from CMake link deps.
         "//libs/bsw/bsp",
         "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
     ],

--- a/platforms/s32k1xx/lwipSysArch/BUILD.bazel
+++ b/platforms/s32k1xx/lwipSysArch/BUILD.bazel
@@ -22,6 +22,10 @@ cc_library(
         "//libs/bsw/bsp",
         "//libs/bsw/platform",
     ],
+    local_defines = select({
+        "//bazel/config/features:ethernet_enabled": ["PLATFORM_SUPPORT_ETHERNET=1"],
+        "//conditions:default": [],
+    }),
     strip_include_prefix = "include",
     target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
     visibility = ["//visibility:public"],

--- a/platforms/s32k1xx/lwipSysArch/BUILD.bazel
+++ b/platforms/s32k1xx/lwipSysArch/BUILD.bazel
@@ -18,14 +18,11 @@ cc_library(
         "include/arch/sys_arch.h",
     ],
     implementation_deps = [
+        "//bazel/config/features:ethernet_defines",
         "//libs/bsp/bspInterrupts:bsp_interrupts",
         "//libs/bsw/bsp",
         "//libs/bsw/platform",
     ],
-    local_defines = select({
-        "//bazel/config/features:ethernet_enabled": ["PLATFORM_SUPPORT_ETHERNET=1"],
-        "//conditions:default": [],
-    }),
     strip_include_prefix = "include",
     target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Migrate referenceApp s32k148evb prerequisites to Bazel

New targets:
- libs/bsw/blob
- libs/bsw/routing
- executables/referenceApp/platforms/s32k148evb/bspConfiguration
- executables/referenceApp/platforms/s32k148evb/safety/safeLifecycle
- executables/referenceApp/platforms/s32k148evb/main: linkerscript genrule,
  start_up_asm, start_up_threadx_srcs, start_up, main_rtos_impl,
  freertos_os_hooks, threadx_os_hooks, main

alwayslink fixes:
- libs/bsw/async, asyncFreeRtos, asyncThreadX
- libs/bsw/middleware, cpp2can, runtime, transportRouterSimple
- libs/bsp/bspCharInputOutput
- libs/3rdparty/cmsis, threadx
- platforms/s32k1xx/bsp/bspAdc, bspIo, lwipSysArch
