### PR TITLE
Updating GCC version in Docker container, including bugfix

### DIFF
--- a/.ci/buildoperations.py
+++ b/.ci/buildoperations.py
@@ -59,8 +59,8 @@ def get_environment(cxxid: str, platform: str):
 
     if platform == "linux":
         if cxxid == "gcc":
-            env["CC"] = get_full_path("gcc-11")
-            env["CXX"] = get_full_path("g++-11")
+            env["CC"] = get_full_path("gcc-14")
+            env["CXX"] = get_full_path("g++-14")
             return env
         if cxxid == "clang":
             env["CC"] = get_full_path("clang-17")

--- a/.ci/code_coverage.py
+++ b/.ci/code_coverage.py
@@ -17,7 +17,7 @@ import sys
 
 # FIXME: Hard-coding the compiler version in this python script feels wrong. It
 # should be changed in the future to provide the compiler from the outside.
-GCC_VERSION = 11
+GCC_VERSION = 14
 
 def get_full_path(command):
     if (cmd := shutil.which(command)) is None:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,16 @@ add_compile_options(
     "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-error=stringop-overflow;-Wno-error=maybe-uninitialized>"
 )
 
+#[[
+    Host Clang builds use libc++ instead of libstdc++. libstdc++'s C++23 headers
+    (e.g. the tuple-like std::tuple constructor) are not compatible with all
+    supported Clang versions. GCC builds keep using libstdc++.
+]]
+if (NOT CMAKE_CROSSCOMPILING AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-stdlib=libc++>")
+    add_link_options(-stdlib=libc++)
+endif ()
+
 # Rust support Note: Only one static Rust library can be linked in the final
 # binary, otherwise the linker will complain about duplicate symbol definitions
 # from the Rust core crate.

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -51,10 +51,12 @@ RUN apt-get update && apt-get install -y \
         clang-tidy-17 \
         cmake \
         curl \
-        g++-11 \
-        gcc-11 \
+        g++-14 \
+        gcc-14 \
         git \
         lcov \
+        libc++-17-dev \
+        libc++abi-17-dev \
         ninja-build \
         python-is-python3 \
         python3 \

--- a/libs/bsw/cpp2someip/test/src/QueryManagerTest.cpp
+++ b/libs/bsw/cpp2someip/test/src/QueryManagerTest.cpp
@@ -475,6 +475,11 @@ TEST_F(QueryManagerTest, offerReceivedTcp)
     EXPECT_EQ(ServiceQuery::SubscriptionState::STATE_WAITING_FOR_ACK, query.subscriptionState);
     EXPECT_CALL(_serviceAnnouncer, unsubscribe(Ref(query.description), sourceAddress)).Times(1);
     _queryManager.unregisterQuery(query);
+
+    // The Return() action of getRpcChannel holds a NetworkChannel referencing 'proxy'.
+    // It is owned by _networkMock (a fixture member) which outlives the local 'proxy',
+    // so the expectations must be released here to avoid a use after free on teardown.
+    Mock::VerifyAndClearExpectations(&_networkMock);
 }
 
 TEST_F(QueryManagerTest, stopOfferReceived)

--- a/libs/bsw/routing/include/routing/Integration.h
+++ b/libs/bsw/routing/include/routing/Integration.h
@@ -285,6 +285,15 @@ public:
 
                         uint8_t const index = channelId - FIRST_PDU_TRANSPORT_CHANNEL_ID;
 
+                        if (index >= MAX_NUM_PDU_TRANSPORT_CHANNELS)
+                        {
+                            logger::Logger::warn(
+                                logger::ROUTING,
+                                "PDU TP channel ID %u out of range",
+                                static_cast<uint32_t>(channelId));
+                            continue;
+                        }
+
                         if ((pduTransportReaders[index] == nullptr)
                             || (pduTransportWriters[index] == nullptr))
                         {


### PR DESCRIPTION
With the old host GCC 11 in the current Docker container,
we are missing some warnings and errors from newer compiler versions.

Also, we are using GCC 14 already as default cross compiler. Therefore,
choosing GCC 14 from the existing Ubuntu environment.

Fix PDU TP channel out of bounds access, uncovered by the new compiler version