### PR TITLE
Remove CMake cache step from puncover workflow

### DIFF
--- a/.github/workflows/puncover_tool.yml
+++ b/.github/workflows/puncover_tool.yml
@@ -26,15 +26,7 @@ jobs:
       - name: Setup Docker Environment
         uses: ./.github/actions/setup-docker-env
 
-      - name: Cache CMake files
-        id: cache-cmake
-        uses: actions/cache@v4
-        with:
-            path: build/s32k148-gcc
-            key: ${{ runner.os }}-${{ steps.build-docker-development.outputs.digest }}-cmake-s32k148-freertos-gcc-RelWithDebInfo-arm-gcc-17-${{ hashFiles('**/*.cpp', '**/*.h',  '**/*.cmake', '**/*.txt', '**/*.c', '**/*.s', '**/*.S') }}
-
       - name: Run the build.py inside the docker container
-        if: steps.cache-cmake.outputs.cache-hit != 'true'
         run: >-
           DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) DOCKER_HISTORY=/dev/null docker compose run --rm development
           python3 .ci/build.py --preset s32k148-freertos-gcc --platform arm --cxxid gcc --cxxstd 17 --config RelWithDebInfo


### PR DESCRIPTION
The "Cache CMake files" step in `puncover_tool.yml` has been inert since two unrelated changes: c416aabf2 switched the build to the `s32k148-freertos-gcc` preset but left the cache path at the old `build/s32k148-gcc` directory, and a3749e835 moved the docker build step into a composite action, so the image digest referenced in the cache key now expands to an empty string.

The same cache was already removed from `build.yml` and `code-coverage.yml` in 1046900d5 for the reasons given there: a hand-picked file list is not a safe cache key and incremental builds are not trusted. The puncover workflow was not part of that change.

Removing the step rather than fixing the path avoids a stale-build hazard. With the digest missing from the key, a corrected path would restore the previous build tree after a toolchain bump in the docker image, skip the build, and publish a puncover report of a binary built with the old compiler.

The change is the same shape as 1046900d5: the cache step and the `if:` condition on the build step are removed, nothing else in the workflow changes.

Resolves:
#592: Puncover workflow caches a non-existent path with an empty digest
