### PR TITLE
Isolate posix EepromDriver unit-test file per test process

### DIFF
--- a/platforms/posix/bsp/bspEepromDriver/include/eeprom/EepromDriver.h
+++ b/platforms/posix/bsp/bspEepromDriver/include/eeprom/EepromDriver.h
@@ -17,10 +17,10 @@
 
 namespace eeprom
 {
-class EepromDriver : public IEepromDriver
+class EepromDriver final : public IEepromDriver
 {
 public:
-    EepromDriver();
+    explicit EepromDriver(std::string filePath = EEPROM_FILEPATH);
     ~EepromDriver();
 
     EepromDriver(EepromDriver const&)            = delete;
@@ -35,7 +35,7 @@ public:
     bsp::BspReturnCode read(uint32_t address, uint8_t* buffer, uint32_t length) override;
 
 private:
-    std::string const eepromFilePath = EEPROM_FILEPATH;
+    std::string const eepromFilePath;
     int eepromFd;
 };
 } // namespace eeprom

--- a/platforms/posix/bsp/bspEepromDriver/src/eeprom/EepromDriver.cpp
+++ b/platforms/posix/bsp/bspEepromDriver/src/eeprom/EepromDriver.cpp
@@ -23,7 +23,7 @@
 namespace eeprom
 {
 
-EepromDriver::EepromDriver() : eepromFd(-1)
+EepromDriver::EepromDriver(std::string filePath) : eepromFilePath(std::move(filePath)), eepromFd(-1)
 {
     bool fileExisted = false;
 

--- a/platforms/posix/bsp/bspEepromDriver/test/CMakeLists.txt
+++ b/platforms/posix/bsp/bspEepromDriver/test/CMakeLists.txt
@@ -6,12 +6,5 @@ target_include_directories(bspEepromDriverTest PRIVATE ../include)
 target_link_libraries(bspEepromDriverTest PRIVATE bsp bspConfiguration
                                                   gtest_main)
 
-# The posix EepromDriver is backed by a single shared file (EEPROM_FILEPATH).
-# gtest_discover_tests registers every test case as its own process and ctest
-# runs them in parallel (CTEST_PARALLEL_LEVEL). Without a lock the concurrent
-# EepromDriver constructors race on that shared file and can re-initialize it
-# (fill it with 0xFF), clobbering data another test just wrote. Serialize the
-# tests against each other with a RESOURCE_LOCK on the shared file.
-gtest_discover_tests(
-    bspEepromDriverTest PROPERTIES LABELS "bspEepromDriverTest" RESOURCE_LOCK
-                                   "openbsw_posix_eeprom_ut_file")
+gtest_discover_tests(bspEepromDriverTest PROPERTIES LABELS
+                                                    "bspEepromDriverTest")

--- a/platforms/posix/bsp/bspEepromDriver/test/src/eeprom/EepromDriverTest.cpp
+++ b/platforms/posix/bsp/bspEepromDriver/test/src/eeprom/EepromDriverTest.cpp
@@ -12,6 +12,12 @@
 
 #include <gtest/gtest.h>
 
+#include <etl/optional.h>
+
+#include <cstdlib>
+#include <string>
+#include <unistd.h>
+
 namespace
 {
 
@@ -20,7 +26,27 @@ using namespace ::testing;
 class EepromDriverTest : public ::testing::Test
 {
 protected:
-    ::eeprom::EepromDriver _cut;
+    ::etl::optional<::eeprom::EepromDriver> _cut;
+    std::string _eepromFilePath;
+
+    void SetUp() override
+    {
+        ::testing::TestInfo const* testInfo
+            = ::testing::UnitTest::GetInstance()->current_test_info();
+        _eepromFilePath
+            = ::testing::TempDir() + testInfo->test_suite_name() + testInfo->name() + "_XXXXXX";
+        int const fd = ::mkstemp(const_cast<char*>(_eepromFilePath.data()));
+        ASSERT_NE(-1, fd);
+        ::close(fd);
+        ::unlink(_eepromFilePath.c_str());
+        _cut.emplace(_eepromFilePath);
+    }
+
+    void TearDown() override
+    {
+        _cut.reset();
+        (void)::unlink(_eepromFilePath.c_str());
+    }
 
 public:
     static constexpr size_t EEPROM_SIZE = 4096; // 4KB
@@ -28,26 +54,26 @@ public:
 
 TEST_F(EepromDriverTest, testEepromWriteBeyondSizeError)
 {
-    EXPECT_EQ(::bsp::BSP_OK, _cut.init());
+    EXPECT_EQ(::bsp::BSP_OK, _cut->init());
 
     uint8_t dataToWrite[] = {0x01, 0x02, 0x03, 0x04, 0x05};
     uint32_t address      = EEPROM_SIZE + 1; // Start address beyond size
 
-    EXPECT_EQ(::bsp::BSP_ERROR, _cut.write(address, dataToWrite, sizeof(dataToWrite)));
+    EXPECT_EQ(::bsp::BSP_ERROR, _cut->write(address, dataToWrite, sizeof(dataToWrite)));
 }
 
 TEST_F(EepromDriverTest, testEepromWriteRead)
 {
-    EXPECT_EQ(::bsp::BSP_OK, _cut.init());
+    EXPECT_EQ(::bsp::BSP_OK, _cut->init());
 
     uint8_t dataToWrite[] = {0x01, 0x02, 0x03, 0x04, 0x05};
     uint32_t address      = 0x00;
 
-    EXPECT_EQ(::bsp::BSP_OK, _cut.write(address, dataToWrite, sizeof(dataToWrite)));
+    EXPECT_EQ(::bsp::BSP_OK, _cut->write(address, dataToWrite, sizeof(dataToWrite)));
 
     uint8_t readData[sizeof(dataToWrite)] = {0};
 
-    EXPECT_EQ(::bsp::BSP_OK, _cut.read(address, readData, sizeof(readData)));
+    EXPECT_EQ(::bsp::BSP_OK, _cut->read(address, readData, sizeof(readData)));
 
     // Verify data
     for (size_t i = 0; i < sizeof(dataToWrite); i++)
@@ -58,54 +84,54 @@ TEST_F(EepromDriverTest, testEepromWriteRead)
 
 TEST_F(EepromDriverTest, testEepromReadBeyondSizeError)
 {
-    EXPECT_EQ(::bsp::BSP_OK, _cut.init());
+    EXPECT_EQ(::bsp::BSP_OK, _cut->init());
 
     uint8_t readData[10] = {0};
     uint32_t address     = EEPROM_SIZE + 1;
 
-    EXPECT_EQ(::bsp::BSP_ERROR, _cut.read(address, readData, sizeof(readData)));
+    EXPECT_EQ(::bsp::BSP_ERROR, _cut->read(address, readData, sizeof(readData)));
 }
 
 TEST_F(EepromDriverTest, testNullpointerBufferRead)
 {
-    EXPECT_EQ(::bsp::BSP_OK, _cut.init());
+    EXPECT_EQ(::bsp::BSP_OK, _cut->init());
 
-    EXPECT_EQ(::bsp::BSP_ERROR, _cut.read(0x00, nullptr, 10));
+    EXPECT_EQ(::bsp::BSP_ERROR, _cut->read(0x00, nullptr, 10));
 }
 
 TEST_F(EepromDriverTest, testNullpointerBufferWrite)
 {
-    EXPECT_EQ(::bsp::BSP_OK, _cut.init());
+    EXPECT_EQ(::bsp::BSP_OK, _cut->init());
 
-    EXPECT_EQ(::bsp::BSP_ERROR, _cut.write(0x00, nullptr, 10));
+    EXPECT_EQ(::bsp::BSP_ERROR, _cut->write(0x00, nullptr, 10));
 }
 
 TEST_F(EepromDriverTest, testWriteWithoutInit)
 {
     uint8_t dataToWrite[] = {0x01, 0x02, 0x03, 0x04, 0x05};
 
-    EXPECT_EQ(::bsp::BSP_OK, _cut.write(0x00, dataToWrite, sizeof(dataToWrite)));
+    EXPECT_EQ(::bsp::BSP_OK, _cut->write(0x00, dataToWrite, sizeof(dataToWrite)));
 }
 
 TEST_F(EepromDriverTest, testReadWithoutInit)
 {
     uint8_t readData[10] = {0};
 
-    EXPECT_EQ(::bsp::BSP_OK, _cut.read(0x00, readData, sizeof(readData)));
+    EXPECT_EQ(::bsp::BSP_OK, _cut->read(0x00, readData, sizeof(readData)));
 }
 
 TEST_F(EepromDriverTest, testWriteAtLastByte)
 {
-    EXPECT_EQ(::bsp::BSP_OK, _cut.init());
+    EXPECT_EQ(::bsp::BSP_OK, _cut->init());
 
     uint8_t dataToWrite[] = {0xAB};
     uint32_t address      = EEPROM_SIZE - 1;
 
-    EXPECT_EQ(::bsp::BSP_OK, _cut.write(address, dataToWrite, 1));
+    EXPECT_EQ(::bsp::BSP_OK, _cut->write(address, dataToWrite, 1));
 
     uint8_t readData[1] = {0};
 
-    EXPECT_EQ(::bsp::BSP_OK, _cut.read(address, readData, 1));
+    EXPECT_EQ(::bsp::BSP_OK, _cut->read(address, readData, 1));
 
     EXPECT_EQ(dataToWrite[0], readData[0]);
 }


### PR DESCRIPTION
Isolate posix EepromDriver unit-test file per test process

- Remove RESOURCE_LOCK which was used for parallel test execution
