### PR TITLE
Improve blob and routing documentation

### DIFF
--- a/libs/bsw/blob/doc/design.rst
+++ b/libs/bsw/blob/doc/design.rst
@@ -28,7 +28,9 @@ Components
     Wraps a validated blob span and exposes a forward (input) iterator over its configurations. The
     constructor calls ``checkHeader()`` and verifies that the memory region size matches
     ``HEADER_SIZE + size``; on failure it logs an error and yields an empty span. Iteration
-    advances by each configuration's declared size and stops once the span is exhausted.
+    advances by each configuration's declared size and stops once the span is exhausted. The
+    recommended top-level entry point ``load()`` (declared in ``Blob.h``) also lives here: it runs
+    the full validation sequence and returns a CRC-verified blob span (or an empty span on failure).
 
 ``Config``
     Represents a single configuration as a ``type`` and a ``data`` span. ``Config::from_bytes()``
@@ -36,9 +38,9 @@ Components
     inconsistent sizes, and returns a span bounded to the configuration's extent.
 
 ``util``
-    Free functions for higher-level access: ``load()`` performs full validation, ``config()`` looks
-    up the first configuration of a given type, ``checkCrc()`` verifies a configuration's trailing
-    CRC, and the ``loadColumn()`` template safely reinterprets a sized byte run as a typed column.
+    Free helper functions (declared in ``util.h``): ``config()`` looks up the first configuration of
+    a given type, ``checkCrc()`` verifies a configuration's trailing CRC, and the ``loadColumn()``
+    template safely reinterprets a sized byte run as a typed column.
 
 Loading and validation flow
 ---------------------------

--- a/libs/bsw/blob/doc/generator.rst
+++ b/libs/bsw/blob/doc/generator.rst
@@ -107,8 +107,8 @@ The ``blob.routing`` subpackage provides an auxiliary CLI for working with routi
 It can sort routings by channel ID, pretty-print them, render a Graphviz ``.dot`` visualization of
 the routing graph, and generate a C++ header containing the routing channel IDs.
 
-Regenerating the referenceApp headers
--------------------------------------
+Regenerating generated headers
+------------------------------
 
 The script ``tools/blob/regenerate.sh`` regenerates all three generated headers.
 It accepts positional arguments so it can be reused by any project that vendors
@@ -118,15 +118,14 @@ this repository:
 
     tools/blob/regenerate.sh JSONL_FILE OUT_BLOB_DIR OUT_ROUTING_DIR
 
-For the reference application, run from the **project root**:
+Run it from the **project root** with paths for the integrating project:
 
 .. code-block:: console
 
-    # Inside the openbsw-development Docker container (deps pre-installed):
     tools/blob/regenerate.sh \
-        executables/referenceApp/configuration/routing.jsonl \
-        executables/referenceApp/configuration/include/blob \
-        executables/referenceApp/configuration/include/routing
+        path/to/routing.jsonl \
+        path/to/generated/blob/include \
+        path/to/generated/routing/include
 
 .. code-block:: console
 
@@ -136,9 +135,9 @@ For the reference application, run from the **project root**:
 
     # Then run, pointing PYTHON at the venv interpreter:
     PYTHON=tools/.venv/bin/python3 tools/blob/regenerate.sh \
-        executables/referenceApp/configuration/routing.jsonl \
-        executables/referenceApp/configuration/include/blob \
-        executables/referenceApp/configuration/include/routing
+        path/to/routing.jsonl \
+        path/to/generated/blob/include \
+        path/to/generated/routing/include
 
 The script resolves all paths to absolute before changing directory internally,
 so relative paths work as long as they are valid from the directory where you
@@ -160,8 +159,8 @@ active or the container's ``/opt/venv`` on ``PATH``):
 .. code-block:: console
 
     cd tools
-    JSONL=../executables/referenceApp/configuration/routing.jsonl
-    OUT=../executables/referenceApp/configuration/include
+    JSONL=../path/to/routing.jsonl
+    OUT=../path/to/generated/include
 
     python3 -m blob binary -i "${JSONL}" -c blob.routing.table \
         | python3 -m blob header data -n CONFIGURATION_BLOB \

--- a/libs/bsw/blob/doc/integration.rst
+++ b/libs/bsw/blob/doc/integration.rst
@@ -12,10 +12,36 @@
 Integration
 ===========
 
-The module defines the API ``load()``, which converts a pointer in memory to a span of data, after
-sufficiently checking that this data is that of a blob.
+The module entry point is ``load()``. It validates a memory region that should contain a blob and
+returns the validated span to pass to consuming modules. ``Blob`` can also be instantiated directly
+to iterate over configurations, but consumers should normally use the span returned by ``load()`` and
+construct a ``Blob`` iterator only when they need to inspect configurations.
 
-Alternatively, the ``Blob`` class can be instantiated with a blob span, so as to neatly iterate over
-configurations using the class's custom iterator implementation. However, it is recommended that the
-blob span returned by ``load()`` be used for any further processing in a given module, and that the
-``Blob`` iterator be constructed only on demand.
+Workflow
+--------
+
+The ``blob`` module holds no state and owns no resources, so there is no separate
+de-initialization step. A typical integration is:
+
+1. **Locate the blob.** Obtain an ``::etl::span<uint8_t const>`` over the memory region that holds
+   the blob. No copy into RAM is required.
+2. **Validate once at startup.** Call ``load()`` a single time. It verifies the header
+   (version + magic), checks that the region is at least ``HEADER_SIZE + size`` bytes, and
+   re-computes the CRC-32 of *every* configuration. On success it returns a span that is guaranteed
+   to reference a structurally valid, CRC-verified blob; on any failure it logs and returns an empty
+   span. Treat an empty span as a hard configuration error.
+3. **Access configurations.** Pass the validated span to the consuming modules. Use
+   ``config(blob, type)`` to fetch the first configuration of a given type, or iterate with
+   ``Blob`` when several are needed. Because the blob is read-only, these accessors are reentrant
+   and may be called from any context.
+4. **De-initialization.** None required — simply stop referencing the span. If the underlying
+   memory can be unmapped or overwritten, ensure no consumer still holds a span into it.
+
+Performance and efficiency
+--------------------------
+
+* ``load()`` walks the whole blob and re-computes every CRC, so call it once during startup and keep
+  the returned span for later access.
+* Access is span-based and allocation-free; the module never copies the blob data.
+* ``config()`` starts iteration from the beginning on each call. If several configurations are
+  needed, iterate once with ``Blob`` instead of doing repeated lookups.

--- a/libs/bsw/routing/doc/design.rst
+++ b/libs/bsw/routing/doc/design.rst
@@ -73,3 +73,62 @@ The diagram is generated with:
 .. graphviz:: resources/routing_example.dot
 
 
+
+System context
+--------------
+
+The building-block diagram in the module overview shows the internal components. From an
+architectural point of view it is equally important to see the module in its **system context** —
+the external actors it depends on and the boundaries it must not cross:
+
+.. uml::
+   :align: center
+
+   left to right direction
+
+   [Configuration blob\n(in flash)] as blob
+   [CAN / FlexRay\ndrivers] as bus
+   [Network stack\n(UDP sockets)] as net
+   [Periodic scheduler\n(async context)] as sched
+   [Error handler\n(integrator callback)] as err
+
+   package "routing" {
+     [Integration] as integ
+   }
+
+   blob --> integ : parsed tables (read-only)
+   bus <--> integ : PDUs via SPSC MemoryQueue\n(driver context)
+   net <--> integ : datagrams\n(network context)
+   sched --> integ : route()/send/timeout\n(periodic context)
+   integ --> err : status codes
+
+This context view makes the two critical boundaries explicit: the **flash boundary** (the blob is
+read-only and never copied) and the **context boundary** between the bus driver context and the
+routing/network context, which is crossed only through single-producer/single-consumer queues.
+
+Error handling and reliability
+------------------------------
+
+The module is *fail-operational at the PDU granularity*: a malformed or undeliverable PDU is
+dropped and reported, but never corrupts the pipeline or blocks other PDUs. Errors are surfaced
+through the integrator-supplied ``ErrorHandler`` callback rather than through exceptions or return
+codes on the hot path. The reported status codes are:
+
+.. literalinclude:: ../include/routing/ErrorHandler.h
+   :start-after: STATUS_CODES_BEGIN
+   :end-before: STATUS_CODES_END
+   :language: cpp
+
+Key reliability properties:
+
+* **Bounded, non-blocking degradation.** When an RX allocation fails (queue full), the incoming
+  datagram/frame is discarded and counted; the error is reported only on the first failure of a run
+  to avoid log flooding. Statistics counters (``failedMemAllocPdus``, ``invalidIpAddressPdus``,
+  ``timeoutSends``, ``flushes``, …) are exposed for health monitoring.
+* **Source filtering.** UDP receivers optionally validate the source IP against a configured
+  allow-list before accepting a datagram.
+* **No silent blocking on TX.** The legacy CAN TX path performs no retry; a failed bus write is
+  dropped rather than stalling the router.
+* **Configuration integrity** is a precondition supplied by the ``blob`` module when the integrator
+  passes a span returned by ``blob::load()``. The routing loaders then perform their own
+  table-structure checks before adding channels and routing entries.

--- a/libs/bsw/routing/doc/integration.rst
+++ b/libs/bsw/routing/doc/integration.rst
@@ -25,12 +25,26 @@ Getting started
 +++++++++++++++
 
 1. Generate routing-related blob artifacts with the blob generator tool.
-2. Load the generated blob bytes in your application and pass them to ``PduTransportIntegration::init()``
-   and ``Integration::init()``.
-3. Provide bus and socket endpoints (CAN/FlexRay readers and writers, UDP sockets) to these ``init()``
+2. Provide an ``::etl::span<uint8_t const>`` over the generated blob bytes and validate it with
+   ``blob::load()``. Treat an empty returned span as a configuration error and do not continue
+   routing initialization with it.
+3. Pass the validated span to ``PduTransportIntegration::init()`` and ``Integration::init()``.
+4. Provide bus and socket endpoints (CAN/FlexRay readers and writers, UDP sockets) to these ``init()``
    calls.
-4. In the main loop, call ``checkTransmissionTimeouts()`` and ``sendUdpFrames()`` on
-   ``PduTransportIntegration`` and run the routing pipeline normally.
+5. Call ``PduTransportIntegration::activate()`` once the network stack is up. This binds and joins
+   the UDP sockets and enables the RX/TX direction of each PDU transport channel according to its
+   configured mode and VLAN. Until ``activate()`` has been called, no UDP data is received or
+   transmitted, even though ``init()`` has already built all tables and adapters.
+6. In the periodic task, call ``checkTransmissionTimeouts()`` and ``sendUdpFrames()`` on
+   ``PduTransportIntegration`` and ``route()`` on ``Integration`` (see :ref:`routingLifecycle`).
+7. On shutdown, call ``PduTransportIntegration::disable()`` to close the sockets and tear down the
+   receivers/senders.
+
+.. note::
+
+   The socket API is **not** thread-safe. ``activate()``, ``disable()``, ``checkTransmissionTimeouts()``,
+   ``sendUdpFrames()`` and ``route()`` must all be driven from the same task/context that owns the
+   network stack. See :ref:`routingConcurrency` for the full concurrency model.
 
 Here is the structure of this class, with regard to the ``Routing`` components (note that
 ``CHANNELS = PDU_TRANSPORT_CHANNELS + CAN_CHANNELS + FLEXRAY_CHANNELS``):
@@ -183,3 +197,107 @@ If we look at the way these components are interconnected and connected with the
 
    iudp -up- isock
    oudp -up- osock
+
+.. _routingLifecycle:
+
+Lifecycle and workflows
+-----------------------
+
+The routing components are plain objects with explicit ``init``/``activate``/``disable`` phases;
+they do not own a task and never allocate. The integrating system owns the lifecycle and schedules
+the runtime calls.
+
+Initialization
+    *Entry points:* ``PduTransportIntegration::init()``, ``Integration::init()``.
+
+    Parse the already validated blob span, discover the configured channels, build the RX/TX adapter
+    tables and the routing table, and connect the readers/writers. No socket or bus I/O happens yet.
+    ``init()`` is idempotent: a second call on an already-initialized instance is ignored.
+
+Startup
+    *Entry points:* ``PduTransportIntegration::activate()``, plus registering the bus listeners and
+    starting the periodic task.
+
+    Bind and join the UDP sockets, enable the RX and/or TX direction of every PDU transport
+    channel whose configured VLAN matches, and start driving the runtime loop. ``activate()``
+    clears the RX/TX queues and resets the buffered writers, so it is safe to call again to
+    re-activate after a ``disable()``.
+
+Runtime
+    *Entry points:* ``checkTransmissionTimeouts()``, ``sendUdpFrames()``, ``route()``.
+
+    Executed at the cadence chosen by the integrating system. See below.
+
+Shutdown / de-initialization
+    *Entry points:* ``PduTransportIntegration::disable()``, plus deregistering the bus listeners and
+    cancelling the task.
+
+    Disconnect and close all sockets and destroy the receivers/senders. The parsed tables remain
+    valid, so the instance can be re-activated with ``activate()`` without re-running ``init()``.
+
+The runtime step performs three actions, in order:
+
+* ``checkTransmissionTimeouts()`` flushes any buffered TX frame whose transmission timeout has
+  expired or is within the implementation's early-flush margin, bounding TX latency.
+* ``sendUdpFrames()`` drains the TX queues to the sockets, sending at most a fixed number of frames
+  per channel per call (a compile-time constant, currently 10, in ``PduTransportIntegration``).
+* ``route()`` moves PDUs from the RX side to the TX side of the router (see
+  :ref:`routingThroughput`).
+
+.. _routingConcurrency:
+
+Threading and concurrency
+-------------------------
+
+The routing pipeline is designed around **single-threaded execution of the router and the socket
+I/O**, with lock-free hand-off queues bridging any other context that produces or consumes PDUs.
+
+* **Router / PDU transport context.** ``route()``, ``checkTransmissionTimeouts()``,
+  ``sendUdpFrames()``, ``activate()`` and ``disable()`` must run in one and the same context — the
+  one that owns the network (socket) stack. The socket API is not thread-safe, so this constraint is
+  mandatory, not merely advisory.
+* **UDP reception** happens as a data-listener callback from the network stack (same context) and is
+  written into a per-channel RX ``MemoryQueue``.
+* **Legacy bus reception** (CAN/FlexRay) typically happens in a *different* driver context. The
+  driver's frame callback writes the PDU into a single-producer/single-consumer (SPSC)
+  ``MemoryQueue``; the router reads from it in its own context. This queue is the only
+  synchronization primitive needed — it is lock-free and wait-free for one producer and one
+  consumer, so no mutex is taken on the hot path.
+
+Consequently the only cross-context sharing is through ``MemoryQueue`` instances, each restricted to
+exactly one producer and one consumer. Do not call any router or PDU-transport method concurrently
+from two contexts.
+
+.. _routingThroughput:
+
+Performance and efficiency
+--------------------------
+
+The module targets constrained, hard-real-time ECUs. The most important characteristics for an
+integrator to size and tune the pipeline are:
+
+* **Static, allocation-free.** All buffers are fixed-capacity ``etl`` arrays/vectors sized at
+  compile time from the template parameters; there is no heap use at init or runtime. The memory
+  footprint is deterministic and given by the formulas in :doc:`interface`.
+* **Span-based, bounded copying.** Configuration data is read in place from the validated blob span.
+  Routed payload bytes are copied when adapters extract PDUs and when writers emit output PDUs or
+  cross queue, bus, or socket boundaries.
+* **One PDU per** ``route()`` **call, round-robin.** ``route()`` inspects the channels in a
+  rotating order and returns after forwarding a *single* PDU (or after one full sweep finds
+  nothing). This guarantees fairness across channels and a bounded, predictable per-call cost, but
+  it also means the routed throughput equals the ``route()`` call rate. To raise throughput, call
+  ``route()`` in a loop until it returns ``false`` (drain), or increase the task frequency —
+  trading CPU headroom for latency.
+* **Frame batching on TX.** ``PduTransportBufferedWriter`` packs multiple PDUs into one Ethernet
+  frame up to the configured channel element size. This amortizes the per-frame IP/UDP overhead. A
+  frame is committed when the next PDU no longer fits **or** the per-channel transmission timeout
+  expires; the timeout therefore bounds the added latency of batching. Set the timeout to ``0`` to
+  disable batching latency at the cost of protocol overhead.
+* **Bounded socket work.** ``sendUdpFrames()`` sends at most a fixed number of frames per channel
+  per call — a compile-time constant (currently 10) in ``PduTransportIntegration``, not a runtime-
+  or blob-configurable value. This keeps the worst-case execution time of a single runtime step
+  bounded even under burst load; backlog is drained over subsequent calls. Changing the cap means
+  editing that constant.
+* **Blob read in place.** The configuration blob is span-based and allocation-free (see the
+  ``blob`` module design), so the routing tables need not be copied into routing-owned RAM before
+  parsing.

--- a/libs/bsw/routing/include/routing/ErrorHandler.h
+++ b/libs/bsw/routing/include/routing/ErrorHandler.h
@@ -20,6 +20,7 @@ namespace routing
 {
 struct ErrorHandler
 {
+    // [STATUS_CODES_BEGIN]
     enum class StatusCode : uint8_t
     {
         OK,
@@ -40,6 +41,7 @@ struct ErrorHandler
         // A PDU transport channel received data from an invalid source.
         INVALID_REMOTE_IP_ADDRESS,
     };
+    // [STATUS_CODES_END]
 
     using Function = ::etl::delegate<void(StatusCode, uint8_t, uint32_t)>;
 


### PR DESCRIPTION
## Purpose of this PR
- [ ] Bugfix
- [ ] New Feature
- [x] Documentation Update
- [ ] Other (Please specify)

**Description**
Improves the `blob` and `routing` module documentation (design, integration, configuration, generator) so it more accurately reflects the implementation and is easier to read:

- Clarifies that CRC/config-integrity validation is performed by `blob::load()`, and that integrators must validate a blob span with `blob::load()` before passing it to `PduTransportIntegration::init()` / `Integration::init()`. Routing's own loaders only perform structural table checks, not CRC validation.
- Corrects wording that described the routing data path as "zero-copy". Blob/configuration data is read in place, but PDU payloads are copied at adapter/queue/bus/socket boundaries during RX extraction and TX forwarding; the docs now describe this as span-based, fixed-buffer processing without heap allocation.
- Removes reference-application-specific details (concrete class names, task periods, MTU-derived constants) from the module docs so they stay implementation-generic and reusable outside the reference application.
- Condenses duplicated explanations that were repeated across neighboring `blob`/`routing` doc pages.
- Adds `[STATUS_CODES_BEGIN]`/`[STATUS_CODES_END]` literalinclude markers in `routing/include/routing/ErrorHandler.h` so the status codes can be included directly in the docs instead of being duplicated by hand.

No source/implementation behavior changes; this PR only touches `.rst` documentation files and doc-include markers in one header.

**Related Issues**
N/A

**Breaking Changes**
- [ ] Yes
- [x] No

**Test Plan**
- Built the documentation locally with Sphinx (`doc/dev/Makefile`, `make html`) and confirmed a clean build with no warnings/errors introduced by these changes.
- Ran `git diff --check` to confirm no whitespace issues.
- Manually cross-checked the corrected claims (CRC validation ownership, copy behavior of the routing data path) against the current `blob` and `routing` source.

**Regression Tests**
Have tests been added/updated? [ ] Yes [x] No (documentation-only change)
