### PR TITLE
Fix outdated CMake preset names in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ options and build the generated project.
 ### Building with CMake
 ```
 host> DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) docker compose run --build development
-docker> cmake --preset posix
-docker> cmake --build --preset posix
+docker> cmake --preset posix-freertos
+docker> cmake --build --preset posix-freertos
 ```
 
 ### Building with Bazel

--- a/doc/dev/learning/ethernet/index.rst
+++ b/doc/dev/learning/ethernet/index.rst
@@ -62,7 +62,7 @@ Setup in Testing PC:
    - Navigate to the openBsw root directory.
    - Run the script to set up the tap interface: ``./tools/enet/bring-up-ethernet.sh``
    - Run the application on POSIX with the below command in the terminal:
-     ``build/posix/executables/referenceApp/application/Release/app.referenceApp.elf``
+     ``build/posix-freertos/executables/referenceApp/application/Release/app.referenceApp.elf``
 
 S32K148
 +++++++

--- a/doc/dev/learning/layout/index.rst
+++ b/doc/dev/learning/layout/index.rst
@@ -22,9 +22,9 @@ You can view this as a map to regularly refer back to as you navigate and become
 .. code-block:: text
 
     ├── build
-    │   ├── posix
-    │   ├── s32k148-clang
-    │   └── s32k148-gcc
+    │   ├── posix-freertos
+    │   ├── s32k148-freertos-clang
+    │   └── s32k148-freertos-gcc
     ├── cmake
     │   ├── modules
     │   ├── presets
@@ -50,7 +50,8 @@ Most libraries also contain their own RST documentation along-side their code an
 when this documentation is built, as can be seen in the index on the left.
 
 ``build/[preset]``: holds build artifacts & executables created by ``cmake`` for different ``[presets]``.
-For example if you build for the ``posix`` platform the directory ``build/posix`` is created.
+For example if you build with the ``posix-freertos`` preset
+the directory ``build/posix-freertos`` is created.
 
 ``executables``: holds application-specific code (not the built executables).
 The ``referenceApp`` subdirectory contains an example application.

--- a/doc/dev/learning/setup/setup_posix_build.rst
+++ b/doc/dev/learning/setup/setup_posix_build.rst
@@ -51,25 +51,28 @@ In the root directory of the repository, run:
 
 .. code-block:: bash
 
-    cmake --preset posix
-    cmake --build --preset posix --parallel
+    cmake --preset posix-freertos
+    cmake --build --preset posix-freertos --parallel
+
+This builds the reference application on top of FreeRTOS.
+Use the ``posix-threadx`` preset to build on top of ThreadX instead of FreeRTOS.
 
 By default release configuration is used. If you want to build debug configuration, use
 
 .. code-block:: bash
 
-    cmake --build --preset posix --config Debug --parallel
+    cmake --build --preset posix-freertos --config Debug --parallel
 
-The build files should be written to a new subdirectory named ``build/posix``
+The build files should be written to a new subdirectory named ``build/posix-freertos``
 and the built executable should be found at
-``build/posix/executables/referenceApp/application/Release/app.referenceApp.elf``.
+``build/posix-freertos/executables/referenceApp/application/Release/app.referenceApp.elf``.
 If you've built it with `--config Debug`, then the executable can be found at
-``build/posix/executables/referenceApp/application/Debug/app.referenceApp.elf``.
+``build/posix-freertos/executables/referenceApp/application/Debug/app.referenceApp.elf``.
 You should be able to run and see output like this in your shell terminal...
 
 .. code-block:: bash
 
-    $ build/posix/executables/referenceApp/application/Release/app.referenceApp.elf
+    $ build/posix-freertos/executables/referenceApp/application/Release/app.referenceApp.elf
     hello
     106367434: RefApp: LIFECYCLE: INFO: Initialize level 1
     106367434: RefApp: LIFECYCLE: INFO: Initialize runtime

--- a/doc/dev/learning/setup/setup_s32k148_gdbserver.rst
+++ b/doc/dev/learning/setup/setup_s32k148_gdbserver.rst
@@ -194,13 +194,13 @@ check the following...
 
    .. code-block:: bash
 
-     build/s32k148-gcc/executables/referenceApp/application/RelWithDebInfo/gapp.referenceApp.elf
+     build/s32k148-freertos-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf
 
 Then, in the root folder you can run the gdb client to start an interactive debug session...
 
   .. code-block:: bash
 
-   arm-none-eabi-gdb -x tools/gdb/pegdbserver.gdb build/s32k148-gcc/executables/referenceApp/application/RelWithDebInfo/gapp.referenceApp.elf
+   arm-none-eabi-gdb -x tools/gdb/pegdbserver.gdb build/s32k148-freertos-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf
 
 Flash the board on command-line
 -------------------------------
@@ -211,7 +211,7 @@ it may be more convenient to flash it in a single command as follows...
 
   .. code-block:: bash
 
-   arm-none-eabi-gdb -batch -x test/pyTest/flash.gdb build/s32k148-gcc/executables/referenceApp/application/RelWithDebInfo/gapp.referenceApp.elf
+   arm-none-eabi-gdb -batch -x test/pyTest/flash.gdb build/s32k148-freertos-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf
 
 Reset the board on command-line
 -------------------------------
@@ -220,4 +220,4 @@ You can reset the board in a single command as follows...
 
   .. code-block:: bash
 
-   arm-none-eabi-gdb -batch -x test/pyTest/reset.gdb build/s32k148-gcc/executables/referenceApp/application/RelWithDebInfo/gapp.referenceApp.elf
+   arm-none-eabi-gdb -batch -x test/pyTest/reset.gdb build/s32k148-freertos-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf

--- a/doc/dev/learning/setup/setup_s32k148_ubuntu_build.rst
+++ b/doc/dev/learning/setup/setup_s32k148_ubuntu_build.rst
@@ -60,12 +60,14 @@ Then, in the base directory run:
 
 .. code-block:: bash
 
-    cmake --preset s32k148-gcc
-    cmake --build --preset s32k148-gcc
+    cmake --preset s32k148-freertos-gcc
+    cmake --build --preset s32k148-freertos-gcc
 
-The build files should be written to a new subdirectory named ``build/s32k148-gcc``
-and the built executable should be found at ``build/s32k148-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf``
+The build files should be written to a new subdirectory named ``build/s32k148-freertos-gcc``
+and the built executable should be found at
+``build/s32k148-freertos-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf``
 which you can flash on the S32K148 development board.
+Use the ``s32k148-threadx-gcc`` preset to build on top of ThreadX instead of FreeRTOS.
 
 Using the clang toolchain
 -------------------------
@@ -111,12 +113,14 @@ Then, in the base directory run:
 
 .. code-block:: bash
 
-    cmake --preset s32k148-clang
-    cmake --build --preset s32k148-clang
+    cmake --preset s32k148-freertos-clang
+    cmake --build --preset s32k148-freertos-clang
 
-The build files should be written to a new subdirectory named ``build/s32k148-gcc``
-and the built executable should be found at ``build/s32k148-clang/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf``
+The build files should be written to a new subdirectory named ``build/s32k148-freertos-clang``
+and the built executable should be found at
+``build/s32k148-freertos-clang/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf``
 which you can flash on the S32K148 development board.
+Use the ``s32k148-threadx-clang`` preset to build on top of ThreadX instead of FreeRTOS.
 
 Optional: Rust Support
 ----------------------

--- a/doc/dev/learning/setup/setup_s32k148_ubuntu_nxpide.rst
+++ b/doc/dev/learning/setup/setup_s32k148_ubuntu_nxpide.rst
@@ -120,7 +120,7 @@ and then change it to point to the external code and the image created as descri
 
    .. code-block::
 
-        [absolute_path_to_project_root]/build/s32k148-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf
+        [absolute_path_to_project_root]/build/s32k148-freertos-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf
 
    .. image:: nxpide_debug_config_linux.png
       :width: 80%

--- a/doc/dev/learning/setup/setup_s32k148_win_nxpide.rst
+++ b/doc/dev/learning/setup/setup_s32k148_win_nxpide.rst
@@ -62,7 +62,7 @@ and then change it to point to the external code and the image created as descri
 
    .. code-block::
 
-        [absolute_path_to_project_root]\build\s32k148-gcc\executables\referenceApp\application\RelWithDebInfo\app.referenceApp.elf
+        [absolute_path_to_project_root]\build\s32k148-freertos-gcc\executables\referenceApp\application\RelWithDebInfo\app.referenceApp.elf
 
    .. image:: nxpide_debug_config.png
       :width: 80%

--- a/doc/dev/learning/setup/setup_vscode.rst
+++ b/doc/dev/learning/setup/setup_vscode.rst
@@ -66,37 +66,37 @@ each task will be listed by their ``label`` below and you can select one to exec
             {
                 "type": "shell",
                 "label": "Clean s32k148 build",
-                "command": "rm -rf build/s32k148-gcc",
+                "command": "rm -rf build/s32k148-freertos-gcc",
                 "group": "build"
             },
             {
                 "type": "shell",
                 "label": "Generate build system for s32k148",
-                "command": "cmake --build --preset s32k148-gcc",
+                "command": "cmake --preset s32k148-freertos-gcc",
                 "group": "build"
             },
             {
                 "type": "shell",
                 "label": "Build s32k148 elf file",
-                "command": "cmake --build --preset s32k148-gcc",
+                "command": "cmake --build --preset s32k148-freertos-gcc",
                 "group": "build"
             },
             {
                 "type": "shell",
                 "label": "Clean posix build",
-                "command": "rm -rf build/posix",
+                "command": "rm -rf build/posix-freertos",
                 "group": "build"
             },
             {
                 "type": "shell",
                 "label": "Generate build system for posix",
-                "command": "cmake --preset posix",
+                "command": "cmake --preset posix-freertos",
                 "group": "build"
             },
             {
                 "type": "shell",
                 "label": "Build posix elf file",
-                "command": "cmake --build --preset posix",
+                "command": "cmake --build --preset posix-freertos",
                 "group": "build"
             }
         ]
@@ -129,14 +129,14 @@ the generated ``compile_commands.json`` files.
                 "cStandard": "c99",
                 "cppStandard": "c++17",
                 "intelliSenseMode": "linux-gcc-x64",
-                "compileCommands": "${workspaceFolder}/build/posix/compile_commands.json"
+                "compileCommands": "${workspaceFolder}/build/posix-freertos/compile_commands.json"
             },
             {
                 "name": "s32k148",
                 "cStandard": "c99",
                 "cppStandard": "c++17",
                 "intelliSenseMode": "gcc-arm",
-                "compileCommands": "${workspaceFolder}/build/s32k148-gcc/compile_commands.json"
+                "compileCommands": "${workspaceFolder}/build/s32k148-freertos-gcc/compile_commands.json"
             }
         ],
         "version": 4
@@ -187,7 +187,7 @@ The debugger will launch and stop at the entry point in ``main()``.
                 "name": "Debug posix",
                 "type": "cppdbg",
                 "request": "launch",
-                "program": "${workspaceFolder}/build/posix/executables/referenceApp/application/Debug/app.referenceApp.elf",
+                "program": "${workspaceFolder}/build/posix-freertos/executables/referenceApp/application/Debug/app.referenceApp.elf",
                 "args": [],
                 "stopAtEntry": true,
                 "cwd": "${workspaceFolder}",
@@ -232,7 +232,7 @@ For example, the task below will flash the elf file onto the S32K148EVB Board.
             {
                 "type": "shell",
                 "label": "Flash s32k148 elf file",
-                "command": "arm-none-eabi-gdb -batch -x test/pyTest/flash.gdb build/s32k148/executables/referenceApp/application/Debug/app.referenceApp.elf",
+                "command": "arm-none-eabi-gdb -batch -x test/pyTest/flash.gdb build/s32k148-freertos-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf",
                 "group": "build"
             }
         ]
@@ -267,7 +267,7 @@ Cut & paste the configuration below into your ``.vscode/launch.json``...
                 {
                     "name": "Debug s32k148",
                     "cwd": "${workspaceFolder}",
-                    "executable": "${workspaceFolder}/build/s32k148/executables/referenceApp/application/Debug/app.referenceApp.elf",
+                    "executable": "${workspaceFolder}/build/s32k148-freertos-gcc/executables/referenceApp/application/Debug/app.referenceApp.elf",
                     "request": "launch",
                     "type": "cortex-debug",
                     "runToEntryPoint": "main",

--- a/doc/dev/learning/tracing/index.rst
+++ b/doc/dev/learning/tracing/index.rst
@@ -63,8 +63,8 @@ the tracing buffer size. For example, to build for S32K148EVB:
 
 .. code-block:: bash
 
-    cmake --preset s32k148-gcc -DBUILD_TRACING=ON -DTRACING_BUFFER_SIZE=65536
-    cmake --build --preset s32k148-gcc
+    cmake --preset s32k148-freertos-gcc -DBUILD_TRACING=ON -DTRACING_BUFFER_SIZE=65536
+    cmake --build --preset s32k148-freertos-gcc
 
 The size of tracing buffer in RAM is configurable (TRACING_BUFFER_SIZE).
 If it is not provided in the cmake command, then the default value of 4096 bytes is configured.

--- a/test/pyTest/README.md
+++ b/test/pyTest/README.md
@@ -80,7 +80,7 @@ If you examine that and the scripts it references you will find that it expects 
     To run tests using the `posix` you must first have built the image for that target
     in its expected default location...
     ```
-    build/posix/executables/referenceApp/application/Release/app.referenceApp.elf
+    build/posix-freertos/executables/referenceApp/application/Release/app.referenceApp.elf
     ```
 
 2. Need to have `vcan0` set up
@@ -103,7 +103,7 @@ For this option...
     To run tests using the `s32k148` you must first have built the image for that target
     in its expected default location...
     ```
-    build/s32k148-gcc/executables/referenceApp/application/Release/app.referenceApp.elf
+    build/s32k148-freertos-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf
     ```
 
 2. Need an [S32K148 development board](https://www.nxp.com/design/design-center/development-boards/automotive-development-platforms/s32k-mcu-platforms/s32k148-q176-evaluation-board-for-automotive-general-purpose:S32K148EVB)
@@ -273,7 +273,7 @@ If present, the following entries are supported.
 eg.
 ```
 [per_run_process]
-command_line = "arm-none-eabi-gdb -batch -x flash.gdb ../../build/s32k148-gcc/executables/referenceApp/application/Release/app.referenceApp.elf > /dev/null 2>&1"
+command_line = "arm-none-eabi-gdb -batch -x flash.gdb ../../build/s32k148-freertos-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf > /dev/null 2>&1"
 wait_for_exit = true
 ```
 
@@ -294,7 +294,7 @@ The following entries are supported.
 eg.
 ```
 [target_process]
-command_line = "../../build/posix/executables/referenceApp/application/Release/app.referenceApp.elf < /tmp/pty_forwarder > /tmp/pty_forwarder"
+command_line = "../../build/posix-freertos/executables/referenceApp/application/Release/app.referenceApp.elf < /tmp/pty_forwarder > /tmp/pty_forwarder"
 kill_at_end = true
 ```
 

--- a/tools/puncover_tool/doc/index.rst
+++ b/tools/puncover_tool/doc/index.rst
@@ -15,7 +15,7 @@ Puncover
 Puncover examines C/C++ binaries to assess code size, static memory usage, and stack requirements.
 It generates detailed reports that include disassembly and call-stack analysis organized by
 directory, file, or function. To generate the output analysis, it uses the built executable located
-in: ``build/s32k148-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf``
+in: ``build/s32k148-freertos-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf``
 
 The ``tools/puncover_tool`` in our repository contains `generate_html.py` script that leverages
 the core functionality of Puncover and generates HTML pages as output locally. This tool is powered

--- a/tools/vscode/dot_vscode/c_cpp_properties.json
+++ b/tools/vscode/dot_vscode/c_cpp_properties.json
@@ -5,14 +5,14 @@
             "cStandard": "c99",
             "cppStandard": "c++17",
             "intelliSenseMode": "linux-gcc-x64",
-            "compileCommands": "${workspaceFolder}/build/posix/compile_commands.json"
+            "compileCommands": "${workspaceFolder}/build/posix-freertos/compile_commands.json"
         },
         {
             "name": "s32k148",
             "cStandard": "c99",
             "cppStandard": "c++17",
             "intelliSenseMode": "gcc-arm",
-            "compileCommands": "${workspaceFolder}/build/s32k148-gcc/compile_commands.json"
+            "compileCommands": "${workspaceFolder}/build/s32k148-freertos-gcc/compile_commands.json"
         }
     ],
     "version": 4

--- a/tools/vscode/dot_vscode/launch.json
+++ b/tools/vscode/dot_vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "Debug posix",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/build/posix/executables/referenceApp/application/Debug/app.referenceApp.elf",
+            "program": "${workspaceFolder}/build/posix-freertos/executables/referenceApp/application/Debug/app.referenceApp.elf",
             "args": [],
             "stopAtEntry": true,
             "cwd": "${workspaceFolder}",
@@ -28,7 +28,7 @@
         {
             "name": "Debug s32k148",
             "cwd": "${workspaceFolder}",
-            "executable": "${workspaceFolder}/build/s32k148-gcc/executables/referenceApp/application/Debug/app.referenceApp.elf",
+            "executable": "${workspaceFolder}/build/s32k148-freertos-gcc/executables/referenceApp/application/Debug/app.referenceApp.elf",
             "request": "launch",
             "type": "cortex-debug",
             "runToEntryPoint": "main",

--- a/tools/vscode/dot_vscode/tasks.json
+++ b/tools/vscode/dot_vscode/tasks.json
@@ -4,43 +4,43 @@
         {
             "type": "shell",
             "label": "Clean s32k148 build (GCC)",
-            "command": "rm -rf build/s32k148-gcc",
+            "command": "rm -rf build/s32k148-freertos-gcc",
             "group": "build"
         },
         {
             "type": "shell",
             "label": "Generate build system for s32k148",
-            "command": "cmake --preset s32k148-gcc",
+            "command": "cmake --preset s32k148-freertos-gcc",
             "group": "build"
         },
         {
             "type": "shell",
             "label": "Build s32k148 elf file",
-            "command": "cmake --build --preset s32k148-gcc",
+            "command": "cmake --build --preset s32k148-freertos-gcc",
             "group": "build"
         },
         {
             "type": "shell",
             "label": "Flash s32k148 elf file",
-            "command": "arm-none-eabi-gdb -batch -x test/pyTest/flash.gdb build/s32k148-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf",
+            "command": "arm-none-eabi-gdb -batch -x test/pyTest/flash.gdb build/s32k148-freertos-gcc/executables/referenceApp/application/RelWithDebInfo/app.referenceApp.elf",
             "group": "build"
         },
         {
             "type": "shell",
             "label": "Clean posix build",
-            "command": "rm -rf build/posix",
+            "command": "rm -rf build/posix-freertos",
             "group": "build"
         },
         {
             "type": "shell",
             "label": "Generate build system for posix",
-            "command": "cmake --preset posix",
+            "command": "cmake --preset posix-freertos",
             "group": "build"
         },
         {
             "type": "shell",
             "label": "Build posix elf file",
-            "command": "cmake --build --preset posix",
+            "command": "cmake --build --preset posix-freertos",
             "group": "build"
         }
     ]


### PR DESCRIPTION
Fix outdated CMake preset names in documentation

Following the setup guide fails at the first cmake call. The presets
posix, s32k148-gcc and s32k148-clang were renamed when the RTOS became
part of the preset name, but the learning pages, the README, the
pyTest README and the VS Code templates still use the old names and
build directories.

Replace them with posix-freertos, s32k148-freertos-gcc and
s32k148-freertos-clang, point out the threadx presets, and update the
build/ paths. Mistakes on the same lines are corrected too:

* the clang section named the gcc build directory
* the gdb server page named a gapp.referenceApp.elf that is never
  produced
* the pyTest README stated Release where target_s32k148.toml uses
  RelWithDebInfo
* the VS Code generate task ran cmake --build, and the flash task in
  the VS Code page pointed at a Debug elf under build/s32k148; it now
  matches the shipped tools/vscode template

Resolves:
#379: Documentation: CMake preset names are outdated

See also:
#335: Refactor learning pages

One old name is left on purpose: `.github/workflows/puncover_tool.yml` caches `build/s32k148-gcc`. Its cache key interpolates `steps.build-docker-development.outputs.digest`, a step id that does not exist in that workflow, so the key has an empty segment and the cache has never restored. Correcting the path would make the cache live and let the job skip the build after a toolchain change. That is a behaviour change rather than a documentation fix, so I left it for a separate issue.

Tag: `no_hw_test_required`.
