### PR TITLE
Add PLATFORM_SUPPORT feature flags to Bazel (3/5)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,8 @@
+# Feature matrix lives in the platform() flags (//bazel/platform), mirroring how
+# CMake Options.cmake ties PLATFORM_SUPPORT_* to OPENBSW_PLATFORM.
 build:s32k148_gcc --platforms=//bazel/platform:s32k148
 # Default to gcc
 build:s32k148 --config=s32k148_gcc
-# Platform feature defines (CMake root add_compile_definitions(PLATFORM_SUPPORT_*=1) from
-# platforms/s32k148evb/Options.cmake). Global to the s32k148 build, like on the CMake side.
-build:s32k148 --copt=-DPLATFORM_SUPPORT_IO=1
 
 # TODO: Temporary config only needed for artifact analysis
 # Make Bazel's build match CMake s32k148-freertos-gcc default config
@@ -13,6 +12,12 @@ build:s32k148_relwithdebinfo --copt=-O2
 build:s32k148_relwithdebinfo --copt=-DNDEBUG
 build:s32k148_threadx --config=s32k148
 build:s32k148_threadx --//bazel/config/rtos=threadx
+
+# POSIX is the DEFAULT platform: a plain `bazel build //...` is the posix host build. The posix
+# PLATFORM_SUPPORT_* matrix lives in //bazel/platform:posix flags. `--config=posix` is kept as an
+# explicit alias.
+build --platforms=//bazel/platform:posix
+build:posix --platforms=//bazel/platform:posix
 
 # Select the ETL profile for builds inside the OpenBSW repo based on executable_config (mirrors
 # CMake BUILD_EXECUTABLE). This ONLY applies when OpenBSW is the root module. Downstream consumers 

--- a/bazel/config/features/BUILD.bazel
+++ b/bazel/config/features/BUILD.bazel
@@ -1,0 +1,337 @@
+# *******************************************************************************
+# Copyright (c) 2026 Accenture
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""
+PLATFORM_SUPPORT feature flags
+
+Each flag is a self-contained triple: bool_flag + config_settings + defines carrier lib.
+All flags default to False. //bazel/platform platform() `flags` sets the matrix per platform.
+Override any flag individually, e.g. --//bazel/config/features:can=false
+
+feature_defines aggregates all carrier libs for the common dep.
+"""
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+bool_flag(
+    name = "can",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "can_enabled",
+    flag_values = {":can": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "can_disabled",
+    flag_values = {":can": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "can_defines",
+    defines = select({
+        ":can_enabled": ["PLATFORM_SUPPORT_CAN=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "ethernet",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "ethernet_enabled",
+    flag_values = {":ethernet": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "ethernet_disabled",
+    flag_values = {":ethernet": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ethernet_defines",
+    defines = select({
+        ":ethernet_enabled": ["PLATFORM_SUPPORT_ETHERNET=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "io",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "io_enabled",
+    flag_values = {":io": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "io_disabled",
+    flag_values = {":io": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "io_defines",
+    defines = select({
+        ":io_enabled": ["PLATFORM_SUPPORT_IO=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "ipv6",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "ipv6_enabled",
+    flag_values = {":ipv6": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "ipv6_disabled",
+    flag_values = {":ipv6": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ipv6_defines",
+    defines = select({
+        ":ipv6_enabled": ["PLATFORM_SUPPORT_IPV6=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "middleware",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "middleware_enabled",
+    flag_values = {":middleware": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "middleware_disabled",
+    flag_values = {":middleware": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "middleware_defines",
+    defines = select({
+        ":middleware_enabled": ["PLATFORM_SUPPORT_MIDDLEWARE=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "mpu",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "mpu_enabled",
+    flag_values = {":mpu": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "mpu_disabled",
+    flag_values = {":mpu": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "mpu_defines",
+    defines = select({
+        ":mpu_enabled": ["PLATFORM_SUPPORT_MPU=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "rom_check",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "rom_check_enabled",
+    flag_values = {":rom_check": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "rom_check_disabled",
+    flag_values = {":rom_check": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "rom_check_defines",
+    defines = select({
+        ":rom_check_enabled": ["PLATFORM_SUPPORT_ROM_CHECK=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "storage",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "storage_enabled",
+    flag_values = {":storage": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "storage_disabled",
+    flag_values = {":storage": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "storage_defines",
+    defines = select({
+        ":storage_enabled": ["PLATFORM_SUPPORT_STORAGE=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "transport",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "transport_enabled",
+    flag_values = {":transport": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "transport_disabled",
+    flag_values = {":transport": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "transport_defines",
+    defines = select({
+        ":transport_enabled": ["PLATFORM_SUPPORT_TRANSPORT=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "uds",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "uds_enabled",
+    flag_values = {":uds": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "uds_disabled",
+    flag_values = {":uds": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "uds_defines",
+    defines = select({
+        ":uds_enabled": ["PLATFORM_SUPPORT_UDS=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "watchdog",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "watchdog_enabled",
+    flag_values = {":watchdog": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "watchdog_disabled",
+    flag_values = {":watchdog": "false"},
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "watchdog_defines",
+    defines = select({
+        ":watchdog_enabled": ["PLATFORM_SUPPORT_WATCHDOG=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "feature_defines",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":can_defines",
+        ":ethernet_defines",
+        ":io_defines",
+        ":ipv6_defines",
+        ":middleware_defines",
+        ":mpu_defines",
+        ":rom_check_defines",
+        ":storage_defines",
+        ":transport_defines",
+        ":uds_defines",
+        ":watchdog_defines",
+    ],
+)

--- a/bazel/platform/BUILD.bazel
+++ b/bazel/platform/BUILD.bazel
@@ -8,6 +8,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+# Feature matrix travels WITH the platform (mirrors CMake Options.cmake, which ties the
+# PLATFORM_SUPPORT_* CACHE BOOLs to OPENBSW_PLATFORM). Selecting the platform selects the
+# whole PLATFORM_SUPPORT_* set. Consumer selects on //bazel/config/features stay untouched.
 platform(
     name = "s32k148",
     constraint_values = [
@@ -15,4 +18,41 @@ platform(
         "@platforms//os:none",
         "//bazel/platform/constraints/soc:s32k148",
     ],
+    # Mirrors Options.cmake (s32k148evb): every PLATFORM_SUPPORT_* set explicitly.
+    flags = [
+        "--//bazel/config/features:can=true",
+        "--//bazel/config/features:ethernet=true",
+        "--//bazel/config/features:io=true",
+        "--//bazel/config/features:ipv6=false",
+        "--//bazel/config/features:middleware=false",
+        "--//bazel/config/features:mpu=true",
+        "--//bazel/config/features:rom_check=false",
+        "--//bazel/config/features:storage=true",
+        "--//bazel/config/features:transport=true",
+        "--//bazel/config/features:uds=true",
+        "--//bazel/config/features:watchdog=true",
+    ],
+)
+
+# POSIX host build. Inherits the autodetected host constraints/toolchain via `parents`, and
+# carries the posix PLATFORM_SUPPORT_* matrix. This is the DEFAULT platform (see .bazelrc), so a
+# plain `bazel build //...` is the posix build.
+platform(
+    name = "posix",
+    # Mirrors posix/Options.cmake. Options.cmake gates CAN on non-Darwin; this repo targets Linux
+    # so CAN is included.
+    flags = [
+        "--//bazel/config/features:can=true",
+        "--//bazel/config/features:ethernet=true",
+        "--//bazel/config/features:io=false",
+        "--//bazel/config/features:ipv6=false",
+        "--//bazel/config/features:middleware=true",
+        "--//bazel/config/features:mpu=false",
+        "--//bazel/config/features:rom_check=false",
+        "--//bazel/config/features:storage=true",
+        "--//bazel/config/features:transport=true",
+        "--//bazel/config/features:uds=true",
+        "--//bazel/config/features:watchdog=false",
+    ],
+    parents = ["@platforms//host:host"],
 )

--- a/executables/referenceApp/safety/safeWatchdog/BUILD.bazel
+++ b/executables/referenceApp/safety/safeWatchdog/BUILD.bazel
@@ -12,7 +12,6 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(
     name = "safe_watchdog_watchdog_support",
-    defines = ["PLATFORM_SUPPORT_WATCHDOG=1"],
     target_compatible_with = ["//bazel/platform/constraints/soc:s32k148"],
     deps = [
         "//platforms/s32k1xx/bsp/bspMcu:bsp_mcu",
@@ -42,5 +41,8 @@ cc_library(
     ],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
-    deps = ["//libs/bsw/platform"],
+    deps = [
+        "//bazel/config/features:feature_defines",
+        "//libs/bsw/platform",
+    ],
 )


### PR DESCRIPTION
Add PLATFORM_SUPPORT feature flags to Bazel

bazel/config/features:
- bool_flag, config_setting and cc_library per PLATFORM_SUPPORT flag
- feature_defines aggregate

bazel/platform:
- Add flags to s32k148 platform (mirrors Options.cmake PLATFORM_SUPPORT matrix)
- Add posix platform (parents = @platforms//host:host + posix feature matrix)
- posix is the DEFAULT platform: plain `bazel build //...` is the posix host build

.bazelrc:
- Replace per-flag approach with platform() flags
- Add build --platforms=//bazel/platform:posix as default

safeWatchdog:
- migrate inline defines to feature_defines
