### PR TITLE
Fix gmock dependency declarations of mock libraries

### DIFF
--- a/libs/bsw/async/mock/CMakeLists.txt
+++ b/libs/bsw/async/mock/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(asyncMock INTERFACE)
 
 target_include_directories(asyncMock INTERFACE gmock/include)
 
-target_link_libraries(asyncMock INTERFACE etl platform)
+target_link_libraries(asyncMock INTERFACE etl gmock platform)
 
 add_library(
     asyncMockImpl gmock/src/async/AsyncMock.cpp gmock/src/async/TestContext.cpp

--- a/libs/bsw/bsp/mock/CMakeLists.txt
+++ b/libs/bsw/bsp/mock/CMakeLists.txt
@@ -2,4 +2,4 @@ add_library(bspMock src/bsp/timer/SystemTimerMock.cpp)
 
 target_include_directories(bspMock PUBLIC include)
 
-target_link_libraries(bspMock PUBLIC bsp etl gmock_main)
+target_link_libraries(bspMock PUBLIC bsp etl gmock)

--- a/libs/bsw/bsp/test/CMakeLists.txt
+++ b/libs/bsw/bsp/test/CMakeLists.txt
@@ -4,6 +4,6 @@ add_executable(
 
 target_include_directories(bspTest PRIVATE)
 
-target_link_libraries(bspTest PRIVATE bsp bspMock util)
+target_link_libraries(bspTest PRIVATE bsp bspMock util gmock_main)
 
 gtest_discover_tests(bspTest PROPERTIES LABELS "bspTest")

--- a/libs/bsw/cpp2can/CMakeLists.txt
+++ b/libs/bsw/cpp2can/CMakeLists.txt
@@ -25,5 +25,8 @@ if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     target_include_directories(cpp2canMock PUBLIC mock/include)
 
-    target_link_libraries(cpp2canMock PRIVATE bspMock cpp2can gmock_main)
+    target_link_libraries(
+        cpp2canMock
+        PUBLIC cpp2can gmock
+        PRIVATE bspMock)
 endif ()

--- a/libs/bsw/cpp2can/test/CMakeLists.txt
+++ b/libs/bsw/cpp2can/test/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(
 
 target_include_directories(cpp2canTest PRIVATE)
 
-target_link_libraries(cpp2canTest PRIVATE bspMock cpp2can cpp2canMock)
+target_link_libraries(cpp2canTest PRIVATE bspMock cpp2can cpp2canMock
+                                          gmock_main)
 
 gtest_discover_tests(cpp2canTest PROPERTIES LABELS "cpp2canTest")

--- a/libs/bsw/cpp2ethernet/CMakeLists.txt
+++ b/libs/bsw/cpp2ethernet/CMakeLists.txt
@@ -31,5 +31,5 @@ if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     target_include_directories(cpp2ethernetMock INTERFACE mock/include)
 
-    target_link_libraries(cpp2ethernetMock INTERFACE cpp2ethernet)
+    target_link_libraries(cpp2ethernetMock INTERFACE cpp2ethernet gmock)
 endif ()

--- a/libs/bsw/docan/CMakeLists.txt
+++ b/libs/bsw/docan/CMakeLists.txt
@@ -20,6 +20,6 @@ if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     target_include_directories(docanMock INTERFACE mock/gmock/include)
 
-    target_link_libraries(docanMock INTERFACE docan)
+    target_link_libraries(docanMock INTERFACE docan gmock)
 
 endif ()

--- a/libs/bsw/io/CMakeLists.txt
+++ b/libs/bsw/io/CMakeLists.txt
@@ -9,5 +9,5 @@ if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     target_include_directories(ioMock INTERFACE mock/include)
 
-    target_link_libraries(ioMock INTERFACE io etl gmock_main)
+    target_link_libraries(ioMock INTERFACE io etl gmock)
 endif ()

--- a/libs/bsw/io/test/CMakeLists.txt
+++ b/libs/bsw/io/test/CMakeLists.txt
@@ -7,6 +7,6 @@ add_executable(
     src/io/SplitWriterTest.cpp
     src/io/VariantQueueTest.cpp)
 
-target_link_libraries(ioTest PRIVATE io ioMock)
+target_link_libraries(ioTest PRIVATE io ioMock gmock_main)
 
 gtest_discover_tests(ioTest PROPERTIES LABELS "ioTest")

--- a/libs/bsw/logger/CMakeLists.txt
+++ b/libs/bsw/logger/CMakeLists.txt
@@ -14,5 +14,5 @@ if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     target_include_directories(loggerMock INTERFACE mock/include)
 
-    target_link_libraries(loggerMock INTERFACE bspMock utilMock gmock_main)
+    target_link_libraries(loggerMock INTERFACE bspMock utilMock gmock)
 endif ()

--- a/libs/bsw/logger/test/CMakeLists.txt
+++ b/libs/bsw/logger/test/CMakeLists.txt
@@ -15,6 +15,6 @@ add_executable(
 
 target_include_directories(loggerTest PRIVATE)
 
-target_link_libraries(loggerTest PRIVATE logger loggerMock util)
+target_link_libraries(loggerTest PRIVATE logger loggerMock util gmock_main)
 
 gtest_discover_tests(loggerTest PROPERTIES LABELS "loggerTest")

--- a/libs/bsw/storage/CMakeLists.txt
+++ b/libs/bsw/storage/CMakeLists.txt
@@ -5,7 +5,7 @@ if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     target_include_directories(storageMock INTERFACE mock/include)
 
-    target_link_libraries(storageMock INTERFACE storage gmock_main)
+    target_link_libraries(storageMock INTERFACE storage gmock)
 else ()
     list(APPEND storage.extraSources src/storage/StorageTester.cpp)
 endif ()

--- a/libs/bsw/util/CMakeLists.txt
+++ b/libs/bsw/util/CMakeLists.txt
@@ -38,5 +38,5 @@ if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     target_include_directories(utilMock PUBLIC mock/gmock/include)
 
-    target_link_libraries(utilMock PUBLIC util etl)
+    target_link_libraries(utilMock PUBLIC util etl gmock)
 endif ()

--- a/platforms/s32k1xx/bsp/bspIo/CMakeLists.txt
+++ b/platforms/s32k1xx/bsp/bspIo/CMakeLists.txt
@@ -15,5 +15,5 @@ if (BUILD_EXECUTABLE STREQUAL "unitTest")
 
     target_include_directories(bspIoMock PUBLIC mock/gmock/include)
 
-    target_link_libraries(bspIoMock PRIVATE gmock_main)
+    target_link_libraries(bspIoMock PUBLIC bspIo etl gmock)
 endif ()

--- a/platforms/s32k1xx/bsp/canflex2Transceiver/test/CMakeLists.txt
+++ b/platforms/s32k1xx/bsp/canflex2Transceiver/test/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(
             bspIo
             lifecycle
             bspMock
-            gmock)
+            gmock_main)
 
 gtest_discover_tests(CanFlex2TransceiverTest
                      PROPERTIES LABELS "CanFlex2TransceiverTest")

--- a/platforms/stm32/bsp/bxCanTransceiver/test/CMakeLists.txt
+++ b/platforms/stm32/bsp/bxCanTransceiver/test/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(
             bspIo
             lifecycle
             bspMock
-            gmock)
+            gmock_main)
 
 gtest_discover_tests(BxCanTransceiverTest PROPERTIES LABELS
                                                      "BxCanTransceiverTest")

--- a/platforms/stm32/bsp/fdCanTransceiver/test/CMakeLists.txt
+++ b/platforms/stm32/bsp/fdCanTransceiver/test/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(
             bspIo
             lifecycle
             bspMock
-            gmock)
+            gmock_main)
 
 gtest_discover_tests(FdCanTransceiverTest PROPERTIES LABELS
                                                      "FdCanTransceiverTest")


### PR DESCRIPTION
Some mock libraries linked `gmock_main` instead of `gmock`, which pulls the test entry point into every consumer of the mock. Others used `<gmock/gmock.h>` in their headers without declaring any gmock dependency and relied on the consuming test to provide it.

Link `gmock` in all ten mock targets. Mocks whose headers include gmock declare it PUBLIC or INTERFACE so that consumers get the include paths.

Seven test executables had no `main()` of their own and obtained it transitively from a mock's `gmock_main`. They now link `gmock_main` explicitly: bspTest, cpp2canTest, ioTest, loggerTest, BxCanTransceiverTest, FdCanTransceiverTest and CanFlex2TransceiverTest.

Verified with the tests-posix-debug, tests-s32k1xx-debug and tests-stm32-debug presets: configure, build and ctest all pass (2564, 40 and 911 tests). `bspIoMock` is changed for consistency only; no preset configures it, because `platforms/s32k1xx/bsp/CMakeLists.txt` skips `bspIo` in unit test builds. `transportMock` shows the same pattern (PRIVATE gmock with gmock in its headers) but is not in the issue list and is left untouched.

CMake only. These mocks have no Bazel targets on main yet; #570 and #584 add them, and #584 currently declares `gtest_main` for `bsp_mock`, `cpp2can_mock` and `io_mock`.

Resolves:
#567: Mock libraries declare their gmock dependency incorrectly
