### PR TITLE
Middleware split db instance gen

### DIFF
--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_connections_srcCluster_to_tgtCluster.h.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/cluster_connections_srcCluster_to_tgtCluster.h.jinja
@@ -56,24 +56,24 @@ public:
     ClusterConnection{{connection.source_cluster.name}}To{{connection.target_cluster.name}}Meta()
 {% if (connection.proxies|length > 0) and (connection.skeletons|length > 0) %}
     : proxyTransceivers_{{'{{'}}
-    {% for proxy in connection.proxies %}
+    {% for proxy in connection.proxies | sort(attribute='id') %}
                 {&{{proxy.namespace|replace("::", "")}}{{proxy.name}}ProxyTransceivers_, {{proxy.namespace}}::{{proxy.name}}::internal::SERVICE_ID, 0U}{{ "," if not loop.last }}
     {% endfor %}
       {{'}}'}},
       skeletonTransceivers_{{'{{'}}
-    {% for skeleton in connection.skeletons %}
+    {% for skeleton in connection.skeletons | sort(attribute='id') %}
                 {&{{skeleton.namespace|replace("::", "")}}{{skeleton.name}}SkeletonTransceivers_, {{skeleton.namespace}}::{{skeleton.name}}::internal::SERVICE_ID, 0U}{{ "," if not loop.last }}
     {% endfor %}
       {{'}}'}}
 {% elif connection.proxies|length > 0 %}
     : proxyTransceivers_{{'{{'}}
-    {% for proxy in connection.proxies %}
+    {% for proxy in connection.proxies | sort(attribute='id') %}
                 {&{{proxy.namespace|replace("::", "")}}{{proxy.name}}ProxyTransceivers_, {{proxy.namespace}}::{{proxy.name}}::internal::SERVICE_ID, 0U}{{ "," if not loop.last }}
     {% endfor %}
       {{'}}'}}
 {% else %}
     : skeletonTransceivers_{{'{{'}}
-    {% for skeleton in connection.skeletons %}
+    {% for skeleton in connection.skeletons | sort(attribute='id') %}
                 {&{{skeleton.namespace|replace("::", "")}}{{skeleton.name}}SkeletonTransceivers_, {{skeleton.namespace}}::{{skeleton.name}}::internal::SERVICE_ID, 0U}{{ "," if not loop.last }}
     {% endfor %}
       {{'}}'}}

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_common.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_common.cpp.jinja
@@ -33,51 +33,44 @@ namespace {{ service.namespace }}::{{ service.name }}
 
 namespace internal
 {
-{# For simulation mode: Generate only merged InstancesDatabase (individual cluster databases removed) #}
-
-{# Create merged InstancesDatabase for simulation (all cores together) #}
 {% set clusters_with_instances = service.deployment.clusters | selectattr('providers.instance_ids') | list %}
-{# Collect all instance IDs from all provider clusters #}
-{%- set all_instance_ids = [] -%}
-{%- for cluster_deployment in clusters_with_instances -%}
-  {%- for instance_id in cluster_deployment.providers.instance_ids -%}
-    {%- set _ = all_instance_ids.append(instance_id) -%}
-  {%- endfor -%}
-{%- endfor -%}
 
-{# Collect all connections for this service across ALL clusters (simulation mode) #}
-{%- set all_skeleton_connections = [] -%}
-{%- set all_proxy_connections = [] -%}
+{% for cluster_deployment in clusters_with_instances %}
+{%- set cluster_skeleton_connections = [] -%}
+{%- set cluster_proxy_connections = [] -%}
 
-{# Find all skeleton connections (provider connections) #}
+{# Find skeleton connections for this provider cluster #}
 {%- for connection in connections -%}
-  {%- for skeleton in connection.skeletons if connection.skeletons -%}
-    {%- if skeleton.name == service.name -%}
-      {%- set _ = all_skeleton_connections.append(connection) -%}
-    {%- endif -%}
-  {%- endfor -%}
+  {%- if connection.source_cluster.name == cluster_deployment.cluster.name -%}
+    {%- for skeleton in connection.skeletons if connection.skeletons -%}
+      {%- if skeleton.name == service.name -%}
+        {%- set _ = cluster_skeleton_connections.append(connection) -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
 {%- endfor -%}
 
-{# Find all proxy connections (consumer connections) #}
+{# Find proxy connections targeting this provider cluster #}
 {%- for connection in connections -%}
-  {%- for proxy in connection.proxies if connection.proxies -%}
-    {%- if proxy.name == service.name -%}
-      {%- set _ = all_proxy_connections.append(connection) -%}
-    {%- endif -%}
-  {%- endfor -%}
+  {%- if connection.target_cluster.name == cluster_deployment.cluster.name -%}
+    {%- for proxy in connection.proxies if connection.proxies -%}
+      {%- if proxy.name == service.name -%}
+        {%- set _ = cluster_proxy_connections.append(connection) -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
 {%- endfor -%}
 
-{# Generate merged InstancesDatabase for simulation #}
-class InstancesDatabase_Merged : public ::middleware::core::IInstanceDatabase
+class InstancesDatabase_{{ cluster_deployment.cluster.name }} : public ::middleware::core::IInstanceDatabase
 {
   public:
-    constexpr InstancesDatabase_Merged() = default;
+    constexpr InstancesDatabase_{{ cluster_deployment.cluster.name }}() = default;
     ::etl::span<::middleware::core::IClusterConnection* const> getSkeletonConnectionsRange() const override
     {
-        {% if all_skeleton_connections %}
-        static constexpr ::etl::array<::middleware::core::IClusterConnection* const, {{all_skeleton_connections | length}}U> connections = {
+        {% if cluster_skeleton_connections %}
+        static constexpr ::etl::array<::middleware::core::IClusterConnection* const, {{cluster_skeleton_connections | length}}U> connections = {
             {
-            {%- for connection in all_skeleton_connections %}
+            {%- for connection in cluster_skeleton_connections %}
             &::middleware::ClusterConnection{{ connection.source_cluster.name }}To{{ connection.target_cluster.name }}{{ "," if not loop.last }}
             {%- endfor %}
             }
@@ -90,10 +83,10 @@ class InstancesDatabase_Merged : public ::middleware::core::IInstanceDatabase
 
     ::etl::span<::middleware::core::IClusterConnection* const> getProxyConnectionsRange() const override
     {
-        {% if all_proxy_connections %}
-        static constexpr ::etl::array<::middleware::core::IClusterConnection* const, {{all_proxy_connections | length}}U> connections = {
+        {% if cluster_proxy_connections %}
+        static constexpr ::etl::array<::middleware::core::IClusterConnection* const, {{cluster_proxy_connections | length}}U> connections = {
             {
-            {%- for connection in all_proxy_connections %}
+            {%- for connection in cluster_proxy_connections %}
             &::middleware::ClusterConnection{{ connection.source_cluster.name }}To{{ connection.target_cluster.name }}{{ "," if not loop.last }}
             {%- endfor %}
             }
@@ -110,15 +103,20 @@ class InstancesDatabase_Merged : public ::middleware::core::IInstanceDatabase
     }
 
   private:
-    static constexpr ::etl::array<const uint16_t, {{all_instance_ids | length}}U> fInstanceIds = {% if all_instance_ids -%}{ {{all_instance_ids | join('U, ')}}U }{%- else -%}{  }{%- endif %};
+    static constexpr ::etl::array<const uint16_t, {{ cluster_deployment.providers.instance_ids | length }}U> fInstanceIds = { {{ cluster_deployment.providers.instance_ids | join('U, ') }}U };
 };
 
-constexpr ::etl::array<const uint16_t, {{all_instance_ids | length}}U> InstancesDatabase_Merged::fInstanceIds;
+constexpr ::etl::array<const uint16_t, {{ cluster_deployment.providers.instance_ids | length }}U> InstancesDatabase_{{ cluster_deployment.cluster.name }}::fInstanceIds;
 
-constexpr InstancesDatabase_Merged _InstancesDatabase_Merged;
+constexpr InstancesDatabase_{{ cluster_deployment.cluster.name }} _InstancesDatabase_{{ cluster_deployment.cluster.name }};
+{% endfor %}
 
-constexpr ::etl::array<const ::middleware::core::IInstanceDatabase* const, 1U> instancesDatabase{
-    &_InstancesDatabase_Merged
+constexpr ::etl::array<const ::middleware::core::IInstanceDatabase* const, {{ clusters_with_instances | length }}U> instancesDatabase{
+{% if clusters_with_instances %}
+    {%- for cluster_deployment in clusters_with_instances %}
+    &_InstancesDatabase_{{ cluster_deployment.cluster.name }}{{ "," if not loop.last }}
+    {%- endfor %}
+{% endif %}
 };
 
 ::etl::span<const ::middleware::core::IInstanceDatabase* const> getClusterConnectionsDb()

--- a/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_common.cpp.jinja
+++ b/libs/bsw/middleware/tools/cpp_generator/templates/jinja/service_common.cpp.jinja
@@ -39,22 +39,22 @@ namespace internal
 {%- set cluster_skeleton_connections = [] -%}
 {%- set cluster_proxy_connections = [] -%}
 
-{# Find skeleton connections for this provider cluster #}
+{# Find skeleton connections for this provider cluster (dedupe: a connection may list the same service multiple times) #}
 {%- for connection in connections -%}
   {%- if connection.source_cluster.name == cluster_deployment.cluster.name -%}
     {%- for skeleton in connection.skeletons if connection.skeletons -%}
-      {%- if skeleton.name == service.name -%}
+      {%- if skeleton.name == service.name and connection not in cluster_skeleton_connections -%}
         {%- set _ = cluster_skeleton_connections.append(connection) -%}
       {%- endif -%}
     {%- endfor -%}
   {%- endif -%}
 {%- endfor -%}
 
-{# Find proxy connections targeting this provider cluster #}
+{# Find proxy connections targeting this provider cluster (dedupe: a connection may list the same service multiple times) #}
 {%- for connection in connections -%}
   {%- if connection.target_cluster.name == cluster_deployment.cluster.name -%}
     {%- for proxy in connection.proxies if connection.proxies -%}
-      {%- if proxy.name == service.name -%}
+      {%- if proxy.name == service.name and connection not in cluster_proxy_connections -%}
         {%- set _ = cluster_proxy_connections.append(connection) -%}
       {%- endif -%}
     {%- endfor -%}
@@ -121,7 +121,11 @@ constexpr ::etl::array<const ::middleware::core::IInstanceDatabase* const, {{ cl
 
 ::etl::span<const ::middleware::core::IInstanceDatabase* const> getClusterConnectionsDb()
 {
+    {% if clusters_with_instances %}
     return ::etl::make_span(instancesDatabase);
+    {% else %}
+    return ::etl::span<const ::middleware::core::IInstanceDatabase* const>();
+    {% endif %}
 }
 
 }  // namespace internal


### PR DESCRIPTION
Split the merged InstancesDatabase into one instance per provider cluster, filtering skeleton and proxy connections by source/target cluster instead of aggregating them across all clusters. The aggregate instancesDatabase array now references all per-cluster databases.