### PR TITLE
Activate middleware for target build

### DIFF
--- a/executables/referenceApp/middlewareConfiguration/CMakeLists.txt
+++ b/executables/referenceApp/middlewareConfiguration/CMakeLists.txt
@@ -1,7 +1,3 @@
-if (NOT UNIX)
-    return()
-endif ()
-
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 # -----------------------------------------------------------------------

--- a/executables/referenceApp/platforms/s32k148evb/Options.cmake
+++ b/executables/referenceApp/platforms/s32k148evb/Options.cmake
@@ -40,3 +40,6 @@ set(PLATFORM_SUPPORT_STORAGE
 set(PLATFORM_SUPPORT_ROM_CHECK
     OFF
     CACHE BOOL "Turn ON ROM check support" FORCE)
+set(PLATFORM_SUPPORT_MIDDLEWARE
+    ON
+    CACHE BOOL "Turn middleware service demo support on or off" FORCE)

--- a/libs/bsw/middleware/include/middleware/core/types.h
+++ b/libs/bsw/middleware/include/middleware/core/types.h
@@ -81,14 +81,16 @@ enum class HRESULT : uint8_t
  */
 struct AbsoluteToleranceEqual
 {
+    // __builtin_fabs is used instead of std::fabs because newlib's fabs() is not constexpr,
+    // which trips -Werror=invalid-constexpr on arm-none-eabi-gcc.
     constexpr bool operator()(double const x, double const y) const
     {
-        return std::fabs(x - y) <= ::etl::numeric_limits<double>::min();
+        return __builtin_fabs(x - y) <= ::etl::numeric_limits<double>::min();
     }
 
     constexpr bool operator()(float const x, float const y) const
     {
-        return std::fabs(x - y) <= ::etl::numeric_limits<float>::min();
+        return __builtin_fabsf(x - y) <= ::etl::numeric_limits<float>::min();
     }
 };
 

--- a/libs/bsw/middleware/include/middleware/core/types.h
+++ b/libs/bsw/middleware/include/middleware/core/types.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <etl/absolute.h>
 #include <etl/limits.h>
 #include <etl/platform.h>
 
@@ -81,16 +82,16 @@ enum class HRESULT : uint8_t
  */
 struct AbsoluteToleranceEqual
 {
-    // __builtin_fabs is used instead of std::fabs because newlib's fabs() is not constexpr,
-    // which trips -Werror=invalid-constexpr on arm-none-eabi-gcc.
+    // ETL's absolute is used instead of std::fabs because newlib's fabs() is not constexpr,
+    // which would prevent these comparison operators from remaining constexpr.
     constexpr bool operator()(double const x, double const y) const
     {
-        return __builtin_fabs(x - y) <= ::etl::numeric_limits<double>::min();
+        return ::etl::absolute(x - y) <= ::etl::numeric_limits<double>::min();
     }
 
     constexpr bool operator()(float const x, float const y) const
     {
-        return __builtin_fabsf(x - y) <= ::etl::numeric_limits<float>::min();
+        return ::etl::absolute(x - y) <= ::etl::numeric_limits<float>::min();
     }
 };
 

--- a/libs/bsw/middleware/test/CMakeLists.txt
+++ b/libs/bsw/middleware/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(
     src/core/ResponseBufferTest.cpp
     src/core/SkeletonAttributeTest.cpp
     src/core/SkeletonBaseTest.cpp
+    src/core/TypesTest.cpp
     src/logger/mock/LoggerMock.cpp
     src/memory/AllocatorBaseTest.cpp
     src/memory/mock/AllocatorMock.cpp

--- a/libs/bsw/middleware/test/src/core/TypesTest.cpp
+++ b/libs/bsw/middleware/test/src/core/TypesTest.cpp
@@ -1,0 +1,69 @@
+/********************************************************************************
+ * Copyright (c) 2026 BMW AG
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include <etl/limits.h>
+#include <gtest/gtest.h>
+
+#include "middleware/core/types.h"
+
+namespace middleware::core::test
+{
+
+TEST(AbsoluteToleranceEqualTest, ReturnsTrueForEqualFloatValues)
+{
+    AbsoluteToleranceEqual const equal{};
+
+    EXPECT_TRUE(equal(1.0F, 1.0F));
+}
+
+TEST(AbsoluteToleranceEqualTest, ReturnsTrueAtFloatToleranceBoundary)
+{
+    AbsoluteToleranceEqual const equal{};
+    float const tolerance = ::etl::numeric_limits<float>::min();
+
+    EXPECT_TRUE(equal(0.0F, tolerance));
+    EXPECT_TRUE(equal(0.0F, -tolerance));
+}
+
+TEST(AbsoluteToleranceEqualTest, ReturnsFalseOutsideFloatTolerance)
+{
+    AbsoluteToleranceEqual const equal{};
+    float const tolerance = ::etl::numeric_limits<float>::min();
+
+    EXPECT_FALSE(equal(0.0F, 2.0F * tolerance));
+    EXPECT_FALSE(equal(0.0F, -2.0F * tolerance));
+}
+
+TEST(AbsoluteToleranceEqualTest, ReturnsTrueForEqualDoubleValues)
+{
+    AbsoluteToleranceEqual const equal{};
+
+    EXPECT_TRUE(equal(1.0, 1.0));
+}
+
+TEST(AbsoluteToleranceEqualTest, ReturnsTrueAtDoubleToleranceBoundary)
+{
+    AbsoluteToleranceEqual const equal{};
+    double const tolerance = ::etl::numeric_limits<double>::min();
+
+    EXPECT_TRUE(equal(0.0, tolerance));
+    EXPECT_TRUE(equal(0.0, -tolerance));
+}
+
+TEST(AbsoluteToleranceEqualTest, ReturnsFalseOutsideDoubleTolerance)
+{
+    AbsoluteToleranceEqual const equal{};
+    double const tolerance = ::etl::numeric_limits<double>::min();
+
+    EXPECT_FALSE(equal(0.0, 2.0 * tolerance));
+    EXPECT_FALSE(equal(0.0, -2.0 * tolerance));
+}
+
+} // namespace middleware::core::test

--- a/test/pyTest/middleware/test_middleware.py
+++ b/test/pyTest/middleware/test_middleware.py
@@ -23,7 +23,6 @@ appear in the captured serial output with the format:
 import re
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -46,7 +45,7 @@ def _extract_foo_value(line: bytes) -> int | None:
 # Tests
 # ---------------------------------------------------------------------------
 
-@pytest.mark.skip_if("target==['s32k148']", "Middleware Foo test not supported on s32k148")
+
 def test_foo_broadcast_sent(target_session):
     """Cluster0 FooSkeleton sends at least one Foo broadcast after boot."""
     capserial = target_session.capserial()
@@ -58,7 +57,7 @@ def test_foo_broadcast_sent(target_session):
     )
     assert success, "Timed out waiting for Foo broadcast"
 
-@pytest.mark.skip_if("target==['s32k148']", "Middleware Foo test not supported on s32k148")
+
 def test_foo_attribute_notification(target_session):
     """Cluster1 FooProxy receives a change notification right after a broadcast."""
     capserial = target_session.capserial()
@@ -73,9 +72,11 @@ def test_foo_attribute_notification(target_session):
     success, _, _ = capserial.read_until(
         b"[Middleware] Foo attribute changed", timeout=_NOTIFY_TIMEOUT
     )
-    assert success, "Proxy did not receive attribute change notification after broadcast"
+    assert (
+        success
+    ), "Proxy did not receive attribute change notification after broadcast"
 
-@pytest.mark.skip_if("target==['s32k148']", "Middleware Foo test not supported on s32k148")
+
 def test_foo_getter_response(target_session):
     """Cluster1 FooProxy getter round-trip returns a response within expected time."""
     capserial = target_session.capserial()
@@ -87,7 +88,7 @@ def test_foo_getter_response(target_session):
     )
     assert success, "Timed out waiting for Foo getter response"
 
-@pytest.mark.skip_if("target==['s32k148']", "Middleware Foo test not supported on s32k148")
+
 def test_foo_value_increments(target_session):
     """fooValue is strictly incremented across two consecutive broadcasts."""
     capserial = target_session.capserial()
@@ -106,12 +107,14 @@ def test_foo_value_increments(target_session):
                 values.append(v)
                 break
 
-    assert len(values) == 2, f"Could not extract fooValue from broadcasts, got: {values}"
-    assert values[1] > values[0], (
-        f"fooValue did not increment: first={values[0]}, second={values[1]}"
-    )
+    assert (
+        len(values) == 2
+    ), f"Could not extract fooValue from broadcasts, got: {values}"
+    assert (
+        values[1] > values[0]
+    ), f"fooValue did not increment: first={values[0]}, second={values[1]}"
 
-@pytest.mark.skip_if("target==['s32k148']", "Middleware Foo test not supported on s32k148")
+
 def test_foo_broadcast_and_getter_values_match(target_session):
     """The fooValue in a getter response matches the most recent broadcast value."""
     capserial = target_session.capserial()
@@ -124,7 +127,8 @@ def test_foo_broadcast_and_getter_values_match(target_session):
     )
     assert success, "Timed out waiting for Foo broadcast"
     broadcast_value = next(
-        (_extract_foo_value(line) for line in reversed(lines) if b"broadcast" in line), None
+        (_extract_foo_value(line) for line in reversed(lines) if b"broadcast" in line),
+        None,
     )
     assert broadcast_value is not None
 
@@ -134,9 +138,14 @@ def test_foo_broadcast_and_getter_values_match(target_session):
     )
     assert success, "Timed out waiting for Foo getter response"
     getter_value = next(
-        (_extract_foo_value(line) for line in reversed(lines) if b"get response" in line), None
+        (
+            _extract_foo_value(line)
+            for line in reversed(lines)
+            if b"get response" in line
+        ),
+        None,
     )
     assert getter_value is not None
-    assert getter_value >= broadcast_value, (
-        f"Getter value {getter_value} is older than broadcast value {broadcast_value}"
-    )
+    assert (
+        getter_value >= broadcast_value
+    ), f"Getter value {getter_value} is older than broadcast value {broadcast_value}"


### PR DESCRIPTION
# Activate middleware for target build

## Summary

Enables the middleware to be built and run on the S32K148 target (not just
in simulation), and adds unit test coverage for `AbsoluteToleranceEqual`.

## Commits

### Middleware can now be activated for target
- Removed the CMake step that was blocking `middlewareConfiguration`
  from being built for the target platform.
- Added the required option to `platforms/s32k148evb/Options.cmake` to
  enable the middleware on target.
- Updated `test_middleware.py` (pyTest) to reflect the new target build
  behavior.

### Add unit tests for AbsoluteToleranceTest
- Replaced `std::fabs`/`std::fabsf` in `AbsoluteToleranceEqual` with
  `etl::absolute`, since newlib's `fabs()` is not `constexpr` and trips
  `-Werror=invalid-constexpr` on `arm-none-eabi-gcc`.
- Added `TypesTest.cpp` with unit tests covering `AbsoluteToleranceEqual`
  for both `double` and `float`.
- Wired the new test file into `libs/bsw/middleware/test/CMakeLists.txt`.

## Testing
- Unit tests: `AbsoluteToleranceTest` (new)
- pyTest: `test_middleware.py` updated for target activation
